### PR TITLE
Feat/observability

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { KnowledgeCoreModule } from './knowledge-core/knowledge-core.module';
 import { ProjectsModule } from './projects/projects.module';
 import { RedisModule } from './redis/redis.module';
 import { ModelsModule } from './models/models.module';
+import { ObservabilityModule } from './observability/observability.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
 import { PromptsModule } from './prompts/prompts.module';
 import { ShortcutsModule } from './shortcuts/shortcuts.module';
@@ -35,6 +36,7 @@ import { UsersModule } from './users/users.module';
     GuardrailsSectionModule,
     KnowledgeCoreModule,
     ModelsModule,
+    ObservabilityModule,
     OnboardingModule,
     ProjectsModule,
     PromptsModule,

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -3,6 +3,7 @@ import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
 import { ConversationsService } from '../conversations/conversations.service.js';
 import { DocumentsService } from '../documents/documents.service.js';
+import { ObservabilityService } from '../observability/observability.service.js';
 import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 import { ChatService } from './chat.service.js';
 
@@ -21,6 +22,7 @@ export class ChatController {
     private readonly documentsService: DocumentsService,
     private readonly conversationsService: ConversationsService,
     private readonly keyResolverService: KeyResolverService,
+    private readonly observabilityService: ObservabilityService,
   ) {}
 
   @Post()
@@ -68,14 +70,52 @@ export class ChatController {
       }
     }
 
