### PR TITLE
fix: add accessible title to Sheet and hide collapse toggle on mobile

### DIFF
--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -28,7 +28,7 @@ export const Appbar = () => {
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="p-0 w-72">
-            <SidebarContent />
+            <SidebarContent showToggle={false} />
           </SheetContent>
         </Sheet>
 

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -36,7 +36,7 @@ function getInitials(name: string | null | undefined): string {
     .slice(0, 2);
 }
 
-export const SidebarContent = () => {
+export const SidebarContent = ({ showToggle = true }: { showToggle?: boolean }) => {
   const { user } = useAuth();
   const pathname = usePathname();
   const { collapsed, toggle } = useSidebar();
@@ -94,17 +94,19 @@ export const SidebarContent = () => {
           </Link>
         </div>
         {/* Toggle button – positioned on the edge of the sidebar */}
-        <button
-          onClick={toggle}
-          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-          className="absolute top-1/2 -translate-y-1/2 -right-3 z-30 flex h-6 w-6 items-center justify-center rounded-lg border border-border-2 bg-white text-text-3 transition-colors hover:bg-bg-1 hover:text-text-2"
-        >
-          {collapsed ? (
-            <ChevronsRight className="h-3.5 w-3.5" />
-          ) : (
-            <ChevronsLeft className="h-3.5 w-3.5" />
-          )}
-        </button>
+        {showToggle && (
+          <button
+            onClick={toggle}
+            title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            className="absolute top-1/2 -translate-y-1/2 -right-3 z-30 flex h-6 w-6 items-center justify-center rounded-lg border border-border-2 bg-white text-text-3 transition-colors hover:bg-bg-1 hover:text-text-2"
+          >
+            {collapsed ? (
+              <ChevronsRight className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronsLeft className="h-3.5 w-3.5" />
+            )}
+          </button>
+        )}
       </div>
 
       {/* Primary Actions */}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { XIcon } from "lucide-react"
-import { Dialog as SheetPrimitive } from "radix-ui"
+import { Dialog as SheetPrimitive, VisuallyHidden } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -73,6 +73,9 @@ function SheetContent({
         )}
         {...props}
       >
+        <VisuallyHidden.Root>
+          <SheetPrimitive.Title>Menu</SheetPrimitive.Title>
+        </VisuallyHidden.Root>
         {children}
         {showCloseButton && (
           <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">


### PR DESCRIPTION
### A summary of the changes:

- src/components/ui/sheet.tsx — Fixed the accessibility warning by importing VisuallyHidden from radix-ui and adding a hidden DialogTitle inside SheetContent. This satisfies the screen reader requirement without showing any visible title.

- src/components/layout/sidebar.tsx — Added an optional showToggle prop (defaults to true) to SidebarContent, and wrapped the collapse/expand button in a conditional so it can be hidden when used inside the mobile Sheet.

- src/components/layout/appbar.tsx — Passes showToggle={false} to <SidebarContent> inside the mobile hamburger Sheet, so the collapse button doesn't appear in the mobile version.

### Details:

- Import VisuallyHidden from radix-ui and add hidden DialogTitle inside SheetContent to fix screen reader accessibility warning

- Add showToggle prop to SidebarContent (defaults to true)

- Pass showToggle={false} in Appbar mobile Sheet to hide the collapse/expand button in hamburger menu
