### PR TITLE
feat(web): show Advanced/Basic tier badge on user detail page

### DIFF
--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -100,6 +100,7 @@ export class UsersService {
         picture: users.picture,
         monthlyBudgetCents: users.monthlyBudgetCents,
         openrouterKeyId: users.openrouterKeyId,
+        isPaid: users.isPaid,
         createdAt: users.createdAt,
       })
       .from(users)
@@ -157,12 +158,20 @@ export class UsersService {
       }
     }
 
+    // Same gate used by the sidebar Advanced/Basic badge: isPaid OR
+    // owner-of-any-team OR advanced-member-in-any-team.
+    const isAdvanced =
+      user.isPaid ||
+      isOwner.length > 0 ||
+      membershipRows.some((m) => m.role === 'advanced');
+
     return {
       id: user.id,
       name: user.name,
       email: user.email,
       picture: user.picture,
       role,
+      tier: (isAdvanced ? 'advanced' : 'basic') as 'advanced' | 'basic',
       monthlyBudgetCents: user.monthlyBudgetCents,
       spentCents,
       projectedCents,

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
 } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -142,7 +143,18 @@ export default function UserDetailPage({
           <div className="flex items-center gap-3">
             <UserAvatar name={displayName} picture={user.picture} size={80} />
             <div className="space-y-3">
-              <p className="text-[18px] font-bold text-text-1">{displayName}</p>
+              <div className="flex items-center gap-2">
+                <p className="text-[18px] font-bold text-text-1">{displayName}</p>
+                <Badge
+                  className={
+                    user.tier === "advanced"
+                      ? "border-transparent bg-primary-1 text-primary-7 uppercase tracking-wide text-[10px] px-1.5 py-0"
+                      : "border-transparent bg-bg-3 text-text-2 uppercase tracking-wide text-[10px] px-1.5 py-0"
+                  }
+                >
+                  {user.tier === "advanced" ? "Advanced" : "Basic"}
+                </Badge>
+              </div>
               <p className="text-[16px] text-text-1">{user.email}</p>
             </div>
           </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -693,6 +693,7 @@ export interface OrgUserDetail {
   name: string | null;
   picture: string | null;
   role: "basic" | "advanced" | "admin";
+  tier: "basic" | "advanced";
   monthlyBudgetCents: number;
   spentCents: number;
   projectedCents: number;


### PR DESCRIPTION
- users.service.findOne selects isPaid and returns a derived tier field ("advanced" if isPaid OR team owner OR advanced role in any team, otherwise "basic") — same gate the sidebar Advanced badge already uses.
- OrgUserDetail type gets tier.
- /users/[id] renders a Badge next to the name using the same primary-1 / bg-3 styling as the sidebar.