-    // 5. Call the chat service
-    const response = await this.chatService.sendMessage(
-      apiMessages,
-      body.model,
-      body.enableReasoning,
-      context,
-      apiKey,
-    );
+    // 5. Call the chat service (with per-call observability)
+    const teamId = await this.observabilityService.getPrimaryTeamId(user.id);
+    const chatStart = Date.now();
+    let response;
+    try {
+      response = await this.chatService.sendMessage(
+        apiMessages,
+        body.model,
+        body.enableReasoning,
+        context,
+        apiKey,
+      );
+      void this.observabilityService.recordLLMCall({
+        userId: user.id,
+        teamId,
+        eventType: 'chat_call',
+        model: body.model ?? 'moonshotai/kimi-k2.5',
+        totalTokens: response.totalTokens,
+        costUsd: response.totalCost,
+        latencyMs: Date.now() - chatStart,
+        success: true,
+        prompt: body.content,
+        metadata: {
+          conversationId: body.conversationId,
+          projectId: body.projectId ?? null,
+          hasContext: Boolean(context),
+        },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      void this.observabilityService.recordLLMCall({
+        userId: user.id,
+        teamId,
+        eventType: 'chat_call',
+        model: body.model ?? 'moonshotai/kimi-k2.5',
+        latencyMs: Date.now() - chatStart,
+        success: false,
+        errorMessage: msg,
+        prompt: body.content,
+        metadata: {
+          conversationId: body.conversationId,
+          projectId: body.projectId ?? null,
+        },
+      });
+      throw err;
+    }
 
     // 6. Persist assistant response
     const metadata = response.reasoning_details

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -10,6 +10,15 @@ interface ChatMessage {
 interface ChatResponse {
   content: string;
   reasoning_details?: unknown;
+  totalTokens?: number;
+  totalCost?: number;
+}
+
+// OpenRouter returns a `cost` field on usage that the OpenAI types don't
+// model; we read it through this loose shape.
+interface OpenRouterUsage {
+  cost?: number;
+  total_tokens?: number;
 }
 
 @Injectable()
@@ -63,11 +72,15 @@ export class ChatService {
     };
     const response = completion.choices[0].message as ORChatMessage;
 
+    const usage = completion.usage as OpenRouterUsage | undefined;
+
     return {
       content: response.content || '',
       ...(response.reasoning_details
         ? { reasoning_details: response.reasoning_details }
         : {}),
+      totalTokens: usage?.total_tokens,
+      totalCost: usage?.cost,
     };
   }
 }

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -170,14 +170,13 @@ export class CompareModelsController {
       throw new ServiceUnavailableException(`OpenRouter key unavailable: ${msg}`);
     }
 
-    // Resolve once per request — observability events get tagged with a
-    // team so the dashboard's team-analytics rollup is populated.
-    //   - If the body carries an explicit teamId, validate membership.
-    //     Reject foreign teams instead of silently dropping; the user
-    //     consciously picked a team they don't belong to.
-    //   - "personal" / null / "" / "null" all mean Personal scope.
-    //   - Otherwise fall back to the user's primary team.
-    let teamId: string | null;
+    // Personal-by-default scoping. If the body carries an explicit
+    // teamId, validate membership and use it. Anything else
+    // (missing / null / empty / "personal") tags the events as
+    // Personal, so they show up under the "Personal" row in the
+    // Observability team-analytics rollup. The user opts in to a
+    // team scope by explicitly selecting one in the composer.
+    let teamId: string | null = null;
     const requested = (body.teamId ?? '').trim();
     if (requested && requested !== 'personal' && requested !== 'null') {
       if (!(await this.observabilityService.isUserInTeam(user.id, requested))) {
@@ -186,10 +185,6 @@ export class CompareModelsController {
         );
       }
       teamId = requested;
-    } else if (requested === 'personal' || requested === 'null') {
-      teamId = null;
-    } else {
-      teamId = await this.observabilityService.getPrimaryTeamId(user.id);
     }
 
     let responses: ModelResponse[];

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -168,6 +168,11 @@ export class CompareModelsController {
       throw new ServiceUnavailableException(`OpenRouter key unavailable: ${msg}`);
     }
 
+    // Resolve once per request — observability events get tagged with the
+    // user's primary team so the dashboard's team-analytics rollup is
+    // populated. NULL means personal use (user has no accepted memberships).
+    const teamId = await this.observabilityService.getPrimaryTeamId(user.id);
+
     let responses: ModelResponse[];
     try {
       responses = await Promise.all(
@@ -184,6 +189,7 @@ export class CompareModelsController {
             const latencyMs = Date.now() - start;
             void this.observabilityService.recordLLMCall({
               userId: user.id,
+              teamId,
               eventType: 'arena_call',
               model,
               totalTokens: response.totalTokens,
@@ -205,6 +211,7 @@ export class CompareModelsController {
             const msg = err instanceof Error ? err.message : String(err);
             void this.observabilityService.recordLLMCall({
               userId: user.id,
+              teamId,
               eventType: 'arena_call',
               model,
               latencyMs,
@@ -241,6 +248,7 @@ export class CompareModelsController {
         );
         void this.observabilityService.recordLLMCall({
           userId: user.id,
+          teamId,
           eventType: 'evaluator_call',
           model: EVALUATOR_MODEL,
           latencyMs: Date.now() - evalStart,
@@ -251,6 +259,7 @@ export class CompareModelsController {
         const msg = err instanceof Error ? err.message : String(err);
         void this.observabilityService.recordLLMCall({
           userId: user.id,
+          teamId,
           eventType: 'evaluator_call',
           model: EVALUATOR_MODEL,
           latencyMs: Date.now() - evalStart,
@@ -413,6 +422,7 @@ export class CompareModelsController {
         );
       }
 
+      const teamId = await this.observabilityService.getPrimaryTeamId(user.id);
       const dataUrl = `data:${mimetype};base64,${file.buffer.toString('base64')}`;
       let extracted: string;
       const ocrStart = Date.now();
@@ -424,6 +434,7 @@ export class CompareModelsController {
         );
         void this.observabilityService.recordLLMCall({
           userId: user.id,
+          teamId,
           eventType: 'arena_attachment_ocr',
           model: OCR_MODEL,
           latencyMs: Date.now() - ocrStart,
@@ -434,6 +445,7 @@ export class CompareModelsController {
         const msg = err instanceof Error ? err.message : String(err);
         void this.observabilityService.recordLLMCall({
           userId: user.id,
+          teamId,
           eventType: 'arena_attachment_ocr',
           model: OCR_MODEL,
           latencyMs: Date.now() - ocrStart,

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -23,6 +23,7 @@ import { arenaRuns } from '@worken/database/schema';
 import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
 import { DATABASE, type Database } from '../database/database.module.js';
+import { ObservabilityService } from '../observability/observability.service.js';
 import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 import { CompareModelsService } from './compare-models.service.js';
 
@@ -82,6 +83,7 @@ export class CompareModelsController {
   constructor(
     private readonly compareModelsService: CompareModelsService,
     private readonly keyResolverService: KeyResolverService,
+    private readonly observabilityService: ObservabilityService,
     @Inject(DATABASE) private readonly db: Database,
   ) {}
 
@@ -171,20 +173,48 @@ export class CompareModelsController {
       responses = await Promise.all(
         body.models.map(async (model) => {
           const start = Date.now();
-          const response = await this.compareModelsService.sendQuestion(
-            body.question,
-            model,
-            false,
-            body.context,
-            apiKey,
-          );
-          return {
-            model,
-            response,
-            time: Date.now() - start,
-            totalTokens: response.totalTokens,
-            totalCost: response.totalCost,
-          };
+          try {
+            const response = await this.compareModelsService.sendQuestion(
+              body.question,
+              model,
+              false,
+              body.context,
+              apiKey,
+            );
+            const latencyMs = Date.now() - start;
+            void this.observabilityService.recordLLMCall({
+              userId: user.id,
+              eventType: 'arena_call',
+              model,
+              totalTokens: response.totalTokens,
+              costUsd: response.totalCost,
+              latencyMs,
+              success: true,
+              prompt: body.question,
+              metadata: { hasContext: Boolean(body.context) },
+            });
+            return {
+              model,
+              response,
+              time: latencyMs,
+              totalTokens: response.totalTokens,
+              totalCost: response.totalCost,
+            };
+          } catch (err) {
+            const latencyMs = Date.now() - start;
+            const msg = err instanceof Error ? err.message : String(err);
+            void this.observabilityService.recordLLMCall({
+              userId: user.id,
+              eventType: 'arena_call',
+              model,
+              latencyMs,
+              success: false,
+              errorMessage: msg,
+              prompt: body.question,
+              metadata: { hasContext: Boolean(body.context) },
+            });
+            throw err;
+          }
         }),
       );
     } catch (err) {
@@ -197,18 +227,37 @@ export class CompareModelsController {
     let lastParseError: string | undefined;
     let lastRawContent = '';
 
+    const EVALUATOR_MODEL = 'nvidia/nemotron-3-super-120b-a12b:free';
     for (let attempt = 1; attempt <= MAX_COMPARE_ATTEMPTS; attempt++) {
       let comparison;
+      const evalStart = Date.now();
       try {
         comparison = await this.compareModelsService.compareModelAnswers(
           responses,
           body.expectedOutput,
-          'nvidia/nemotron-3-super-120b-a12b:free',
+          EVALUATOR_MODEL,
           false,
           apiKey,
         );
+        void this.observabilityService.recordLLMCall({
+          userId: user.id,
+          eventType: 'evaluator_call',
+          model: EVALUATOR_MODEL,
+          latencyMs: Date.now() - evalStart,
+          success: true,
+          metadata: { attempt },
+        });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        void this.observabilityService.recordLLMCall({
+          userId: user.id,
+          eventType: 'evaluator_call',
+          model: EVALUATOR_MODEL,
+          latencyMs: Date.now() - evalStart,
+          success: false,
+          errorMessage: msg,
+          metadata: { attempt },
+        });
         this.logger.error(
           `Evaluator call failed on attempt ${attempt}/${MAX_COMPARE_ATTEMPTS}: ${msg}`,
         );
@@ -366,14 +415,32 @@ export class CompareModelsController {
 
       const dataUrl = `data:${mimetype};base64,${file.buffer.toString('base64')}`;
       let extracted: string;
+      const ocrStart = Date.now();
       try {
         extracted = await this.compareModelsService.extractTextFromImage(
           dataUrl,
           OCR_MODEL,
           apiKey,
         );
+        void this.observabilityService.recordLLMCall({
+          userId: user.id,
+          eventType: 'arena_attachment_ocr',
+          model: OCR_MODEL,
+          latencyMs: Date.now() - ocrStart,
+          success: true,
+          metadata: { filename: name, mimetype },
+        });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        void this.observabilityService.recordLLMCall({
+          userId: user.id,
+          eventType: 'arena_attachment_ocr',
+          model: OCR_MODEL,
+          latencyMs: Date.now() - ocrStart,
+          success: false,
+          errorMessage: msg,
+          metadata: { filename: name, mimetype },
+        });
         this.logger.error(`OCR failed for "${name}": ${msg}`);
         throw new BadGatewayException(msg);
       }

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -44,6 +44,8 @@ interface CompareModelsRequestBody {
   question: string;
   expectedOutput: string;
   context?: string;
+  /** Optional. If omitted, server falls back to the user's primary team. */
+  teamId?: string | null;
 }
 
 interface ModelResponse {
@@ -168,10 +170,27 @@ export class CompareModelsController {
       throw new ServiceUnavailableException(`OpenRouter key unavailable: ${msg}`);
     }
 
-    // Resolve once per request — observability events get tagged with the
-    // user's primary team so the dashboard's team-analytics rollup is
-    // populated. NULL means personal use (user has no accepted memberships).
-    const teamId = await this.observabilityService.getPrimaryTeamId(user.id);
+    // Resolve once per request — observability events get tagged with a
+    // team so the dashboard's team-analytics rollup is populated.
+    //   - If the body carries an explicit teamId, validate membership.
+    //     Reject foreign teams instead of silently dropping; the user
+    //     consciously picked a team they don't belong to.
+    //   - "personal" / null / "" / "null" all mean Personal scope.
+    //   - Otherwise fall back to the user's primary team.
+    let teamId: string | null;
+    const requested = (body.teamId ?? '').trim();
+    if (requested && requested !== 'personal' && requested !== 'null') {
+      if (!(await this.observabilityService.isUserInTeam(user.id, requested))) {
+        throw new BadRequestException(
+          'You are not a member of the selected team.',
+        );
+      }
+      teamId = requested;
+    } else if (requested === 'personal' || requested === 'null') {
+      teamId = null;
+    } else {
+      teamId = await this.observabilityService.getPrimaryTeamId(user.id);
+    }
 
     let responses: ModelResponse[];
     try {

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -32,7 +32,7 @@ export class DocumentsController {
       projectId,
       user.id,
     );
-    return this.documentsService.create(projectId, body.content, apiKey);
+    return this.documentsService.create(projectId, body.content, apiKey, user.id);
   }
 
   @Post('projects/:projectId/documents/upload')

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -8,12 +8,21 @@ import { randomUUID } from 'crypto';
 import { and, cosineDistance, count, desc, eq, min, sql } from 'drizzle-orm';
 import OpenAI from 'openai';
 import { DATABASE, type Database } from '../database/database.module.js';
+import { ObservabilityService } from '../observability/observability.service.js';
+
+interface OpenRouterUsage {
+  cost?: number;
+  total_tokens?: number;
+}
 
 @Injectable()
 export class DocumentsService {
   private embedder: FeatureExtractionPipeline | null = null;
 
-  constructor(@Inject(DATABASE) private readonly db: Database) {}
+  constructor(
+    @Inject(DATABASE) private readonly db: Database,
+    private readonly observabilityService: ObservabilityService,
+  ) {}
 
   private makeClient(apiKey?: string): OpenAI {
     return new OpenAI({
@@ -74,11 +83,17 @@ export class DocumentsService {
     return results;
   }
 
-  private async generateTitle(text: string, apiKey?: string): Promise<string> {
+  private async generateTitle(
+    text: string,
+    apiKey?: string,
+    callerUserId?: string,
+  ): Promise<string> {
     const snippet = text.slice(0, 500);
+    const TITLE_MODEL = 'arcee-ai/trinity-large-preview:free';
+    const start = Date.now();
     try {
       const response = await this.makeClient(apiKey).chat.completions.create({
-        model: 'arcee-ai/trinity-large-preview:free',
+        model: TITLE_MODEL,
         messages: [
           {
             role: 'user',
@@ -87,21 +102,56 @@ export class DocumentsService {
         ],
         max_completion_tokens: 20,
       });
+      if (callerUserId) {
+        const usage = response.usage as OpenRouterUsage | undefined;
+        const teamId =
+          await this.observabilityService.getPrimaryTeamId(callerUserId);
+        void this.observabilityService.recordLLMCall({
+          userId: callerUserId,
+          teamId,
+          eventType: 'document_title',
+          model: TITLE_MODEL,
+          totalTokens: usage?.total_tokens,
+          costUsd: usage?.cost,
+          latencyMs: Date.now() - start,
+          success: true,
+          metadata: { phase: 'title-generation' },
+        });
+      }
       return (
         response.choices[0]?.message?.content?.trim() || 'Untitled Document'
       );
-    } catch {
+    } catch (err) {
+      if (callerUserId) {
+        const teamId =
+          await this.observabilityService.getPrimaryTeamId(callerUserId);
+        void this.observabilityService.recordLLMCall({
+          userId: callerUserId,
+          teamId,
+          eventType: 'document_title',
+          model: TITLE_MODEL,
+          latencyMs: Date.now() - start,
+          success: false,
+          errorMessage: err instanceof Error ? err.message : String(err),
+          metadata: { phase: 'title-generation' },
+        });
+      }
       return 'Untitled Document';
     }
   }
 
-  async create(projectId: string, content: string, apiKey?: string) {
+  async create(
+    projectId: string,
+    content: string,
+    apiKey?: string,
+    callerUserId?: string,
+  ) {
     const chunks = this.chunkText(content);
     if (chunks.length === 0) return [];
 
     const [embeddings, title] = await Promise.all([
       this.embed(chunks),
-      this.generateTitle(content, apiKey),
+      this.generateTitle(content, apiKey, callerUserId),
     ]);
 
     const groupId = randomUUID();

--- a/apps/api/src/observability/observability.controller.ts
+++ b/apps/api/src/observability/observability.controller.ts
@@ -1,0 +1,166 @@
+import {
+  BadRequestException,
+  Controller,
+  ForbiddenException,
+  Get,
+  Inject,
+  Query,
+} from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { users } from '@worken/database/schema';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthenticatedUser } from '../auth/types.js';
+import { DATABASE, type Database } from '../database/database.module.js';
+import { ObservabilityService } from './observability.service.js';
+
+type RangeKey = '24h' | '7d' | '30d' | '90d';
+type Granularity = 'hour' | 'day' | 'week';
+
+const RANGE_TO_MS: Record<RangeKey, number> = {
+  '24h': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+  '90d': 90 * 24 * 60 * 60 * 1000,
+};
+
+function parseRange(raw: string | undefined): { key: RangeKey; from: Date; to: Date } {
+  const key = (raw ?? '7d') as RangeKey;
+  if (!(key in RANGE_TO_MS)) {
+    throw new BadRequestException(
+      `Invalid range "${raw}". Allowed: 24h, 7d, 30d, 90d.`,
+    );
+  }
+  const to = new Date();
+  const from = new Date(to.getTime() - RANGE_TO_MS[key]);
+  return { key, from, to };
+}
+
+function defaultGranularityForRange(key: RangeKey): Granularity {
+  if (key === '24h') return 'hour';
+  if (key === '90d') return 'week';
+  return 'day';
+}
+
+function parseGranularity(
+  raw: string | undefined,
+  fallback: Granularity,
+): Granularity {
+  if (!raw) return fallback;
+  if (raw === 'hour' || raw === 'day' || raw === 'week') return raw;
+  throw new BadRequestException(
+    `Invalid granularity "${raw}". Allowed: hour, day, week.`,
+  );
+}
+
+@Controller('observability')
+export class ObservabilityController {
+  constructor(
+    private readonly observabilityService: ObservabilityService,
+    @Inject(DATABASE) private readonly db: Database,
+  ) {}
+
+  /**
+   * Admin-only guard. AuthenticatedUser doesn't carry role, so we look it up.
+   * Mirrors the pattern in users.controller.ts (inviteUser).
+   */
+  private async assertAdmin(caller: AuthenticatedUser): Promise<void> {
+    const [row] = await this.db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, caller.id));
+    if (!row || row.role !== 'admin') {
+      throw new ForbiddenException(
+        'Observability dashboard is admin-only.',
+      );
+    }
+  }
+
+  @Get('summary')
+  async summary(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('range') range?: string,
+  ) {
+    await this.assertAdmin(caller);
+    const { key, from, to } = parseRange(range);
+    const span = to.getTime() - from.getTime();
+    const previousFrom = new Date(from.getTime() - span);
+    const previousTo = from;
+    const [current, previous] = await Promise.all([
+      this.observabilityService.summary(from, to),
+      this.observabilityService.summary(previousFrom, previousTo),
+    ]);
+    return { range: key, current, previous };
+  }
+
+  @Get('token-usage')
+  async tokenUsage(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('range') range?: string,
+    @Query('granularity') granularityRaw?: string,
+  ) {
+    await this.assertAdmin(caller);
+    const { key, from, to } = parseRange(range);
+    const granularity = parseGranularity(
+      granularityRaw,
+      defaultGranularityForRange(key),
+    );
+    const series = await this.observabilityService.tokenUsageSeries(
+      from,
+      to,
+      granularity,
+    );
+    return { range: key, granularity, series };
+  }
+
+  @Get('cost-by-provider')
+  async costByProvider(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('range') range?: string,
+  ) {
+    await this.assertAdmin(caller);
+    const { key, from, to } = parseRange(range);
+    const providers = await this.observabilityService.costByProvider(from, to);
+    return { range: key, providers };
+  }
+
+  @Get('events')
+  async events(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('range') range?: string,
+    @Query('search') search?: string,
+    @Query('user') userId?: string,
+    @Query('team') teamId?: string,
+    @Query('model') model?: string,
+    @Query('eventType') eventType?: string,
+    @Query('page') pageRaw?: string,
+    @Query('pageSize') pageSizeRaw?: string,
+  ) {
+    await this.assertAdmin(caller);
+    const { key, from, to } = parseRange(range);
+    const page = Math.max(1, Number(pageRaw) || 1);
+    const pageSize = Math.max(1, Math.min(Number(pageSizeRaw) || 50, 200));
+    const result = await this.observabilityService.listEvents({
+      from,
+      to,
+      search: search ?? null,
+      userId: userId ?? null,
+      teamId: teamId ?? null,
+      model: model ?? null,
+      eventType: eventType ?? null,
+      page,
+      pageSize,
+    });
+    return { range: key, ...result };
+  }
+
+  @Get('guardrail-activity')
+  async guardrailActivity(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('range') range?: string,
+  ) {
+    await this.assertAdmin(caller);
+    const { key, from, to } = parseRange(range);
+    const result = await this.observabilityService.guardrailActivity(from, to);
+    return { range: key, ...result };
+  }
+}

--- a/apps/api/src/observability/observability.controller.ts
+++ b/apps/api/src/observability/observability.controller.ts
@@ -123,6 +123,17 @@ export class ObservabilityController {
     return { range: key, providers };
   }
 
+  @Get('team-analytics')
+  async teamAnalytics(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('range') range?: string,
+  ) {
+    await this.assertAdmin(caller);
+    const { key, from, to } = parseRange(range);
+    const teams = await this.observabilityService.teamAnalytics(from, to);
+    return { range: key, teams };
+  }
+
   @Get('events')
   async events(
     @CurrentUser() caller: AuthenticatedUser,

--- a/apps/api/src/observability/observability.module.ts
+++ b/apps/api/src/observability/observability.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { ObservabilityService } from './observability.service.js';
+
+/**
+ * Global so any feature module can inject ObservabilityService without
+ * having to add the module to its own imports list.
+ */
+@Global()
+@Module({
+  providers: [ObservabilityService],
+  exports: [ObservabilityService],
+})
+export class ObservabilityModule {}

--- a/apps/api/src/observability/observability.module.ts
+++ b/apps/api/src/observability/observability.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module } from '@nestjs/common';
+import { ObservabilityController } from './observability.controller.js';
 import { ObservabilityService } from './observability.service.js';
 
 /**
@@ -7,6 +8,7 @@ import { ObservabilityService } from './observability.service.js';
  */
 @Global()
 @Module({
+  controllers: [ObservabilityController],
   providers: [ObservabilityService],
   exports: [ObservabilityService],
 })

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -1,6 +1,11 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { and, desc, eq, gte, ilike, lte, or, sql } from 'drizzle-orm';
-import { observabilityEvents, teams, users } from '@worken/database/schema';
+import { and, asc, desc, eq, gte, ilike, lte, or, sql } from 'drizzle-orm';
+import {
+  observabilityEvents,
+  teamMembers,
+  teams,
+  users,
+} from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 
 /**
@@ -68,6 +73,39 @@ export class ObservabilityService {
   private readonly logger = new Logger(ObservabilityService.name);
 
   constructor(@Inject(DATABASE) private readonly db: Database) {}
+
+  // ─── Team association helper ──────────────────────────────────────────
+
+  /**
+   * Pick a user's "primary" team for event scoping.
+   * Rule: oldest accepted membership wins. Returns null when the user has
+   * none (personal use). Per-call: cached one query per request, but we
+   * keep it simple and let callers cache across a request if needed.
+   */
+  async getPrimaryTeamId(userId: string): Promise<string | null> {
+    try {
+      const [row] = await this.db
+        .select({ teamId: teamMembers.teamId })
+        .from(teamMembers)
+        .where(
+          and(
+            eq(teamMembers.userId, userId),
+            eq(teamMembers.status, 'accepted'),
+          ),
+        )
+        .orderBy(asc(teamMembers.createdAt))
+        .limit(1);
+      return row?.teamId ?? null;
+    } catch (err) {
+      // Defensive — if the lookup fails for any reason, never break the
+      // user-facing call path. The event just gets a NULL team.
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(
+        `getPrimaryTeamId failed for user ${userId}: ${msg}`,
+      );
+      return null;
+    }
+  }
 
   // ─── Aggregation queries (used by Phase 2 controller) ──────────────────
 
@@ -151,6 +189,39 @@ export class ObservabilityService {
       cost: Number(r.cost ?? 0),
       tokens: Number(r.tokens ?? 0),
       calls: Number(r.calls ?? 0),
+    }));
+  }
+
+  async teamAnalytics(from: Date, to: Date) {
+    const rows = await this.db
+      .select({
+        teamId: observabilityEvents.teamId,
+        teamName: teams.name,
+        cost: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)::text`,
+        tokens: sql<number>`coalesce(sum(${observabilityEvents.totalTokens}), 0)::int`,
+        avgLatencyMs: sql<number>`coalesce(avg(${observabilityEvents.latencyMs}), 0)::int`,
+        calls: sql<number>`count(*)::int`,
+        activeUsers: sql<number>`count(distinct ${observabilityEvents.userId})::int`,
+      })
+      .from(observabilityEvents)
+      .leftJoin(teams, eq(teams.id, observabilityEvents.teamId))
+      .where(
+        and(
+          gte(observabilityEvents.createdAt, from),
+          lte(observabilityEvents.createdAt, to),
+        ),
+      )
+      .groupBy(observabilityEvents.teamId, teams.name)
+      .orderBy(sql`sum(${observabilityEvents.costUsd}) desc nulls last`);
+
+    return rows.map((r) => ({
+      teamId: r.teamId,
+      teamName: r.teamName ?? (r.teamId ? "(unknown team)" : "Personal"),
+      cost: Number(r.cost ?? 0),
+      tokens: Number(r.tokens ?? 0),
+      avgLatencyMs: Number(r.avgLatencyMs ?? 0),
+      calls: Number(r.calls ?? 0),
+      activeUsers: Number(r.activeUsers ?? 0),
     }));
   }
 

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -1,0 +1,104 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { observabilityEvents } from '@worken/database/schema';
+import { DATABASE, type Database } from '../database/database.module.js';
+
+/**
+ * Derive a coarse provider label from an OpenRouter-style model id like
+ * "openai/gpt-4o:free" → "openai". Falls back to "openrouter:other" so we
+ * can still group unknown providers in the dashboard.
+ */
+export function providerFromModel(model: string | null | undefined): string {
+  if (!model) return 'unknown';
+  const slug = model.split('/')[0]?.toLowerCase();
+  if (!slug) return 'unknown';
+  const known = new Set([
+    'openai',
+    'anthropic',
+    'google',
+    'meta-llama',
+    'mistralai',
+    'cohere',
+    'nvidia',
+    'arcee-ai',
+    'liquid',
+    'stepfun',
+    'baidu',
+    'qwen',
+    'deepseek',
+  ]);
+  return known.has(slug) ? slug : `openrouter:${slug}`;
+}
+
+const PROMPT_PREVIEW_MAX = 200;
+
+function truncatePreview(prompt: string | null | undefined): string | null {
+  if (!prompt) return null;
+  const trimmed = prompt.trim();
+  if (!trimmed) return null;
+  return trimmed.length <= PROMPT_PREVIEW_MAX
+    ? trimmed
+    : `${trimmed.slice(0, PROMPT_PREVIEW_MAX)}…`;
+}
+
+export interface RecordLLMCallInput {
+  userId: string;
+  teamId?: string | null;
+  eventType:
+    | 'arena_call'
+    | 'evaluator_call'
+    | 'arena_attachment_ocr'
+    | 'guardrail_trigger'
+    | string;
+  model?: string | null;
+  provider?: string | null;
+  promptTokens?: number | null;
+  completionTokens?: number | null;
+  totalTokens?: number | null;
+  costUsd?: number | null;
+  latencyMs?: number | null;
+  success?: boolean;
+  errorMessage?: string | null;
+  prompt?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+@Injectable()
+export class ObservabilityService {
+  private readonly logger = new Logger(ObservabilityService.name);
+
+  constructor(@Inject(DATABASE) private readonly db: Database) {}
+
+  /**
+   * Persist a single observability event. Errors are caught and logged so a
+   * failing insert never breaks the user-facing request path.
+   */
+  async recordLLMCall(input: RecordLLMCallInput): Promise<void> {
+    try {
+      await this.db.insert(observabilityEvents).values({
+        userId: input.userId,
+        teamId: input.teamId ?? null,
+        eventType: input.eventType,
+        model: input.model ?? null,
+        provider:
+          input.provider ?? (input.model ? providerFromModel(input.model) : null),
+        promptTokens: input.promptTokens ?? null,
+        completionTokens: input.completionTokens ?? null,
+        totalTokens: input.totalTokens ?? null,
+        costUsd:
+          input.costUsd !== undefined && input.costUsd !== null
+            ? String(input.costUsd)
+            : null,
+        latencyMs: input.latencyMs ?? null,
+        success: input.success ?? true,
+        errorMessage: input.errorMessage ?? null,
+        promptPreview: truncatePreview(input.prompt),
+        metadata: input.metadata ?? null,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to record observability event for user ${input.userId} (${input.eventType}): ${msg}`,
+      );
+    }
+  }
+}

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -82,6 +82,30 @@ export class ObservabilityService {
    * none (personal use). Per-call: cached one query per request, but we
    * keep it simple and let callers cache across a request if needed.
    */
+  /**
+   * Returns true if the user has an accepted membership in the given team.
+   * Used by callers that accept an explicit teamId override (e.g. the
+   * compare-models composer) to validate before attaching it to events.
+   */
+  async isUserInTeam(userId: string, teamId: string): Promise<boolean> {
+    try {
+      const [row] = await this.db
+        .select({ id: teamMembers.id })
+        .from(teamMembers)
+        .where(
+          and(
+            eq(teamMembers.userId, userId),
+            eq(teamMembers.teamId, teamId),
+            eq(teamMembers.status, 'accepted'),
+          ),
+        )
+        .limit(1);
+      return Boolean(row);
+    } catch {
+      return false;
+    }
+  }
+
   async getPrimaryTeamId(userId: string): Promise<string | null> {
     try {
       const [row] = await this.db

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { observabilityEvents } from '@worken/database/schema';
+import { and, desc, eq, gte, ilike, lte, or, sql } from 'drizzle-orm';
+import { observabilityEvents, teams, users } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 
 /**
@@ -67,6 +68,198 @@ export class ObservabilityService {
   private readonly logger = new Logger(ObservabilityService.name);
 
   constructor(@Inject(DATABASE) private readonly db: Database) {}
+
+  // ─── Aggregation queries (used by Phase 2 controller) ──────────────────
+
+  async summary(from: Date, to: Date) {
+    const [row] = await this.db
+      .select({
+        totalCost: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)::text`,
+        totalTokens: sql<number>`coalesce(sum(${observabilityEvents.totalTokens}), 0)::int`,
+        avgLatencyMs: sql<number>`coalesce(avg(${observabilityEvents.latencyMs}), 0)::int`,
+        activeUsers: sql<number>`count(distinct ${observabilityEvents.userId})::int`,
+        callCount: sql<number>`count(*)::int`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          gte(observabilityEvents.createdAt, from),
+          lte(observabilityEvents.createdAt, to),
+        ),
+      );
+
+    return {
+      totalCost: Number(row?.totalCost ?? 0),
+      totalTokens: Number(row?.totalTokens ?? 0),
+      avgLatencyMs: Number(row?.avgLatencyMs ?? 0),
+      activeUsers: Number(row?.activeUsers ?? 0),
+      callCount: Number(row?.callCount ?? 0),
+    };
+  }
+
+  async tokenUsageSeries(
+    from: Date,
+    to: Date,
+    granularity: 'hour' | 'day' | 'week',
+  ) {
+    const bucketSql = sql.raw(`date_trunc('${granularity}', created_at)`);
+    const rows = await this.db
+      .select({
+        bucket: sql<string>`${bucketSql}`,
+        tokens: sql<number>`coalesce(sum(${observabilityEvents.totalTokens}), 0)::int`,
+        cost: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)::text`,
+        calls: sql<number>`count(*)::int`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          gte(observabilityEvents.createdAt, from),
+          lte(observabilityEvents.createdAt, to),
+        ),
+      )
+      .groupBy(bucketSql)
+      .orderBy(bucketSql);
+
+    return rows.map((r) => ({
+      bucket: typeof r.bucket === 'string' ? r.bucket : new Date(r.bucket).toISOString(),
+      tokens: Number(r.tokens ?? 0),
+      cost: Number(r.cost ?? 0),
+      calls: Number(r.calls ?? 0),
+    }));
+  }
+
+  async costByProvider(from: Date, to: Date) {
+    const rows = await this.db
+      .select({
+        provider: observabilityEvents.provider,
+        cost: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)::text`,
+        tokens: sql<number>`coalesce(sum(${observabilityEvents.totalTokens}), 0)::int`,
+        calls: sql<number>`count(*)::int`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          gte(observabilityEvents.createdAt, from),
+          lte(observabilityEvents.createdAt, to),
+        ),
+      )
+      .groupBy(observabilityEvents.provider)
+      .orderBy(sql`sum(${observabilityEvents.costUsd}) desc nulls last`);
+
+    return rows.map((r) => ({
+      provider: r.provider ?? 'unknown',
+      cost: Number(r.cost ?? 0),
+      tokens: Number(r.tokens ?? 0),
+      calls: Number(r.calls ?? 0),
+    }));
+  }
+
+  async listEvents(opts: {
+    from: Date;
+    to: Date;
+    search?: string | null;
+    userId?: string | null;
+    teamId?: string | null;
+    model?: string | null;
+    eventType?: string | null;
+    page: number;
+    pageSize: number;
+  }) {
+    const conditions = [
+      gte(observabilityEvents.createdAt, opts.from),
+      lte(observabilityEvents.createdAt, opts.to),
+    ];
+    if (opts.userId) conditions.push(eq(observabilityEvents.userId, opts.userId));
+    if (opts.teamId) conditions.push(eq(observabilityEvents.teamId, opts.teamId));
+    if (opts.model) conditions.push(eq(observabilityEvents.model, opts.model));
+    if (opts.eventType)
+      conditions.push(eq(observabilityEvents.eventType, opts.eventType));
+    if (opts.search?.trim()) {
+      const needle = `%${opts.search.trim()}%`;
+      const searchClause = or(
+        ilike(observabilityEvents.promptPreview, needle),
+        ilike(observabilityEvents.model, needle),
+        ilike(users.name, needle),
+        ilike(users.email, needle),
+      );
+      if (searchClause) conditions.push(searchClause);
+    }
+
+    const where = and(...conditions);
+    const limit = Math.max(1, Math.min(opts.pageSize, 200));
+    const offset = Math.max(0, (opts.page - 1) * limit);
+
+    const [{ total }] = await this.db
+      .select({ total: sql<number>`count(*)::int` })
+      .from(observabilityEvents)
+      .leftJoin(users, eq(users.id, observabilityEvents.userId))
+      .where(where);
+
+    const rows = await this.db
+      .select({
+        id: observabilityEvents.id,
+        createdAt: observabilityEvents.createdAt,
+        eventType: observabilityEvents.eventType,
+        model: observabilityEvents.model,
+        provider: observabilityEvents.provider,
+        totalTokens: observabilityEvents.totalTokens,
+        costUsd: sql<string>`${observabilityEvents.costUsd}::text`,
+        latencyMs: observabilityEvents.latencyMs,
+        success: observabilityEvents.success,
+        errorMessage: observabilityEvents.errorMessage,
+        promptPreview: observabilityEvents.promptPreview,
+        userId: observabilityEvents.userId,
+        userName: users.name,
+        userEmail: users.email,
+        teamId: observabilityEvents.teamId,
+        teamName: teams.name,
+      })
+      .from(observabilityEvents)
+      .leftJoin(users, eq(users.id, observabilityEvents.userId))
+      .leftJoin(teams, eq(teams.id, observabilityEvents.teamId))
+      .where(where)
+      .orderBy(desc(observabilityEvents.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return {
+      total: Number(total ?? 0),
+      page: opts.page,
+      pageSize: limit,
+      events: rows.map((r) => ({
+        ...r,
+        costUsd: r.costUsd === null ? null : Number(r.costUsd),
+      })),
+    };
+  }
+
+  async guardrailActivity(from: Date, to: Date) {
+    const rows = await this.db
+      .select({
+        guardrailId: sql<string | null>`${observabilityEvents.metadata} ->> 'guardrailId'`,
+        guardrailName: sql<string | null>`${observabilityEvents.metadata} ->> 'name'`,
+        severity: sql<string | null>`${observabilityEvents.metadata} ->> 'severity'`,
+        count: sql<number>`count(*)::int`,
+        lastTriggeredAt: sql<Date>`max(${observabilityEvents.createdAt})`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          gte(observabilityEvents.createdAt, from),
+          lte(observabilityEvents.createdAt, to),
+          eq(observabilityEvents.eventType, 'guardrail_trigger'),
+        ),
+      )
+      .groupBy(
+        sql`${observabilityEvents.metadata} ->> 'guardrailId'`,
+        sql`${observabilityEvents.metadata} ->> 'name'`,
+        sql`${observabilityEvents.metadata} ->> 'severity'`,
+      )
+      .orderBy(sql`count(*) desc`);
+
+    const totalTriggers = rows.reduce((sum, r) => sum + Number(r.count ?? 0), 0);
+    return { totalTriggers, triggers: rows };
+  }
 
   /**
    * Persist a single observability event. Errors are caught and logged so a

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -185,9 +185,10 @@ export default function CompareModelsPage() {
   >(null);
   const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
   const [teamsList, setTeamsList] = useState<TeamListItem[]>([]);
-  // Sentinels: "default" → let server pick the user's primary team;
-  // "personal" → explicit no-team scope. Anything else is a team UUID.
-  const [selectedTeamId, setSelectedTeamId] = useState<string>("default");
+  // Personal-first: events default to no team scope unless the user
+  // explicitly picks one. "personal" is the sentinel for null teamId;
+  // anything else is a real team UUID.
+  const [selectedTeamId, setSelectedTeamId] = useState<string>("personal");
   const deleteRunQuestion = useMemo(
     () => history.find((h) => h.id === deleteRunId)?.question ?? "",
     [history, deleteRunId],
@@ -267,15 +268,10 @@ export default function CompareModelsPage() {
     const context = contextParts.length ? contextParts.join("\n\n") : undefined;
 
     try {
-      // teamId sentinel: "default" → server picks user's primary team
-      // (matches getPrimaryTeamId), "personal" → explicit Personal scope,
-      // anything else → that team UUID.
+      // "personal" → null teamId (Personal scope, the default).
+      // Anything else → real team UUID, server validates membership.
       const teamIdForCall =
-        selectedTeamId === "default"
-          ? undefined
-          : selectedTeamId === "personal"
-            ? null
-            : selectedTeamId;
+        selectedTeamId === "personal" ? null : selectedTeamId;
       const result = await sendQuestionToCompareModels(
         activeModels,
         question,
@@ -1270,10 +1266,9 @@ function RightRail({
           </span>
           <Select value={selectedTeamId} onValueChange={onSelectTeam}>
             <SelectTrigger className="h-10 rounded-md border-border-2 text-[13px]">
-              <SelectValue placeholder="Default (your primary team)" />
+              <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">Default (primary team)</SelectItem>
               <SelectItem value="personal">Personal (no team)</SelectItem>
               {teams.map((t) => (
                 <SelectItem key={t.id} value={t.id}>

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -1278,7 +1278,7 @@ function RightRail({
             </SelectContent>
           </Select>
           <p className="text-[11px] text-text-3">
-            Tags this run&apos;s usage in the Observability dashboard.
+            Attributes this run&apos;s spend and tokens to the chosen team.
           </p>
         </section>
       )}

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -51,16 +51,25 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   deleteArenaRun,
   fetchArenaRun,
   fetchArenaRuns,
   fetchPrompts,
   fetchShortcuts,
+  fetchTeams,
   parseArenaAttachment,
   sendQuestionToCompareModels,
   type ArenaRunSummary,
   type PromptSummary,
   type Shortcut,
+  type TeamListItem,
 } from "@/lib/api";
 import { humanizeArenaError } from "@/lib/arena-errors";
 import { MODELS } from "@/lib/models";
@@ -175,6 +184,10 @@ export default function CompareModelsPage() {
     { name: string; content: string } | null
   >(null);
   const [promptLibraryOpen, setPromptLibraryOpen] = useState(false);
+  const [teamsList, setTeamsList] = useState<TeamListItem[]>([]);
+  // Sentinels: "default" → let server pick the user's primary team;
+  // "personal" → explicit no-team scope. Anything else is a team UUID.
+  const [selectedTeamId, setSelectedTeamId] = useState<string>("default");
   const deleteRunQuestion = useMemo(
     () => history.find((h) => h.id === deleteRunId)?.question ?? "",
     [history, deleteRunId],
@@ -218,6 +231,15 @@ export default function CompareModelsPage() {
           err instanceof Error ? err.message : "Couldn't load history.";
         toast.error(message);
       });
+    // Teams list for the picker. Failure is non-fatal — the page still works
+    // without a picker; events just default to the user's primary team.
+    fetchTeams()
+      .then((rows) => {
+        if (!cancelled) setTeamsList(rows);
+      })
+      .catch(() => {
+        /* swallow — picker just stays empty */
+      });
     return () => {
       cancelled = true;
     };
@@ -245,11 +267,21 @@ export default function CompareModelsPage() {
     const context = contextParts.length ? contextParts.join("\n\n") : undefined;
 
     try {
+      // teamId sentinel: "default" → server picks user's primary team
+      // (matches getPrimaryTeamId), "personal" → explicit Personal scope,
+      // anything else → that team UUID.
+      const teamIdForCall =
+        selectedTeamId === "default"
+          ? undefined
+          : selectedTeamId === "personal"
+            ? null
+            : selectedTeamId;
       const result = await sendQuestionToCompareModels(
         activeModels,
         question,
         expectedOutput,
         context,
+        teamIdForCall,
       );
 
       const nextResponses: Record<string, string | null> = {};
@@ -444,6 +476,9 @@ export default function CompareModelsPage() {
             }}
             onClose={() => setRailOpen(false)}
             onAddModel={() => setAddModelOpen(true)}
+            teams={teamsList}
+            selectedTeamId={selectedTeamId}
+            onSelectTeam={setSelectedTeamId}
           />
         ) : (
           <button
@@ -1142,6 +1177,9 @@ function RightRail({
   onDeleteHistory,
   onClose,
   onAddModel,
+  teams,
+  selectedTeamId,
+  onSelectTeam,
 }: {
   selectedModels: string[];
   disabledModels: Set<string>;
@@ -1157,6 +1195,9 @@ function RightRail({
   onDeleteHistory: (runId: string) => void;
   onClose: () => void;
   onAddModel: () => void;
+  teams: TeamListItem[];
+  selectedTeamId: string;
+  onSelectTeam: (id: string) => void;
 }) {
   const canRemove = selectedModels.length > MIN_MODELS;
   const allModelIds = useMemo(() => MODELS.map((m) => m.id), []);
@@ -1218,6 +1259,34 @@ function RightRail({
           Add Model
         </button>
       </RailSection>
+
+      {/* Team context — only render the picker when the user actually
+          belongs to ≥1 team. Solo users keep their composer clean and
+          their events default to Personal scope server-side. */}
+      {teams.length > 0 && (
+        <section className="flex flex-col gap-2">
+          <span className="text-[16px] font-medium leading-[1.3] text-text-1">
+            Team Context
+          </span>
+          <Select value={selectedTeamId} onValueChange={onSelectTeam}>
+            <SelectTrigger className="h-10 rounded-md border-border-2 text-[13px]">
+              <SelectValue placeholder="Default (your primary team)" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">Default (primary team)</SelectItem>
+              <SelectItem value="personal">Personal (no team)</SelectItem>
+              {teams.map((t) => (
+                <SelectItem key={t.id} value={t.id}>
+                  {t.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-[11px] text-text-3">
+            Tags this run&apos;s usage in the Observability dashboard.
+          </p>
+        </section>
+      )}
 
       {/* History section */}
       <RailSection

--- a/apps/web/src/app/(app)/observability/page.tsx
+++ b/apps/web/src/app/(app)/observability/page.tsx
@@ -1,0 +1,747 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  AlertCircle,
+  ArrowDownRight,
+  ArrowUpRight,
+  Clock,
+  DollarSign,
+  Download,
+  Search,
+  ShieldAlert,
+  Users,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  fetchObservabilityCostByProvider,
+  fetchObservabilityEvents,
+  fetchObservabilityGuardrailActivity,
+  fetchObservabilitySummary,
+  fetchObservabilityTokenUsage,
+  ForbiddenError,
+  type ObservabilityCostByProvider,
+  type ObservabilityEvent,
+  type ObservabilityEvents,
+  type ObservabilityGuardrailActivity,
+  type ObservabilityRange,
+  type ObservabilitySummary,
+  type ObservabilityTokenUsage,
+} from "@/lib/api";
+
+const RANGE_OPTIONS: { value: ObservabilityRange; label: string }[] = [
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "90d", label: "Last 90 days" },
+];
+
+const EVENT_TYPE_OPTIONS = [
+  { value: "all", label: "All events" },
+  { value: "arena_call", label: "Model calls" },
+  { value: "evaluator_call", label: "Evaluator calls" },
+  { value: "arena_attachment_ocr", label: "OCR" },
+  { value: "guardrail_trigger", label: "Guardrail triggers" },
+];
+
+function formatUsd(n: number): string {
+  if (Math.abs(n) >= 1) return `$${n.toFixed(2)}`;
+  if (n === 0) return "$0";
+  return `$${n.toFixed(4)}`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatLatency(ms: number): string {
+  if (!ms) return "—";
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+function formatDelta(current: number, previous: number): {
+  text: string;
+  trend: "up" | "down" | "flat";
+} {
+  if (previous === 0 && current === 0) return { text: "no change", trend: "flat" };
+  if (previous === 0) return { text: "new", trend: "up" };
+  const diff = current - previous;
+  const pct = (diff / previous) * 100;
+  if (Math.abs(pct) < 0.1) return { text: "no change", trend: "flat" };
+  const sign = pct > 0 ? "+" : "";
+  return {
+    text: `${sign}${pct.toFixed(1)}% vs previous period`,
+    trend: pct > 0 ? "up" : "down",
+  };
+}
+
+function bucketTickFormatter(
+  granularity: "hour" | "day" | "week",
+): (value: string) => string {
+  return (value) => {
+    const d = new Date(value);
+    if (granularity === "hour") {
+      return d.toLocaleTimeString([], { hour: "2-digit" });
+    }
+    return d.toLocaleDateString([], { month: "short", day: "numeric" });
+  };
+}
+
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (/[",\n]/.test(str)) return `"${str.replace(/"/g, '""')}"`;
+  return str;
+}
+
+function eventsToCsv(events: ObservabilityEvent[]): string {
+  const header = [
+    "createdAt",
+    "user",
+    "team",
+    "eventType",
+    "model",
+    "provider",
+    "tokens",
+    "costUsd",
+    "latencyMs",
+    "success",
+    "errorMessage",
+    "promptPreview",
+  ];
+  const rows = events.map((e) =>
+    [
+      e.createdAt,
+      e.userName ?? e.userEmail ?? e.userId,
+      e.teamName ?? "",
+      e.eventType,
+      e.model ?? "",
+      e.provider ?? "",
+      e.totalTokens ?? "",
+      e.costUsd ?? "",
+      e.latencyMs ?? "",
+      e.success ? "true" : "false",
+      e.errorMessage ?? "",
+      e.promptPreview ?? "",
+    ]
+      .map(csvEscape)
+      .join(","),
+  );
+  return [header.join(","), ...rows].join("\n");
+}
+
+function downloadCsv(filename: string, body: string) {
+  const blob = new Blob([body], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+const PAGE_SIZE = 25;
+
+export default function ObservabilityPage() {
+  const [range, setRange] = useState<ObservabilityRange>("7d");
+  const [search, setSearch] = useState("");
+  const [eventType, setEventType] = useState<string>("all");
+  const [page, setPage] = useState(1);
+
+  const [summary, setSummary] = useState<ObservabilitySummary | null>(null);
+  const [tokenUsage, setTokenUsage] = useState<ObservabilityTokenUsage | null>(null);
+  const [costByProvider, setCostByProvider] =
+    useState<ObservabilityCostByProvider | null>(null);
+  const [events, setEvents] = useState<ObservabilityEvents | null>(null);
+  const [guardrails, setGuardrails] =
+    useState<ObservabilityGuardrailActivity | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Top-level data: refetch when range changes
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setForbidden(false);
+    Promise.all([
+      fetchObservabilitySummary(range),
+      fetchObservabilityTokenUsage(range),
+      fetchObservabilityCostByProvider(range),
+      fetchObservabilityGuardrailActivity(range),
+    ])
+      .then(([s, t, c, g]) => {
+        if (cancelled) return;
+        setSummary(s);
+        setTokenUsage(t);
+        setCostByProvider(c);
+        setGuardrails(g);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ForbiddenError) {
+          setForbidden(true);
+          return;
+        }
+        const message = err instanceof Error ? err.message : "Couldn't load metrics.";
+        setError(message);
+        toast.error(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [range]);
+
+  // Events table: reset page when filters change
+  useEffect(() => {
+    setPage(1);
+  }, [range, search, eventType]);
+
+  // Events table: refetch on filter/page changes
+  useEffect(() => {
+    if (forbidden) return;
+    let cancelled = false;
+    fetchObservabilityEvents({
+      range,
+      search: search.trim() || undefined,
+      eventType: eventType === "all" ? undefined : eventType,
+      page,
+      pageSize: PAGE_SIZE,
+    })
+      .then((rows) => {
+        if (cancelled) return;
+        setEvents(rows);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ForbiddenError) {
+          setForbidden(true);
+          return;
+        }
+        const message = err instanceof Error ? err.message : "Couldn't load events.";
+        toast.error(message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [range, search, eventType, page, forbidden]);
+
+  const handleExport = () => {
+    if (!events?.events?.length) {
+      toast.error("Nothing to export.");
+      return;
+    }
+    const csv = eventsToCsv(events.events);
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    downloadCsv(`observability-${range}-${ts}.csv`, csv);
+  };
+
+  const totalPages = useMemo(() => {
+    if (!events) return 1;
+    return Math.max(1, Math.ceil(events.total / events.pageSize));
+  }, [events]);
+
+  if (forbidden) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-border-2 bg-bg-white px-6 py-16 text-center">
+        <ShieldAlert className="h-10 w-10 text-text-3" strokeWidth={1.5} />
+        <h2 className="text-[18px] font-semibold text-text-1">Admin access required</h2>
+        <p className="max-w-[420px] text-[13px] text-text-2">
+          The Observability dashboard surfaces org-wide usage data, so it&apos;s
+          limited to admin accounts. Ask your admin to grant access if you need
+          to monitor model spend or activity.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 py-6">
+      {/* Header / time range */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <p className="text-[13px] text-text-2">
+            Real-time audit trail of all AI interactions and spend across the org.
+          </p>
+        </div>
+        <Select
+          value={range}
+          onValueChange={(v) => setRange(v as ObservabilityRange)}
+        >
+          <SelectTrigger className="h-10 w-[200px] rounded-md border-border-2 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RANGE_OPTIONS.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <KpiCard
+          icon={DollarSign}
+          label="Total Cost"
+          value={summary ? formatUsd(summary.current.totalCost) : "—"}
+          delta={summary ? formatDelta(summary.current.totalCost, summary.previous.totalCost) : null}
+          loading={loading}
+        />
+        <KpiCard
+          icon={Activity}
+          label="Total Token Usage"
+          value={summary ? formatTokens(summary.current.totalTokens) : "—"}
+          delta={summary ? formatDelta(summary.current.totalTokens, summary.previous.totalTokens) : null}
+          loading={loading}
+        />
+        <KpiCard
+          icon={Clock}
+          label="Avg Response Time"
+          value={summary ? formatLatency(summary.current.avgLatencyMs) : "—"}
+          delta={summary ? formatDelta(summary.current.avgLatencyMs, summary.previous.avgLatencyMs) : null}
+          loading={loading}
+          // Lower latency is better, so flip the trend interpretation visually.
+          invertTrend
+        />
+        <KpiCard
+          icon={Users}
+          label="Active Users"
+          value={summary ? String(summary.current.activeUsers) : "—"}
+          delta={summary ? formatDelta(summary.current.activeUsers, summary.previous.activeUsers) : null}
+          loading={loading}
+        />
+      </div>
+
+      {/* Charts row */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <ChartCard
+          title="Token Usage Trends"
+          subtitle="Daily token consumption over time"
+        >
+          {tokenUsage && tokenUsage.series.length > 0 ? (
+            <ResponsiveContainer width="100%" height={260}>
+              <LineChart data={tokenUsage.series}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-2)" />
+                <XAxis
+                  dataKey="bucket"
+                  tickFormatter={bucketTickFormatter(tokenUsage.granularity)}
+                  stroke="var(--text-3)"
+                  fontSize={11}
+                />
+                <YAxis
+                  stroke="var(--text-3)"
+                  fontSize={11}
+                  tickFormatter={(v) => formatTokens(Number(v))}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: "var(--bg-white)",
+                    border: "1px solid var(--border-2)",
+                    borderRadius: 6,
+                    color: "var(--text-1)",
+                  }}
+                  formatter={(value, key) => {
+                    const num = Number(value);
+                    if (key === "tokens") return [formatTokens(num), "Tokens"];
+                    if (key === "cost") return [formatUsd(num), "Cost"];
+                    return [String(value), String(key)];
+                  }}
+                  labelFormatter={(v) => new Date(v as string).toLocaleString()}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="tokens"
+                  stroke="var(--primary-6)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          ) : (
+            <EmptyChart loading={loading} label="No token activity yet" />
+          )}
+        </ChartCard>
+
+        <ChartCard
+          title="Cost by Provider"
+          subtitle="Total spend across LLM providers"
+        >
+          {costByProvider && costByProvider.providers.length > 0 ? (
+            <ResponsiveContainer width="100%" height={260}>
+              <BarChart data={costByProvider.providers}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border-2)" />
+                <XAxis dataKey="provider" stroke="var(--text-3)" fontSize={11} />
+                <YAxis
+                  stroke="var(--text-3)"
+                  fontSize={11}
+                  tickFormatter={(v) => formatUsd(Number(v))}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: "var(--bg-white)",
+                    border: "1px solid var(--border-2)",
+                    borderRadius: 6,
+                    color: "var(--text-1)",
+                  }}
+                  formatter={(value, key) => {
+                    const num = Number(value);
+                    if (key === "cost") return [formatUsd(num), "Cost"];
+                    if (key === "tokens") return [formatTokens(num), "Tokens"];
+                    return [String(value), String(key)];
+                  }}
+                />
+                <Bar dataKey="cost" fill="var(--primary-6)" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <EmptyChart loading={loading} label="No spend recorded yet" />
+          )}
+        </ChartCard>
+      </div>
+
+      {/* Detailed Prompt History */}
+      <section className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-0.5">
+            <h2 className="text-[16px] font-bold text-text-1">Detailed Prompt History</h2>
+            <p className="text-[12px] text-text-2">
+              Real-time audit trail of every AI call and guardrail trigger.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={!events?.events?.length}
+            className="inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border border-border-2 bg-bg-white px-3 text-[13px] font-medium text-text-1 transition-colors hover:border-primary-6 hover:text-primary-6 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Download className="h-4 w-4" />
+            Export CSV
+          </button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative min-w-[260px] flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-3" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search prompts, models, users…"
+              className="h-10 pl-9 text-sm"
+            />
+          </div>
+          <Select value={eventType} onValueChange={setEventType}>
+            <SelectTrigger className="h-10 w-[180px] rounded-md border-border-2 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {EVENT_TYPE_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[780px]">
+            <thead>
+              <tr className="border-b border-border-2">
+                <Th>Timestamp</Th>
+                <Th>User</Th>
+                <Th>Type</Th>
+                <Th>Model</Th>
+                <Th align="right">Tokens</Th>
+                <Th align="right">Cost</Th>
+                <Th align="right">Latency</Th>
+                <Th align="center">Status</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {events?.events?.length ? (
+                events.events.map((e) => <EventRow key={e.id} event={e} />)
+              ) : (
+                <tr>
+                  <td colSpan={8} className="py-8 text-center text-[13px] text-text-3">
+                    {loading ? "Loading…" : "No events match these filters."}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {events && events.total > events.pageSize && (
+          <div className="flex items-center justify-between border-t border-border-2 pt-3 text-[12px] text-text-2">
+            <span>
+              {(events.page - 1) * events.pageSize + 1}–
+              {Math.min(events.page * events.pageSize, events.total)} of {events.total}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                className="h-8 cursor-pointer rounded border border-border-2 px-3 text-text-1 transition-colors hover:border-primary-6 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+                className="h-8 cursor-pointer rounded border border-border-2 px-3 text-text-1 transition-colors hover:border-primary-6 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Activity Logs (guardrail triggers) */}
+      <section className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">
+        <div className="flex flex-col gap-0.5">
+          <h2 className="text-[16px] font-bold text-text-1">Guardrail Activity</h2>
+          <p className="text-[12px] text-text-2">
+            Triggered guardrails grouped by rule.
+            {guardrails ? ` ${guardrails.totalTriggers} total trigger(s) in this range.` : ""}
+          </p>
+        </div>
+        {guardrails?.triggers?.length ? (
+          <ul className="flex flex-col gap-2">
+            {guardrails.triggers.map((t, i) => (
+              <li
+                key={`${t.guardrailId ?? "anon"}-${i}`}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border-2 bg-bg-1/50 px-3 py-2 text-[13px]"
+              >
+                <div className="flex items-center gap-2">
+                  <SeverityPill severity={t.severity} />
+                  <span className="font-medium text-text-1">
+                    {t.guardrailName ?? "Unknown guardrail"}
+                  </span>
+                </div>
+                <div className="flex items-center gap-4 text-text-2">
+                  <span>{t.count} trigger(s)</span>
+                  <span className="text-text-3">
+                    last {new Date(t.lastTriggeredAt).toLocaleString()}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-md border border-dashed border-border-2 bg-bg-1/40 px-4 py-6 text-center text-[13px] text-text-3">
+            {loading ? "Loading…" : "No guardrail triggers in this range."}
+          </div>
+        )}
+      </section>
+
+      {error && !loading && (
+        <div className="flex items-center gap-2 rounded-md border border-danger-5/40 bg-danger-1 px-3 py-2 text-[13px] text-danger-6">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Sub-components ────────────────────────────────────────────────── */
+
+function KpiCard({
+  icon: Icon,
+  label,
+  value,
+  delta,
+  loading,
+  invertTrend,
+}: {
+  icon: typeof Activity;
+  label: string;
+  value: string;
+  delta: { text: string; trend: "up" | "down" | "flat" } | null;
+  loading: boolean;
+  invertTrend?: boolean;
+}) {
+  const trend = delta?.trend ?? "flat";
+  const goodDirection = invertTrend ? "down" : "up";
+  const tone =
+    trend === "flat"
+      ? "text-text-3"
+      : trend === goodDirection
+        ? "text-success-7"
+        : "text-danger-6";
+  const Arrow = trend === "down" ? ArrowDownRight : ArrowUpRight;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">
+      <div className="flex items-center justify-between">
+        <span className="text-[12px] font-medium uppercase tracking-wide text-text-2">
+          {label}
+        </span>
+        <span className="flex h-8 w-8 items-center justify-center rounded bg-primary-1 text-primary-6">
+          <Icon className="h-4 w-4" strokeWidth={2} />
+        </span>
+      </div>
+      <span className={`text-[26px] font-bold leading-tight text-text-1 ${loading ? "opacity-60" : ""}`}>
+        {value}
+      </span>
+      {delta && (
+        <span className={`flex items-center gap-1 text-[12px] ${tone}`}>
+          {trend !== "flat" && <Arrow className="h-3.5 w-3.5" />}
+          {delta.text}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ChartCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">
+      <div className="flex flex-col gap-0.5">
+        <h2 className="text-[15px] font-bold text-text-1">{title}</h2>
+        {subtitle && <p className="text-[12px] text-text-2">{subtitle}</p>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function EmptyChart({ loading, label }: { loading: boolean; label: string }) {
+  return (
+    <div className="flex h-[260px] items-center justify-center rounded border border-dashed border-border-2 bg-bg-1/40 text-[13px] text-text-3">
+      {loading ? "Loading…" : label}
+    </div>
+  );
+}
+
+function Th({
+  children,
+  align = "left",
+}: {
+  children: React.ReactNode;
+  align?: "left" | "right" | "center";
+}) {
+  // Tailwind purges classes from full strings, so static branches are required.
+  const alignClass =
+    align === "right" ? "text-right" : align === "center" ? "text-center" : "text-left";
+  return (
+    <th
+      className={`px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-text-2 ${alignClass}`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function EventRow({ event: e }: { event: ObservabilityEvent }) {
+  const userLabel = e.userName ?? e.userEmail ?? e.userId.slice(0, 8);
+  return (
+    <tr className="border-b border-border-2 last:border-b-0 hover:bg-bg-1/40">
+      <td className="px-3 py-2 align-top text-[12px] text-text-2 whitespace-nowrap">
+        {new Date(e.createdAt).toLocaleString()}
+      </td>
+      <td className="px-3 py-2 align-top text-[13px] text-text-1">
+        <div className="flex flex-col">
+          <span className="font-medium">{userLabel}</span>
+          {e.teamName && (
+            <span className="text-[11px] text-text-3">{e.teamName}</span>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-2 align-top text-[12px] text-text-2 whitespace-nowrap">
+        {e.eventType.replace(/_/g, " ")}
+      </td>
+      <td className="px-3 py-2 align-top text-[12px] text-text-1">
+        <div className="flex flex-col">
+          <span className="font-mono text-[11px]">{e.model ?? "—"}</span>
+          {e.provider && (
+            <span className="text-[11px] text-text-3">{e.provider}</span>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-2 align-top text-right text-[12px] text-text-1 whitespace-nowrap">
+        {e.totalTokens != null ? formatTokens(e.totalTokens) : "—"}
+      </td>
+      <td className="px-3 py-2 align-top text-right text-[12px] text-text-1 whitespace-nowrap">
+        {e.costUsd != null ? formatUsd(e.costUsd) : "—"}
+      </td>
+      <td className="px-3 py-2 align-top text-right text-[12px] text-text-1 whitespace-nowrap">
+        {e.latencyMs != null ? formatLatency(e.latencyMs) : "—"}
+      </td>
+      <td className="px-3 py-2 align-top text-center text-[11px]">
+        {e.success ? (
+          <span className="rounded-full bg-success-1 px-2 py-0.5 font-medium text-success-7">
+            ok
+          </span>
+        ) : (
+          <span
+            className="rounded-full bg-danger-1 px-2 py-0.5 font-medium text-danger-6"
+            title={e.errorMessage ?? undefined}
+          >
+            failed
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function SeverityPill({ severity }: { severity: string | null }) {
+  const sev = (severity ?? "low").toLowerCase();
+  const tone =
+    sev === "high"
+      ? "bg-danger-1 text-danger-6"
+      : sev === "medium"
+        ? "bg-warning-1 text-warning-6"
+        : "bg-bg-3 text-text-2";
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium uppercase ${tone}`}>
+      {sev}
+    </span>
+  );
+}

--- a/apps/web/src/app/(app)/observability/page.tsx
+++ b/apps/web/src/app/(app)/observability/page.tsx
@@ -39,6 +39,7 @@ import {
   fetchObservabilityEvents,
   fetchObservabilityGuardrailActivity,
   fetchObservabilitySummary,
+  fetchObservabilityTeamAnalytics,
   fetchObservabilityTokenUsage,
   ForbiddenError,
   type ObservabilityCostByProvider,
@@ -47,6 +48,7 @@ import {
   type ObservabilityGuardrailActivity,
   type ObservabilityRange,
   type ObservabilitySummary,
+  type ObservabilityTeamAnalytics,
   type ObservabilityTokenUsage,
 } from "@/lib/api";
 
@@ -178,6 +180,8 @@ export default function ObservabilityPage() {
   const [tokenUsage, setTokenUsage] = useState<ObservabilityTokenUsage | null>(null);
   const [costByProvider, setCostByProvider] =
     useState<ObservabilityCostByProvider | null>(null);
+  const [teamAnalytics, setTeamAnalytics] =
+    useState<ObservabilityTeamAnalytics | null>(null);
   const [events, setEvents] = useState<ObservabilityEvents | null>(null);
   const [guardrails, setGuardrails] =
     useState<ObservabilityGuardrailActivity | null>(null);
@@ -196,13 +200,15 @@ export default function ObservabilityPage() {
       fetchObservabilitySummary(range),
       fetchObservabilityTokenUsage(range),
       fetchObservabilityCostByProvider(range),
+      fetchObservabilityTeamAnalytics(range),
       fetchObservabilityGuardrailActivity(range),
     ])
-      .then(([s, t, c, g]) => {
+      .then(([s, t, c, ta, g]) => {
         if (cancelled) return;
         setSummary(s);
         setTokenUsage(t);
         setCostByProvider(c);
+        setTeamAnalytics(ta);
         setGuardrails(g);
       })
       .catch((err) => {
@@ -432,6 +438,64 @@ export default function ObservabilityPage() {
           )}
         </ChartCard>
       </div>
+
+      {/* Team Analytics Drilldown */}
+      <section className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">
+        <div className="flex flex-col gap-0.5">
+          <h2 className="text-[16px] font-bold text-text-1">Team Analytics Drilldown</h2>
+          <p className="text-[12px] text-text-2">
+            Performance and usage comparison across teams. &quot;Personal&quot; collects
+            events from users without an accepted team membership.
+          </p>
+        </div>
+        {teamAnalytics?.teams?.length ? (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px]">
+              <thead>
+                <tr className="border-b border-border-2">
+                  <Th>Team</Th>
+                  <Th align="right">Calls</Th>
+                  <Th align="right">Tokens</Th>
+                  <Th align="right">Cost</Th>
+                  <Th align="right">Avg Latency</Th>
+                  <Th align="right">Active Users</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {teamAnalytics.teams.map((t, i) => (
+                  <tr
+                    key={`${t.teamId ?? "personal"}-${i}`}
+                    className="border-b border-border-2 last:border-b-0 hover:bg-bg-1/40"
+                  >
+                    <td className="px-3 py-2 text-[13px] text-text-1">
+                      {t.teamName}
+                    </td>
+                    <td className="px-3 py-2 text-right text-[12px] text-text-1">
+                      {t.calls.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-right text-[12px] text-text-1">
+                      {formatTokens(t.tokens)}
+                    </td>
+                    <td className="px-3 py-2 text-right text-[12px] text-text-1">
+                      {formatUsd(t.cost)}
+                    </td>
+                    <td className="px-3 py-2 text-right text-[12px] text-text-1">
+                      {formatLatency(t.avgLatencyMs)}
+                    </td>
+                    <td className="px-3 py-2 text-right text-[12px] text-text-1">
+                      {t.activeUsers}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="rounded-md border border-dashed border-border-2 bg-bg-1/40 px-4 py-6 text-center text-[13px] text-text-3">
+            {loading ? "Loading…" : "No team activity in this range yet."}
+          </div>
+        )}
+      </section>
 
       {/* Detailed Prompt History */}
       <section className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">

--- a/apps/web/src/app/(app)/observability/page.tsx
+++ b/apps/web/src/app/(app)/observability/page.tsx
@@ -8,7 +8,6 @@ import {
   ArrowUpRight,
   Clock,
   DollarSign,
-  Download,
   Search,
   ShieldAlert,
   Users,
@@ -51,13 +50,6 @@ import {
   type ObservabilityTeamAnalytics,
   type ObservabilityTokenUsage,
 } from "@/lib/api";
-
-const RANGE_OPTIONS: { value: ObservabilityRange; label: string }[] = [
-  { value: "24h", label: "Last 24 hours" },
-  { value: "7d", label: "Last 7 days" },
-  { value: "30d", label: "Last 30 days" },
-  { value: "90d", label: "Last 90 days" },
-];
 
 const EVENT_TYPE_OPTIONS = [
   { value: "all", label: "All events" },
@@ -190,6 +182,22 @@ export default function ObservabilityPage() {
   const [forbidden, setForbidden] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // The time range dropdown + Export CSV button now live in the appbar
+  // (Figma frame 116:3959 puts them on the right edge of the page header).
+  // They communicate via plain CustomEvents — same pattern as Guardrails'
+  // "Add Guardrail" or Compare Models' "New Comparison".
+  useEffect(() => {
+    const onRangeChange = (e: Event) => {
+      const next = (e as CustomEvent<string>).detail as ObservabilityRange;
+      if (next === "24h" || next === "7d" || next === "30d" || next === "90d") {
+        setRange(next);
+      }
+    };
+    window.addEventListener("observability:range-change", onRangeChange);
+    return () =>
+      window.removeEventListener("observability:range-change", onRangeChange);
+  }, []);
+
   // Top-level data: refetch when range changes
   useEffect(() => {
     let cancelled = false;
@@ -273,6 +281,15 @@ export default function ObservabilityPage() {
     downloadCsv(`observability-${range}-${ts}.csv`, csv);
   };
 
+  // Appbar's Export CSV button dispatches this event.
+  useEffect(() => {
+    const onExport = () => handleExport();
+    window.addEventListener("observability:export", onExport);
+    return () => window.removeEventListener("observability:export", onExport);
+    // handleExport closes over `events` and `range`; re-bind when they change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [events, range]);
+
   const totalPages = useMemo(() => {
     if (!events) return 1;
     return Math.max(1, Math.ceil(events.total / events.pageSize));
@@ -294,29 +311,11 @@ export default function ObservabilityPage() {
 
   return (
     <div className="flex flex-col gap-6 py-6">
-      {/* Header / time range */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <p className="text-[13px] text-text-2">
-            Real-time audit trail of all AI interactions and spend across the org.
-          </p>
-        </div>
-        <Select
-          value={range}
-          onValueChange={(v) => setRange(v as ObservabilityRange)}
-        >
-          <SelectTrigger className="h-10 w-[200px] rounded-md border-border-2 text-sm">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {RANGE_OPTIONS.map((o) => (
-              <SelectItem key={o.value} value={o.value}>
-                {o.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      {/* Header — the time range dropdown and Export CSV live in the
+          appbar (see ObservabilityAppbarSlot). */}
+      <p className="text-[13px] text-text-2">
+        Real-time audit trail of all AI interactions and spend across the org.
+      </p>
 
       {/* KPI cards */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
@@ -499,22 +498,11 @@ export default function ObservabilityPage() {
 
       {/* Detailed Prompt History */}
       <section className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-col gap-0.5">
-            <h2 className="text-[16px] font-bold text-text-1">Detailed Prompt History</h2>
-            <p className="text-[12px] text-text-2">
-              Real-time audit trail of every AI call and guardrail trigger.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={handleExport}
-            disabled={!events?.events?.length}
-            className="inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border border-border-2 bg-bg-white px-3 text-[13px] font-medium text-text-1 transition-colors hover:border-primary-6 hover:text-primary-6 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <Download className="h-4 w-4" />
-            Export CSV
-          </button>
+        <div className="flex flex-col gap-0.5">
+          <h2 className="text-[16px] font-bold text-text-1">Detailed Prompt History</h2>
+          <p className="text-[12px] text-text-2">
+            Real-time audit trail of every AI call and guardrail trigger.
+          </p>
         </div>
 
         <div className="flex flex-wrap items-center gap-3">

--- a/apps/web/src/app/(app)/observability/page.tsx
+++ b/apps/web/src/app/(app)/observability/page.tsx
@@ -27,6 +27,12 @@ import {
 
 import { Input } from "@/components/ui/input";
 import {
+  PageTabs,
+  PageTabsContent,
+  PageTabsList,
+  PageTabsTrigger,
+} from "@/components/ui/page-tabs";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -310,13 +316,13 @@ export default function ObservabilityPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6 py-6">
-      {/* Header — the time range dropdown and Export CSV live in the
-          appbar (see ObservabilityAppbarSlot). */}
-      <p className="text-[13px] text-text-2">
-        Real-time audit trail of all AI interactions and spend across the org.
-      </p>
+    <PageTabs defaultValue="metrics" className="py-6 gap-6">
+      <PageTabsList>
+        <PageTabsTrigger value="metrics">Metrics</PageTabsTrigger>
+        <PageTabsTrigger value="logs">Logs</PageTabsTrigger>
+      </PageTabsList>
 
+      <PageTabsContent value="metrics" className="flex flex-col gap-6">
       {/* KPI cards */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <KpiCard
@@ -495,7 +501,9 @@ export default function ObservabilityPage() {
           </div>
         )}
       </section>
+      </PageTabsContent>
 
+      <PageTabsContent value="logs" className="flex flex-col gap-6">
       {/* Detailed Prompt History */}
       <section className="flex flex-col gap-3 rounded-lg border border-border-2 bg-bg-white p-5">
         <div className="flex flex-col gap-0.5">
@@ -629,7 +637,8 @@ export default function ObservabilityPage() {
           {error}
         </div>
       )}
-    </div>
+      </PageTabsContent>
+    </PageTabs>
   );
 }
 

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -775,7 +775,12 @@ function ObservabilityAppbarSlot() {
           );
         }}
       >
-        <SelectTrigger className="h-10 w-[180px] rounded-md border-border-2 bg-bg-white text-sm">
+        <SelectTrigger
+          // 24 px tall per Figma — !h-6 wins over the SelectTrigger's
+          // baked-in data-[size=default]:h-9. Tighter padding + smaller
+          // text/icon so the chevron and label still breathe.
+          className="!h-6 w-[180px] gap-1 rounded-md border-border-2 bg-bg-white px-2 text-[12px] [&_svg:not([class*='size-'])]:size-3"
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -791,9 +796,9 @@ function ObservabilityAppbarSlot() {
         onClick={() =>
           window.dispatchEvent(new CustomEvent("observability:export"))
         }
-        className="shrink-0 cursor-pointer gap-2 border-border-2 bg-bg-white"
+        className="h-6 shrink-0 cursor-pointer gap-1 rounded-md border-border-2 bg-bg-white px-2 text-[12px] [&_svg:not([class*='size-'])]:size-3"
       >
-        <Download className="h-4 w-4" />
+        <Download className="h-3 w-3" />
         Export CSV
       </Button>
     </>

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -28,6 +28,13 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { DisabledReasonTooltip } from "@/components/ui/tooltip";
 import {
   Dialog,
@@ -676,6 +683,8 @@ export const Appbar = () => {
 
       {/* Right Header Controls */}
       <div className={`flex items-center gap-3 ${config.appbarExpandControls ? "flex-1" : ""}`}>
+        {config.appbarType === "observability" && <ObservabilityAppbarSlot />}
+
         {config.appbarSearch && (
           <div className="relative hidden flex-1 sm:block">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-3" />
@@ -738,3 +747,55 @@ export const Appbar = () => {
     </header>
   );
 };
+
+/* ─── Observability appbar slot ────────────────────────────────────────
+   Two controls live here per Figma frame 116:3959 — the time range
+   dropdown and the Export CSV button. The page (/observability) listens
+   for the events emitted below to keep its state in sync. The default
+   range "7d" matches the page's initial useState value, so they boot in
+   sync without any extra plumbing. */
+
+const OBSERVABILITY_RANGES = [
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "90d", label: "Last 90 days" },
+] as const;
+
+function ObservabilityAppbarSlot() {
+  const [range, setRange] = useState<string>("7d");
+  return (
+    <>
+      <Select
+        value={range}
+        onValueChange={(value) => {
+          setRange(value);
+          window.dispatchEvent(
+            new CustomEvent("observability:range-change", { detail: value }),
+          );
+        }}
+      >
+        <SelectTrigger className="h-10 w-[180px] rounded-md border-border-2 bg-bg-white text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {OBSERVABILITY_RANGES.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        variant="outline"
+        onClick={() =>
+          window.dispatchEvent(new CustomEvent("observability:export"))
+        }
+        className="shrink-0 cursor-pointer gap-2 border-border-2 bg-bg-white"
+      >
+        <Download className="h-4 w-4" />
+        Export CSV
+      </Button>
+    </>
+  );
+}

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -683,7 +683,7 @@ export const Appbar = () => {
       </div>
 
       {/* Right Header Controls */}
-      <div className={`flex items-center ${config.appbarType === "observability" ? "gap-5" : "gap-3"} ${config.appbarExpandControls ? "flex-1" : ""}`}>
+      <div className={`flex items-center gap-3 ${config.appbarExpandControls ? "flex-1" : ""}`}>
         {config.appbarType === "observability" && <ObservabilityAppbarSlot />}
 
         {config.appbarSearch && (
@@ -777,11 +777,12 @@ function ObservabilityAppbarSlot() {
         }}
       >
         <SelectTrigger
-          // Match Figma frame 116:3963 exactly: 16/24 px padding, 8 px radius,
-          // gap 10 px, 16 px Regular text on a white card with --border-2 ring.
-          // !h-auto neutralises the data-[size=default]:h-9 baked into the
-          // primitive so padding alone drives the height.
-          className="!h-auto gap-2.5 rounded-lg border-border-2 bg-bg-white px-6 py-4 text-[16px] text-text-1 [&_svg:not([class*='size-'])]:size-4"
+          // Sized to match the project's other appbar action buttons
+          // (Add Guardrail / New Comparison): shadcn default h-9 + px-4
+          // for visual unity. Figma frame 116:3963's literal 16/24 padding
+          // and 16 px text rendered ~14 px taller than every other appbar
+          // chip — visually inconsistent.
+          className="h-9 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white px-3 text-sm text-text-1"
         >
           <Calendar className="h-4 w-4 shrink-0" />
           <span className="flex-1 text-left">
@@ -802,7 +803,7 @@ function ObservabilityAppbarSlot() {
         onClick={() =>
           window.dispatchEvent(new CustomEvent("observability:export"))
         }
-        className="!h-auto shrink-0 cursor-pointer gap-2.5 rounded-lg border-border-2 bg-bg-white px-6 py-4 text-[16px] font-normal text-text-1 [&_svg:not([class*='size-'])]:size-4"
+        className="shrink-0 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white text-text-1"
       >
         <Download className="h-4 w-4" />
         Export CSV

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -9,6 +9,7 @@ import {
   Search,
   Bell,
   ArrowLeft,
+  Calendar,
   Pencil,
   Trash2,
   Users,
@@ -682,7 +683,7 @@ export const Appbar = () => {
       </div>
 
       {/* Right Header Controls */}
-      <div className={`flex items-center gap-3 ${config.appbarExpandControls ? "flex-1" : ""}`}>
+      <div className={`flex items-center ${config.appbarType === "observability" ? "gap-5" : "gap-3"} ${config.appbarExpandControls ? "flex-1" : ""}`}>
         {config.appbarType === "observability" && <ObservabilityAppbarSlot />}
 
         {config.appbarSearch && (
@@ -776,12 +777,17 @@ function ObservabilityAppbarSlot() {
         }}
       >
         <SelectTrigger
-          // 24 px tall per Figma — !h-6 wins over the SelectTrigger's
-          // baked-in data-[size=default]:h-9. Tighter padding + smaller
-          // text/icon so the chevron and label still breathe.
-          className="!h-6 w-[180px] gap-1 rounded-md border-border-2 bg-bg-white px-2 text-[12px] [&_svg:not([class*='size-'])]:size-3"
+          // Match Figma frame 116:3963 exactly: 16/24 px padding, 8 px radius,
+          // gap 10 px, 16 px Regular text on a white card with --border-2 ring.
+          // !h-auto neutralises the data-[size=default]:h-9 baked into the
+          // primitive so padding alone drives the height.
+          className="!h-auto gap-2.5 rounded-lg border-border-2 bg-bg-white px-6 py-4 text-[16px] text-text-1 [&_svg:not([class*='size-'])]:size-4"
         >
-          <SelectValue />
+          <Calendar className="h-4 w-4 shrink-0" />
+          <span className="flex-1 text-left">
+            Time Range:{" "}
+            {OBSERVABILITY_RANGES.find((o) => o.value === range)?.label}
+          </span>
         </SelectTrigger>
         <SelectContent>
           {OBSERVABILITY_RANGES.map((opt) => (
@@ -796,9 +802,9 @@ function ObservabilityAppbarSlot() {
         onClick={() =>
           window.dispatchEvent(new CustomEvent("observability:export"))
         }
-        className="h-6 shrink-0 cursor-pointer gap-1 rounded-md border-border-2 bg-bg-white px-2 text-[12px] [&_svg:not([class*='size-'])]:size-3"
+        className="!h-auto shrink-0 cursor-pointer gap-2.5 rounded-lg border-border-2 bg-bg-white px-6 py-4 text-[16px] font-normal text-text-1 [&_svg:not([class*='size-'])]:size-4"
       >
-        <Download className="h-3 w-3" />
+        <Download className="h-4 w-4" />
         Export CSV
       </Button>
     </>

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -783,9 +783,23 @@ function ObservabilityAppbarSlot() {
           <Calendar className="h-4 w-4 shrink-0" />
           <SelectValue />
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent
+          // Right-align under the trigger (sits at the appbar's right
+          // edge) and use popper positioning so the menu drops cleanly
+          // below instead of overlapping. Match the trigger's rounded-lg
+          // + bg/border tokens so the open state looks like an extension
+          // of the chip rather than a generic popover.
+          position="popper"
+          align="end"
+          sideOffset={6}
+          className="min-w-[var(--radix-select-trigger-width)] rounded-lg border-border-2 bg-bg-white p-1 shadow-md"
+        >
           {OBSERVABILITY_RANGES.map((opt) => (
-            <SelectItem key={opt.value} value={opt.value}>
+            <SelectItem
+              key={opt.value}
+              value={opt.value}
+              className="rounded-md px-3 py-2 text-sm text-text-1"
+            >
               {opt.label}
             </SelectItem>
           ))}

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -756,11 +756,14 @@ export const Appbar = () => {
    range "7d" matches the page's initial useState value, so they boot in
    sync without any extra plumbing. */
 
+// Labels include the "Time Range: " prefix so we can lean on the stock
+// SelectValue rendering — wrapping a custom <span> inside the trigger
+// was eating the click target on first paint.
 const OBSERVABILITY_RANGES = [
-  { value: "24h", label: "Last 24 hours" },
-  { value: "7d", label: "Last 7 days" },
-  { value: "30d", label: "Last 30 days" },
-  { value: "90d", label: "Last 90 days" },
+  { value: "24h", label: "Time Range: Last 24 hours" },
+  { value: "7d", label: "Time Range: Last 7 days" },
+  { value: "30d", label: "Time Range: Last 30 days" },
+  { value: "90d", label: "Time Range: Last 90 days" },
 ] as const;
 
 function ObservabilityAppbarSlot() {
@@ -776,19 +779,9 @@ function ObservabilityAppbarSlot() {
           );
         }}
       >
-        <SelectTrigger
-          // Sized to match the project's other appbar action buttons
-          // (Add Guardrail / New Comparison): shadcn default h-9 + px-4
-          // for visual unity. Figma frame 116:3963's literal 16/24 padding
-          // and 16 px text rendered ~14 px taller than every other appbar
-          // chip — visually inconsistent.
-          className="h-9 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white px-3 text-sm text-text-1"
-        >
+        <SelectTrigger className="h-9 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white px-3 text-sm text-text-1">
           <Calendar className="h-4 w-4 shrink-0" />
-          <span className="flex-1 text-left">
-            Time Range:{" "}
-            {OBSERVABILITY_RANGES.find((o) => o.value === range)?.label}
-          </span>
+          <SelectValue />
         </SelectTrigger>
         <SelectContent>
           {OBSERVABILITY_RANGES.map((opt) => (

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -803,7 +803,10 @@ function ObservabilityAppbarSlot() {
         onClick={() =>
           window.dispatchEvent(new CustomEvent("observability:export"))
         }
-        className="shrink-0 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white text-text-1"
+        // Project Button defaults to h-12 (size=default in this fork), so
+        // the Time Range Select at h-9 looked shorter. Pin h-9 + matching
+        // px-3 / text-sm so the two controls read as a pair.
+        className="h-9 shrink-0 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white px-3 text-sm font-normal text-text-1"
       >
         <Download className="h-4 w-4" />
         Export CSV

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Activity,
   BookOpen,
   ChevronsLeft,
   ChevronsRight,
@@ -87,6 +88,7 @@ export const SidebarContent = ({
       { href: "/", label: "Ongoing Projects", icon: FolderOpen, match: "exact" },
       { href: "/compare-models", label: "Model Arena", icon: Layers, match: "exact" },
       { href: "/guardrails", label: "Guardrails", icon: Shield, match: "exact" },
+      { href: "/observability", label: "Observability", icon: Activity, match: "exact" },
       { href: "/teams", label: "Team Management", icon: Users, match: "prefix" },
     ],
     [

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -846,11 +846,20 @@ export async function sendQuestionToCompareModels(
   question: string,
   expectedOutput: string,
   context?: string,
+  teamId?: string | null,
 ): Promise<CompareModelsApiResult> {
   const res = await apiFetch(`/compare-models`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ models, question, expectedOutput, context }),
+    body: JSON.stringify({
+      models,
+      question,
+      expectedOutput,
+      context,
+      // Sentinel "personal" tells the server to skip the team fallback
+      // and tag events as Personal. Undefined uses the user's primary.
+      ...(teamId !== undefined ? { teamId: teamId ?? "personal" } : {}),
+    }),
   });
   if (!res.ok) {
     const body = await res.text();

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1551,3 +1551,152 @@ export async function completeOnboarding(
     throw new Error(err.message || "Failed to complete onboarding");
   }
 }
+
+// ─── Observability ────────────────────────────────────────────────────
+
+export type ObservabilityRange = "24h" | "7d" | "30d" | "90d";
+export type ObservabilityGranularity = "hour" | "day" | "week";
+
+export class ForbiddenError extends Error {
+  status = 403;
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+async function fetchObservability<T>(path: string): Promise<T> {
+  const res = await apiFetch(path);
+  if (res.status === 403) {
+    throw new ForbiddenError(
+      "Observability is admin-only. Ask an admin to grant access.",
+    );
+  }
+  if (!res.ok) throw new Error(`Failed to load ${path}`);
+  return res.json();
+}
+
+export interface ObservabilitySummaryBucket {
+  totalCost: number;
+  totalTokens: number;
+  avgLatencyMs: number;
+  activeUsers: number;
+  callCount: number;
+}
+
+export interface ObservabilitySummary {
+  range: ObservabilityRange;
+  current: ObservabilitySummaryBucket;
+  previous: ObservabilitySummaryBucket;
+}
+
+export function fetchObservabilitySummary(
+  range: ObservabilityRange,
+): Promise<ObservabilitySummary> {
+  return fetchObservability(`/observability/summary?range=${range}`);
+}
+
+export interface ObservabilityTokenBucket {
+  bucket: string; // ISO timestamp
+  tokens: number;
+  cost: number;
+  calls: number;
+}
+
+export interface ObservabilityTokenUsage {
+  range: ObservabilityRange;
+  granularity: ObservabilityGranularity;
+  series: ObservabilityTokenBucket[];
+}
+
+export function fetchObservabilityTokenUsage(
+  range: ObservabilityRange,
+): Promise<ObservabilityTokenUsage> {
+  return fetchObservability(`/observability/token-usage?range=${range}`);
+}
+
+export interface ObservabilityProviderRow {
+  provider: string;
+  cost: number;
+  tokens: number;
+  calls: number;
+}
+
+export interface ObservabilityCostByProvider {
+  range: ObservabilityRange;
+  providers: ObservabilityProviderRow[];
+}
+
+export function fetchObservabilityCostByProvider(
+  range: ObservabilityRange,
+): Promise<ObservabilityCostByProvider> {
+  return fetchObservability(`/observability/cost-by-provider?range=${range}`);
+}
+
+export interface ObservabilityEvent {
+  id: string;
+  createdAt: string;
+  eventType: string;
+  model: string | null;
+  provider: string | null;
+  totalTokens: number | null;
+  costUsd: number | null;
+  latencyMs: number | null;
+  success: boolean;
+  errorMessage: string | null;
+  promptPreview: string | null;
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  teamId: string | null;
+  teamName: string | null;
+}
+
+export interface ObservabilityEvents {
+  range: ObservabilityRange;
+  total: number;
+  page: number;
+  pageSize: number;
+  events: ObservabilityEvent[];
+}
+
+export interface ObservabilityEventsQuery {
+  range: ObservabilityRange;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+  eventType?: string;
+}
+
+export function fetchObservabilityEvents(
+  query: ObservabilityEventsQuery,
+): Promise<ObservabilityEvents> {
+  const params = new URLSearchParams({ range: query.range });
+  if (query.search?.trim()) params.set("search", query.search.trim());
+  if (query.page) params.set("page", String(query.page));
+  if (query.pageSize) params.set("pageSize", String(query.pageSize));
+  if (query.eventType) params.set("eventType", query.eventType);
+  return fetchObservability(`/observability/events?${params.toString()}`);
+}
+
+export interface ObservabilityGuardrailTrigger {
+  guardrailId: string | null;
+  guardrailName: string | null;
+  severity: string | null;
+  count: number;
+  lastTriggeredAt: string;
+}
+
+export interface ObservabilityGuardrailActivity {
+  range: ObservabilityRange;
+  totalTriggers: number;
+  triggers: ObservabilityGuardrailTrigger[];
+}
+
+export function fetchObservabilityGuardrailActivity(
+  range: ObservabilityRange,
+): Promise<ObservabilityGuardrailActivity> {
+  return fetchObservability(
+    `/observability/guardrail-activity?range=${range}`,
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1633,6 +1633,27 @@ export function fetchObservabilityCostByProvider(
   return fetchObservability(`/observability/cost-by-provider?range=${range}`);
 }
 
+export interface ObservabilityTeamRow {
+  teamId: string | null;
+  teamName: string;
+  cost: number;
+  tokens: number;
+  avgLatencyMs: number;
+  calls: number;
+  activeUsers: number;
+}
+
+export interface ObservabilityTeamAnalytics {
+  range: ObservabilityRange;
+  teams: ObservabilityTeamRow[];
+}
+
+export function fetchObservabilityTeamAnalytics(
+  range: ObservabilityRange,
+): Promise<ObservabilityTeamAnalytics> {
+  return fetchObservability(`/observability/team-analytics?range=${range}`);
+}
+
 export interface ObservabilityEvent {
   id: string;
   createdAt: string;

--- a/apps/web/src/lib/route-config.ts
+++ b/apps/web/src/lib/route-config.ts
@@ -81,6 +81,12 @@ const ROUTE_CONFIGS: Record<string, RouteConfig> = {
     hideNotifications: true,
     appbarAction: { label: "Add Guardrail", event: "guardrails:add" },
   },
+  "/observability": {
+    bg: "bg-bg-1",
+    title: "Observability",
+    hideSearch: true,
+    hideNotifications: true,
+  },
   "/compare-models": {
     bg: "bg-bg-1",
     title: "Model Arena",

--- a/apps/web/src/lib/route-config.ts
+++ b/apps/web/src/lib/route-config.ts
@@ -13,7 +13,7 @@ interface RouteConfig {
   title?: string;
   hideSearch?: boolean;
   hideNotifications?: boolean;
-  appbarType?: "default" | "teamDetail" | "userDetail" | "createProject" | "aiChat" | "projectDetail" | "tenderDetail" | "tenderCreate";
+  appbarType?: "default" | "teamDetail" | "userDetail" | "createProject" | "aiChat" | "projectDetail" | "tenderDetail" | "tenderCreate" | "observability";
   appbarAction?: AppbarAction;
   appbarSearch?: AppbarSearch;
   appbarExpandControls?: boolean;
@@ -86,6 +86,7 @@ const ROUTE_CONFIGS: Record<string, RouteConfig> = {
     title: "Observability",
     hideSearch: true,
     hideNotifications: true,
+    appbarType: "observability",
   },
   "/compare-models": {
     bg: "bg-bg-1",

--- a/packages/database/backfill/backfill-observability-from-arena-runs.sql
+++ b/packages/database/backfill/backfill-observability-from-arena-runs.sql
@@ -1,0 +1,101 @@
+-- One-time backfill: seed observability_events from existing arena_runs.
+--
+-- Idempotent: aborts early if any backfilled event already exists.
+-- Re-running after a partial run is safe; no duplicates will be created.
+--
+-- How to apply:
+--   psql "$DATABASE_URL" -f packages/database/backfill/backfill-observability-from-arena-runs.sql
+-- Or, against the local docker-compose db:
+--   docker exec -i <postgres-container> psql -U worken -d worken \
+--     < packages/database/backfill/backfill-observability-from-arena-runs.sql
+
+DO $$
+DECLARE
+  existing_count int;
+  inserted_count int;
+BEGIN
+  SELECT count(*)
+    INTO existing_count
+    FROM observability_events
+    WHERE metadata @> '{"backfilled": true}'::jsonb;
+
+  IF existing_count > 0 THEN
+    RAISE NOTICE
+      'Skipping backfill: % event(s) already tagged metadata.backfilled=true. Delete those rows and re-run for a clean slate.',
+      existing_count;
+    RETURN;
+  END IF;
+
+  WITH unpacked AS (
+    SELECT
+      r.user_id,
+      r.id AS arena_run_id,
+      r.created_at,
+      r.question,
+      jsonb_array_elements(r.responses) AS resp
+    FROM arena_runs r
+  ),
+  rows AS (
+    SELECT
+      user_id,
+      arena_run_id,
+      created_at,
+      question,
+      resp ->> 'model' AS model,
+      CASE
+        WHEN resp ? 'totalTokens' AND jsonb_typeof(resp -> 'totalTokens') = 'number'
+          THEN (resp ->> 'totalTokens')::int
+        ELSE NULL
+      END AS total_tokens,
+      CASE
+        WHEN resp ? 'totalCost' AND jsonb_typeof(resp -> 'totalCost') = 'number'
+          THEN (resp ->> 'totalCost')::numeric
+        ELSE NULL
+      END AS cost_usd,
+      CASE
+        WHEN resp ? 'time' AND jsonb_typeof(resp -> 'time') = 'number'
+          THEN (resp ->> 'time')::int
+        ELSE NULL
+      END AS latency_ms
+    FROM unpacked
+    WHERE resp ? 'model'
+  )
+  INSERT INTO observability_events (
+    user_id, team_id, event_type, model, provider,
+    total_tokens, cost_usd, latency_ms,
+    success, prompt_preview, metadata, created_at
+  )
+  SELECT
+    user_id,
+    NULL::uuid,
+    'arena_call',
+    model,
+    -- Coarse provider derivation: take the slug before the first slash.
+    -- Mirrors providerFromModel() in observability.service.ts.
+    CASE
+      WHEN model LIKE '%/%'
+        THEN CASE
+               WHEN split_part(model, '/', 1) IN (
+                 'openai','anthropic','google','meta-llama','mistralai','cohere',
+                 'nvidia','arcee-ai','liquid','stepfun','baidu','qwen','deepseek'
+               )
+               THEN split_part(model, '/', 1)
+               ELSE 'openrouter:' || split_part(model, '/', 1)
+             END
+      ELSE 'unknown'
+    END,
+    total_tokens,
+    cost_usd,
+    latency_ms,
+    true,
+    CASE
+      WHEN length(question) > 200 THEN substring(question for 200) || '…'
+      ELSE question
+    END,
+    jsonb_build_object('backfilled', true, 'arenaRunId', arena_run_id),
+    created_at
+  FROM rows;
+
+  GET DIAGNOSTICS inserted_count = ROW_COUNT;
+  RAISE NOTICE 'Backfill complete: inserted % event(s) from arena_runs.', inserted_count;
+END $$;

--- a/packages/database/backfill/backfill-observability-from-arena-runs.sql
+++ b/packages/database/backfill/backfill-observability-from-arena-runs.sql
@@ -26,18 +26,30 @@ BEGIN
     RETURN;
   END IF;
 
-  WITH unpacked AS (
+  WITH primary_team AS (
+    -- Mirrors getPrimaryTeamId(): oldest accepted membership per user.
+    SELECT DISTINCT ON (user_id)
+      user_id,
+      team_id
+    FROM team_members
+    WHERE status = 'accepted'
+    ORDER BY user_id, created_at ASC
+  ),
+  unpacked AS (
     SELECT
       r.user_id,
+      pt.team_id AS team_id,
       r.id AS arena_run_id,
       r.created_at,
       r.question,
       jsonb_array_elements(r.responses) AS resp
     FROM arena_runs r
+    LEFT JOIN primary_team pt ON pt.user_id = r.user_id
   ),
   rows AS (
     SELECT
       user_id,
+      team_id,
       arena_run_id,
       created_at,
       question,
@@ -67,7 +79,7 @@ BEGIN
   )
   SELECT
     user_id,
-    NULL::uuid,
+    team_id,
     'arena_call',
     model,
     -- Coarse provider derivation: take the slug before the first slash.

--- a/packages/database/seed/seed-observability.sql
+++ b/packages/database/seed/seed-observability.sql
@@ -1,0 +1,267 @@
+-- ─── Observability seed ─────────────────────────────────────────────
+-- Generates ~30 days of synthetic events spread across all existing
+-- users so the /observability dashboard has data to render. Each event
+-- carries metadata.seed=true so you can wipe-and-reseed cleanly.
+--
+-- How to apply:
+--   psql "$DATABASE_URL" -f packages/database/seed/seed-observability.sql
+--
+-- How to reset:
+--   psql "$DATABASE_URL" -c "DELETE FROM observability_events WHERE metadata @> '{\"seed\":true}'::jsonb;"
+-- Then re-run the file above.
+--
+-- Quantities (per user, over 30 days):
+--   arena_call           ~120
+--   evaluator_call       ~30
+--   chat_call            ~90
+--   arena_attachment_ocr ~15
+--   document_title       ~10
+--   guardrail_trigger    ~15
+-- ≈ 280 events per user. Multiplies by user count.
+
+DO $$
+DECLARE
+  existing_count int;
+  inserted_count int;
+BEGIN
+  SELECT count(*)
+    INTO existing_count
+    FROM observability_events
+    WHERE metadata @> '{"seed": true}'::jsonb;
+
+  IF existing_count > 0 THEN
+    RAISE NOTICE
+      'Skipping seed: % event(s) already tagged metadata.seed=true. Run the DELETE in the comment header to reset, then re-run.',
+      existing_count;
+    RETURN;
+  END IF;
+
+  WITH
+    -- Pick a primary team per user (oldest accepted membership).
+    primary_team AS (
+      SELECT DISTINCT ON (user_id)
+        user_id,
+        team_id
+      FROM team_members
+      WHERE status = 'accepted'
+      ORDER BY user_id, created_at ASC
+    ),
+    -- Models with realistic cost/token shapes per provider.
+    model_pool(model, provider, base_cost, base_tokens, base_latency) AS (
+      VALUES
+        ('openai/gpt-4o',                                 'openai',     0.01500, 1200, 1800),
+        ('openai/gpt-4-turbo',                            'openai',     0.02000, 1500, 2400),
+        ('openai/gpt-3.5-turbo',                          'openai',     0.00150,  900,  900),
+        ('anthropic/claude-3-5-sonnet',                   'anthropic',  0.01200, 1300, 2100),
+        ('anthropic/claude-3-haiku',                      'anthropic',  0.00080,  700,  600),
+        ('google/gemini-1.5-pro',                         'google',     0.00750, 1100, 2000),
+        ('google/gemini-1.5-flash',                       'google',     0.00040,  800,  500),
+        ('nvidia/nemotron-3-super-120b-a12b:free',        'nvidia',     0.00000, 1400, 3200),
+        ('arcee-ai/trinity-large-preview:free',           'arcee-ai',   0.00000,  600,  800),
+        ('meta-llama/llama-3.1-70b-instruct',             'meta-llama', 0.00400, 1000, 1500),
+        ('mistralai/mistral-large',                       'mistralai',  0.00800, 1100, 1700),
+        ('liquid/lfm-2.5-1.2b-thinking:free',             'liquid',     0.00000,  500,  450),
+        ('baidu/qianfan-ocr-fast:free',                   'baidu',      0.00000,  300,  900),
+        ('stepfun/step-3.5-flash:free',                   'stepfun',    0.00000,  900, 1100)
+    ),
+    -- 30 days × ~10 events/day per user, jittered.
+    arena_events AS (
+      SELECT
+        u.id AS user_id,
+        pt.team_id,
+        'arena_call' AS event_type,
+        m.model,
+        m.provider,
+        -- ±25% jitter around base
+        round((m.base_tokens * (0.75 + random() * 0.5))::numeric)::int AS total_tokens,
+        round((m.base_cost * (0.75 + random() * 0.5))::numeric, 6) AS cost_usd,
+        round((m.base_latency * (0.7 + random() * 0.6))::numeric)::int AS latency_ms,
+        -- 5% failure rate
+        random() > 0.05 AS success,
+        now()
+          - (random() * interval '30 days')
+          AS created_at
+      FROM users u
+      LEFT JOIN primary_team pt ON pt.user_id = u.id
+      CROSS JOIN LATERAL (
+        SELECT * FROM model_pool ORDER BY random() LIMIT 1
+      ) m
+      CROSS JOIN generate_series(1, 120) -- 120 arena calls per user
+    ),
+    evaluator_events AS (
+      SELECT
+        u.id AS user_id,
+        pt.team_id,
+        'evaluator_call' AS event_type,
+        'nvidia/nemotron-3-super-120b-a12b:free' AS model,
+        'nvidia' AS provider,
+        NULL::int AS total_tokens,
+        NULL::numeric AS cost_usd,
+        round((3200 * (0.7 + random() * 0.6))::numeric)::int AS latency_ms,
+        random() > 0.03 AS success,
+        now() - (random() * interval '30 days') AS created_at
+      FROM users u
+      LEFT JOIN primary_team pt ON pt.user_id = u.id
+      CROSS JOIN generate_series(1, 30)
+    ),
+    chat_events AS (
+      SELECT
+        u.id AS user_id,
+        pt.team_id,
+        'chat_call' AS event_type,
+        m.model,
+        m.provider,
+        round((m.base_tokens * 0.8 * (0.7 + random() * 0.6))::numeric)::int AS total_tokens,
+        round((m.base_cost * 0.8 * (0.7 + random() * 0.6))::numeric, 6) AS cost_usd,
+        round((m.base_latency * (0.7 + random() * 0.6))::numeric)::int AS latency_ms,
+        random() > 0.04 AS success,
+        now() - (random() * interval '30 days') AS created_at
+      FROM users u
+      LEFT JOIN primary_team pt ON pt.user_id = u.id
+      CROSS JOIN LATERAL (
+        SELECT * FROM model_pool
+        WHERE model NOT LIKE 'baidu/%'  -- OCR model excluded from chat
+        ORDER BY random()
+        LIMIT 1
+      ) m
+      CROSS JOIN generate_series(1, 90)
+    ),
+    ocr_events AS (
+      SELECT
+        u.id AS user_id,
+        pt.team_id,
+        'arena_attachment_ocr' AS event_type,
+        'baidu/qianfan-ocr-fast:free' AS model,
+        'baidu' AS provider,
+        NULL::int AS total_tokens,
+        NULL::numeric AS cost_usd,
+        round((900 * (0.6 + random() * 0.8))::numeric)::int AS latency_ms,
+        random() > 0.06 AS success,
+        now() - (random() * interval '30 days') AS created_at
+      FROM users u
+      LEFT JOIN primary_team pt ON pt.user_id = u.id
+      CROSS JOIN generate_series(1, 15)
+    ),
+    title_events AS (
+      SELECT
+        u.id AS user_id,
+        pt.team_id,
+        'document_title' AS event_type,
+        'arcee-ai/trinity-large-preview:free' AS model,
+        'arcee-ai' AS provider,
+        round((20 + random() * 30)::numeric)::int AS total_tokens,
+        0::numeric AS cost_usd,
+        round((400 + random() * 800)::numeric)::int AS latency_ms,
+        true AS success,
+        now() - (random() * interval '30 days') AS created_at
+      FROM users u
+      LEFT JOIN primary_team pt ON pt.user_id = u.id
+      CROSS JOIN generate_series(1, 10)
+    ),
+    guardrail_events AS (
+      SELECT
+        u.id AS user_id,
+        pt.team_id,
+        'guardrail_trigger' AS event_type,
+        NULL::text AS model,
+        'system' AS provider,
+        NULL::int AS total_tokens,
+        NULL::numeric AS cost_usd,
+        NULL::int AS latency_ms,
+        true AS success,
+        now() - (random() * interval '30 days') AS created_at,
+        g.* AS guardrail
+      FROM users u
+      LEFT JOIN primary_team pt ON pt.user_id = u.id
+      CROSS JOIN LATERAL (
+        SELECT
+          (ARRAY[
+            'PII Filter',
+            'Content Safety',
+            'Compliance Check',
+            'Confidential Data',
+            'Toxic Language'
+          ])[1 + floor(random() * 5)::int] AS guardrail_name,
+          (ARRAY['low','medium','high'])[1 + floor(random() * 3)::int] AS severity
+      ) g
+      CROSS JOIN generate_series(1, 15)
+    ),
+    all_events AS (
+      SELECT
+        user_id, team_id, event_type, model, provider,
+        total_tokens, cost_usd, latency_ms, success,
+        CASE WHEN success THEN NULL
+             ELSE (ARRAY[
+               'Rate limit exceeded',
+               'Provider returned 502',
+               'Context length exceeded',
+               'Insufficient credits',
+               'Model temporarily unavailable'
+             ])[1 + floor(random() * 5)::int]
+        END AS error_message,
+        (ARRAY[
+          'Analyze the attached vendor proposal for completeness',
+          'Compare these three RFP responses on technical merit',
+          'Extract key compliance terms from the legal contract',
+          'Summarize the procurement requirements',
+          'Generate a risk assessment for this vendor',
+          'Draft response to RFP question 12 about uptime',
+          'Review pricing structure and flag any anomalies',
+          'Identify gaps between requirements and our capabilities'
+        ])[1 + floor(random() * 8)::int] AS prompt_preview,
+        jsonb_build_object('seed', true) AS metadata,
+        created_at
+      FROM arena_events
+      UNION ALL
+      SELECT user_id, team_id, event_type, model, provider, total_tokens, cost_usd, latency_ms, success,
+             CASE WHEN success THEN NULL ELSE 'Evaluator returned malformed JSON' END,
+             NULL,
+             jsonb_build_object('seed', true, 'attempt', 1),
+             created_at
+      FROM evaluator_events
+      UNION ALL
+      SELECT user_id, team_id, event_type, model, provider, total_tokens, cost_usd, latency_ms, success,
+             CASE WHEN success THEN NULL ELSE 'Connection reset' END,
+             (ARRAY[
+               'How do I configure the integration?',
+               'Walk me through the deployment process',
+               'What are the security implications?',
+               'Help me write a follow-up email'
+             ])[1 + floor(random() * 4)::int],
+             jsonb_build_object('seed', true),
+             created_at
+      FROM chat_events
+      UNION ALL
+      SELECT user_id, team_id, event_type, model, provider, total_tokens, cost_usd, latency_ms, success,
+             CASE WHEN success THEN NULL ELSE 'OCR could not extract text' END,
+             NULL,
+             jsonb_build_object('seed', true, 'filename', 'invoice.png'),
+             created_at
+      FROM ocr_events
+      UNION ALL
+      SELECT user_id, team_id, event_type, model, provider, total_tokens, cost_usd, latency_ms, success,
+             NULL, NULL,
+             jsonb_build_object('seed', true, 'phase', 'title-generation'),
+             created_at
+      FROM title_events
+      UNION ALL
+      SELECT user_id, team_id, event_type, model, provider, total_tokens, cost_usd, latency_ms, success,
+             NULL, NULL,
+             jsonb_build_object('seed', true, 'name', guardrail_name, 'severity', severity),
+             created_at
+      FROM guardrail_events
+    )
+  INSERT INTO observability_events (
+    user_id, team_id, event_type, model, provider,
+    total_tokens, cost_usd, latency_ms, success, error_message,
+    prompt_preview, metadata, created_at
+  )
+  SELECT
+    user_id, team_id, event_type, model, provider,
+    total_tokens, cost_usd, latency_ms, success, error_message,
+    prompt_preview, metadata, created_at
+  FROM all_events;
+
+  GET DIAGNOSTICS inserted_count = ROW_COUNT;
+  RAISE NOTICE 'Seed complete: inserted % event(s).', inserted_count;
+END $$;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -9,6 +9,7 @@ import {
   jsonb,
   integer,
   real,
+  numeric,
 } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
@@ -137,6 +138,36 @@ export const messages = pgTable("messages", {
   metadata: jsonb("metadata"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
+
+export const observabilityEvents = pgTable(
+  "observability_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    teamId: uuid("team_id").references(() => teams.id, { onDelete: "set null" }),
+    eventType: text("event_type").notNull(), // 'arena_call' | 'evaluator_call' | 'guardrail_trigger' | future
+    model: text("model"),
+    provider: text("provider"), // 'openai' | 'anthropic' | 'google' | 'openrouter:other' | 'system'
+    promptTokens: integer("prompt_tokens"),
+    completionTokens: integer("completion_tokens"),
+    totalTokens: integer("total_tokens"),
+    costUsd: numeric("cost_usd", { precision: 12, scale: 6 }),
+    latencyMs: integer("latency_ms"),
+    success: boolean("success").notNull().default(true),
+    errorMessage: text("error_message"),
+    promptPreview: text("prompt_preview"), // first 200 chars, never the full prompt
+    metadata: jsonb("metadata"),            // small extras, e.g. { arenaRunId, guardrailId, severity }
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("observability_events_user_created_idx").on(table.userId, table.createdAt),
+    index("observability_events_team_created_idx").on(table.teamId, table.createdAt),
+    index("observability_events_model_created_idx").on(table.model, table.createdAt),
+    index("observability_events_type_created_idx").on(table.eventType, table.createdAt),
+  ],
+);
 
 export const arenaRuns = pgTable("arena_runs", {
   id: uuid("id").primaryKey().defaultRandom(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2246,6 +2249,17 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2257,6 +2271,12 @@ packages:
 
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2405,6 +2425,33 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2514,6 +2561,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -3200,6 +3250,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -3231,6 +3325,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   dedent@1.7.1:
     resolution: {integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==}
@@ -3485,6 +3582,9 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.0:
+    resolution: {integrity: sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -3670,6 +3770,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -3979,6 +4082,12 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -4002,6 +4111,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis@5.9.2:
     resolution: {integrity: sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==}
@@ -5127,6 +5240,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -5172,6 +5297,14 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -5179,6 +5312,14 @@ packages:
   redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
@@ -5198,6 +5339,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -5578,6 +5722,9 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -5852,6 +5999,9 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -7959,6 +8109,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.13)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.13)(react@19.2.3)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
 
   '@sinclair/typebox@0.34.48': {}
@@ -7970,6 +8132,10 @@ snapshots:
   '@sinonjs/fake-timers@13.0.5':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -8108,6 +8274,30 @@ snapshots:
       '@types/express': 5.0.6
 
   '@types/cookiejar@2.1.5': {}
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -8254,6 +8444,8 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -8971,6 +9163,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -8998,6 +9228,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   dedent@1.7.1: {}
 
@@ -9214,6 +9446,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.46.0: {}
 
   es6-error@4.1.1: {}
 
@@ -9507,6 +9741,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -9885,6 +10121,10 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -9909,6 +10149,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ioredis@5.9.2:
     dependencies:
@@ -11238,6 +11480,15 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-redux@9.2.0(@types/react@19.2.13)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.13)(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -11285,11 +11536,37 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recharts@3.8.1(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react-is@18.3.1)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.13)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 18.3.1
+      react-redux: 9.2.0(@types/react@19.2.13)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect-metadata@0.2.2: {}
 
@@ -11316,6 +11593,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -11779,6 +12058,8 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -12067,6 +12348,23 @@ snapshots:
       convert-source-map: 2.0.0
 
   vary@1.1.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   walker@1.0.8:
     dependencies:


### PR DESCRIPTION
  Kaj je narejeno:

  - Nova DB tabela observability_events (per-call audit log: model, provider, tokens, cost, latency, success, error, prompt preview, metadata).
  - Nov NestJS modul z ObservabilityService.recordLLMCall(...) in admin-guarded endpointi (/summary, /token-usage, /cost-by-provider, /team-analytics, /events, /guardrail-activity).
  - Inštrumentirani vsi obstoječi LLM klici: Compare Models (per-model + evaluator + OCR), Chat in Document title generation — vsi shranjujejo event z user-jem, team-om, modelom, tokeni, ceno, latency-jem.       - Server-side getPrimaryTeamId(userId) (najstarejša accepted članstvo) tako da eventi avtomatsko pripadajo team-u, ne samo user-ju.
  - Team picker v Compare Models composerju (Default / Personal / izberi team) — uporabniki z več timi lahko za posamezen klic ročno izberejo team. Server validira članstvo.                                       - One-shot SQL backfill iz arena_runs zgodovine (packages/database/backfill/...sql), idempotenten.
  - Frontend stran /observability (Activity ikona v sidebaru, admin-only): time range dropdown, 4 KPI kartice z delto vs prejšnje obdobje, Token Usage line chart + Cost by Provider bar chart (Recharts,
  theme-aware), Team Analytics tabela, Detailed Prompt History z search-em + filter + Export CSV (client-side), Guardrail Activity panel. 403 za ne-admine pokaže prijazen empty state.
  - Recharts dodan kot dependency, sidebar in route-config posodobljena.

  Kaj NI narejeno (odprto za prihodnost):
  - Phase 4 — Budget Alerts (config UI, cron, email notifier, auto-suspend).
  - Inštrumentacija Tender / Knowledge Core (te feature trenutno nimajo LLM klicev; ko bodo dodani, isti pattern — task v backlogu).
