### PR TITLE
fix(observability): address Copilot review feedback

### DIFF
--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -414,9 +414,26 @@ export class CompareModelsController {
   async parseAttachment(
     @UploadedFile() file: Express.Multer.File | undefined,
     @CurrentUser() user: AuthenticatedUser,
+    @Body('teamId') rawTeamId?: string,
   ): Promise<{ name: string; content: string }> {
     if (!file) {
       throw new BadRequestException('No file was uploaded.');
+    }
+
+    // Mirror the /compare-models scoping rule: Personal by default; an
+    // explicit teamId from the composer is honored after membership check.
+    // Without this, OCR events would always be tagged with the user's
+    // primary team and misattributed when the composer is set to Personal
+    // or another team.
+    let teamId: string | null = null;
+    const requested = (rawTeamId ?? '').trim();
+    if (requested && requested !== 'personal' && requested !== 'null') {
+      if (!(await this.observabilityService.isUserInTeam(user.id, requested))) {
+        throw new BadRequestException(
+          'You are not a member of the selected team.',
+        );
+      }
+      teamId = requested;
     }
 
     const mimetype = file.mimetype;
@@ -436,7 +453,6 @@ export class CompareModelsController {
         );
       }
 
-      const teamId = await this.observabilityService.getPrimaryTeamId(user.id);
       const dataUrl = `data:${mimetype};base64,${file.buffer.toString('base64')}`;
       let extracted: string;
       const ocrStart = Date.now();

--- a/apps/api/src/observability/observability.controller.ts
+++ b/apps/api/src/observability/observability.controller.ts
@@ -84,7 +84,7 @@ export class ObservabilityController {
     const { key, from, to } = parseRange(range);
     const span = to.getTime() - from.getTime();
     const previousFrom = new Date(from.getTime() - span);
-    const previousTo = from;
+    const previousTo = new Date(from.getTime() - 1);
     const [current, previous] = await Promise.all([
       this.observabilityService.summary(from, to),
       this.observabilityService.summary(previousFrom, previousTo),

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -8,6 +8,22 @@ import {
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 
+const KNOWN_PROVIDERS = new Set([
+  'openai',
+  'anthropic',
+  'google',
+  'meta-llama',
+  'mistralai',
+  'cohere',
+  'nvidia',
+  'arcee-ai',
+  'liquid',
+  'stepfun',
+  'baidu',
+  'qwen',
+  'deepseek',
+]);
+
 /**
  * Derive a coarse provider label from an OpenRouter-style model id like
  * "openai/gpt-4o:free" → "openai". Falls back to "openrouter:other" so we
@@ -17,22 +33,7 @@ export function providerFromModel(model: string | null | undefined): string {
   if (!model) return 'unknown';
   const slug = model.split('/')[0]?.toLowerCase();
   if (!slug) return 'unknown';
-  const known = new Set([
-    'openai',
-    'anthropic',
-    'google',
-    'meta-llama',
-    'mistralai',
-    'cohere',
-    'nvidia',
-    'arcee-ai',
-    'liquid',
-    'stepfun',
-    'baidu',
-    'qwen',
-    'deepseek',
-  ]);
-  return known.has(slug) ? slug : `openrouter:${slug}`;
+  return KNOWN_PROVIDERS.has(slug) ? slug : `openrouter:${slug}`;
 }
 
 const PROMPT_PREVIEW_MAX = 200;
@@ -77,12 +78,6 @@ export class ObservabilityService {
   // ─── Team association helper ──────────────────────────────────────────
 
   /**
-   * Pick a user's "primary" team for event scoping.
-   * Rule: oldest accepted membership wins. Returns null when the user has
-   * none (personal use). Per-call: cached one query per request, but we
-   * keep it simple and let callers cache across a request if needed.
-   */
-  /**
    * Returns true if the user has an accepted membership in the given team.
    * Used by callers that accept an explicit teamId override (e.g. the
    * compare-models composer) to validate before attaching it to events.
@@ -106,6 +101,12 @@ export class ObservabilityService {
     }
   }
 
+  /**
+   * Pick a user's "primary" team for event scoping.
+   * Rule: oldest accepted membership wins. Returns null when the user has
+   * none (personal use). Per-call: cached one query per request, but we
+   * keep it simple and let callers cache across a request if needed.
+   */
   async getPrimaryTeamId(userId: string): Promise<string | null> {
     try {
       const [row] = await this.db

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -952,7 +952,7 @@ function Composer({
       const verb = isImageFile(file) ? "Reading" : "Parsing";
       const toastId = toast.loading(`${verb} ${file.name}…`);
       try {
-        const parsed = await parseArenaAttachment(file);
+        const parsed = await parseArenaAttachment(file, selectedTeamId);
         setTarget(parsed);
         toast.success(`Attached ${parsed.name}.`, { id: toastId });
       } catch (err) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -916,9 +916,11 @@ export async function deleteArenaRun(id: string): Promise<void> {
 
 export async function parseArenaAttachment(
   file: File,
+  teamId?: string | null,
 ): Promise<{ name: string; content: string }> {
   const form = new FormData();
   form.append("file", file);
+  if (teamId) form.append("teamId", teamId);
   const res = await apiFetch(`/compare-models/attachments/parse`, {
     method: "POST",
     body: form,

--- a/packages/database/backfill/backfill-observability-from-arena-runs.sql
+++ b/packages/database/backfill/backfill-observability-from-arena-runs.sql
@@ -1,7 +1,8 @@
 -- One-time backfill: seed observability_events from existing arena_runs.
 --
--- Idempotent: aborts early if any backfilled event already exists.
--- Re-running after a partial run is safe; no duplicates will be created.
+-- Idempotent per (arena_run_id, model): re-running after a partial or
+-- complete run skips pairs already inserted, so an interrupted run can
+-- be safely resumed.
 --
 -- How to apply:
 --   psql "$DATABASE_URL" -f packages/database/backfill/backfill-observability-from-arena-runs.sql
@@ -21,9 +22,8 @@ BEGIN
 
   IF existing_count > 0 THEN
     RAISE NOTICE
-      'Skipping backfill: % event(s) already tagged metadata.backfilled=true. Delete those rows and re-run for a clean slate.',
+      'Found % previously backfilled event(s); will skip any (arena_run_id, model) pairs already inserted.',
       existing_count;
-    RETURN;
   END IF;
 
   WITH primary_team AS (
@@ -106,8 +106,14 @@ BEGIN
     END,
     jsonb_build_object('backfilled', true, 'arenaRunId', arena_run_id),
     created_at
-  FROM rows;
+  FROM rows
+  WHERE NOT EXISTS (
+    SELECT 1 FROM observability_events oe
+    WHERE oe.metadata @> '{"backfilled": true}'::jsonb
+      AND oe.metadata ->> 'arenaRunId' = rows.arena_run_id::text
+      AND oe.model IS NOT DISTINCT FROM rows.model
+  );
 
   GET DIAGNOSTICS inserted_count = ROW_COUNT;
-  RAISE NOTICE 'Backfill complete: inserted % event(s) from arena_runs.', inserted_count;
+  RAISE NOTICE 'Backfill complete: inserted % new event(s) from arena_runs.', inserted_count;
 END $$;


### PR DESCRIPTION
- Make summary period-over-period non-overlapping: previousTo is now from-1ms (service uses lte/gte inclusive on both bounds, so events at createdAt === from were double-counted across windows).
- Make arena_runs backfill idempotent per (arena_run_id, model) instead of aborting globally; an interrupted run can now be safely resumed.
- Hoist KNOWN_PROVIDERS Set to module scope so providerFromModel doesn't reallocate it on every recorded event.
- Move misplaced JSDoc from above isUserInTeam onto getPrimaryTeamId.
- Honor the Compare Models "Team Context" override on the attachments parse endpoint: validate membership and scope OCR events to the selected team (or Personal) instead of always tagging the user's primary team. Threads selectedTeamId through parseArenaAttachment.