### PR TITLE
Feat/integration

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { ConversationsModule } from './conversations/conversations.module';
 import { DatabaseModule } from './database/database.module';
 import { DocumentsModule } from './documents/documents.module';
 import { GuardrailsSectionModule } from './guardrails/guardrails-section.module';
+import { IntegrationsModule } from './integrations/integrations.module';
 import { KnowledgeCoreModule } from './knowledge-core/knowledge-core.module';
 import { ProjectsModule } from './projects/projects.module';
 import { RedisModule } from './redis/redis.module';
@@ -34,6 +35,7 @@ import { UsersModule } from './users/users.module';
     ConversationsModule,
     DocumentsModule,
     GuardrailsSectionModule,
+    IntegrationsModule,
     KnowledgeCoreModule,
     ModelsModule,
     ObservabilityModule,

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -4,6 +4,7 @@ import type { AuthenticatedUser } from '../auth/types.js';
 import { ConversationsService } from '../conversations/conversations.service.js';
 import { DocumentsService } from '../documents/documents.service.js';
 import { ChatTransportService } from '../integrations/chat-transport.service.js';
+import { OpenRouterCatalogService } from '../models/openrouter-catalog.service.js';
 import { ObservabilityService } from '../observability/observability.service.js';
 import { ChatService } from './chat.service.js';
 
@@ -22,6 +23,7 @@ export class ChatController {
     private readonly documentsService: DocumentsService,
     private readonly conversationsService: ConversationsService,
     private readonly chatTransport: ChatTransportService,
+    private readonly catalogService: OpenRouterCatalogService,
     private readonly observabilityService: ObservabilityService,
   ) {}
 
@@ -85,6 +87,32 @@ export class ChatController {
         transport.apiKey,
         transport.baseURL,
       );
+
+      // Cost backfill for non-OpenRouter routes. OpenRouter returns
+      // `usage.cost` directly; native (BYOK) and Custom endpoints
+      // don't, so observability would otherwise show $0 for those
+      // calls. Estimate from the OpenRouter catalog's per-token
+      // pricing — assumes native pricing matches OpenRouter's listed
+      // prices, which is true for headline providers.
+      let costUsd = response.totalCost ?? null;
+      let costEstimated = false;
+      if (
+        costUsd == null &&
+        transport.source !== 'openrouter' &&
+        response.promptTokens != null &&
+        response.completionTokens != null
+      ) {
+        const estimated = await this.catalogService.estimateCost(
+          body.model ?? 'moonshotai/kimi-k2.5',
+          response.promptTokens,
+          response.completionTokens,
+        );
+        if (estimated != null) {
+          costUsd = estimated;
+          costEstimated = true;
+        }
+      }
+
       void this.observabilityService.recordLLMCall({
         userId: user.id,
         teamId,
@@ -92,7 +120,7 @@ export class ChatController {
         model: body.model ?? 'moonshotai/kimi-k2.5',
         provider: transport.provider,
         totalTokens: response.totalTokens,
-        costUsd: response.totalCost,
+        costUsd,
         latencyMs: Date.now() - chatStart,
         success: true,
         prompt: body.content,
@@ -101,6 +129,7 @@ export class ChatController {
           projectId: body.projectId ?? null,
           hasContext: Boolean(context),
           routingSource: transport.source,
+          costEstimated,
         },
       });
     } catch (err) {

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -86,6 +86,7 @@ export class ChatController {
         context,
         transport.apiKey,
         transport.baseURL,
+        transport.kind,
       );
 
       // Cost backfill for non-OpenRouter routes. OpenRouter returns

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -3,8 +3,8 @@ import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
 import { ConversationsService } from '../conversations/conversations.service.js';
 import { DocumentsService } from '../documents/documents.service.js';
+import { ChatTransportService } from '../integrations/chat-transport.service.js';
 import { ObservabilityService } from '../observability/observability.service.js';
-import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 import { ChatService } from './chat.service.js';
 
 interface ChatRequestBody {
@@ -21,7 +21,7 @@ export class ChatController {
     private readonly chatService: ChatService,
     private readonly documentsService: DocumentsService,
     private readonly conversationsService: ConversationsService,
-    private readonly keyResolverService: KeyResolverService,
+    private readonly chatTransport: ChatTransportService,
     private readonly observabilityService: ObservabilityService,
   ) {}
 
@@ -44,11 +44,13 @@ export class ChatController {
       user.id,
     );
 
-    // Resolve per-team or per-user API key
-    const apiKey = await this.keyResolverService.resolveForProject(
-      conversation.projectId,
-      user.id,
-    );
+    // Resolve transport: BYOK / Custom LLM if user configured one for
+    // this model, else OpenRouter via the resolved per-team/per-user key.
+    const transport = await this.chatTransport.resolve({
+      userId: user.id,
+      modelIdentifier: body.model ?? 'moonshotai/kimi-k2.5',
+      projectId: conversation.projectId,
+    });
 
     // 3. Map stored messages to OpenRouter format
     const apiMessages = conversation.messages.map((m) => ({
@@ -77,16 +79,18 @@ export class ChatController {
     try {
       response = await this.chatService.sendMessage(
         apiMessages,
-        body.model,
+        transport.model,
         body.enableReasoning,
         context,
-        apiKey,
+        transport.apiKey,
+        transport.baseURL,
       );
       void this.observabilityService.recordLLMCall({
         userId: user.id,
         teamId,
         eventType: 'chat_call',
         model: body.model ?? 'moonshotai/kimi-k2.5',
+        provider: transport.provider,
         totalTokens: response.totalTokens,
         costUsd: response.totalCost,
         latencyMs: Date.now() - chatStart,
@@ -96,6 +100,7 @@ export class ChatController {
           conversationId: body.conversationId,
           projectId: body.projectId ?? null,
           hasContext: Boolean(context),
+          routingSource: transport.source,
         },
       });
     } catch (err) {
@@ -105,6 +110,7 @@ export class ChatController {
         teamId,
         eventType: 'chat_call',
         model: body.model ?? 'moonshotai/kimi-k2.5',
+        provider: transport.provider,
         latencyMs: Date.now() - chatStart,
         success: false,
         errorMessage: msg,
@@ -112,6 +118,7 @@ export class ChatController {
         metadata: {
           conversationId: body.conversationId,
           projectId: body.projectId ?? null,
+          routingSource: transport.source,
         },
       });
 

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -122,7 +122,7 @@ export class ChatController {
         },
       });
 
-      // Surface OpenRouter HTTP status codes (402/401/429/…) to the
+      // Surface upstream HTTP status codes (402/401/429/…) to the
       // client so the FE humanizer can route them to a specific message.
       // The OpenAI SDK throws errors with a numeric `status` field;
       // everything else falls through as 500.
@@ -137,10 +137,18 @@ export class ChatController {
           message?: string;
           error?: { message?: string };
         };
-        const detail =
-          apiErr.error?.message ??
-          apiErr.message ??
-          `OpenRouter error ${apiErr.status}`;
+        const upstreamMessage =
+          apiErr.error?.message ?? apiErr.message ?? '';
+
+        // 401 + no-auth placeholder = user registered a Custom LLM
+        // without an API key but the endpoint requires one. Surface a
+        // distinct message so the humanizer doesn't say "your key is
+        // invalid" (the user has no key).
+        const noAuthAttempt =
+          transport.apiKey === 'no-auth' && apiErr.status === 401;
+        const detail = noAuthAttempt
+          ? `Custom LLM endpoint rejected the request — it requires an API key. Open Management → Integration → ${transport.provider}, click Settings, and add your key.`
+          : upstreamMessage || `${transport.provider} error ${apiErr.status}`;
         throw new HttpException(detail, apiErr.status);
       }
       throw err;

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -5,6 +5,7 @@ import { ChatController } from './chat.controller.js';
 import { DocumentsModule } from '../documents/documents.module.js';
 import { ConversationsModule } from '../conversations/conversations.module.js';
 import { IntegrationsModule } from '../integrations/integrations.module.js';
+import { ModelsModule } from '../models/models.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
@@ -13,6 +14,7 @@ import { OpenRouterModule } from '../openrouter/openrouter.module.js';
     DocumentsModule,
     ConversationsModule,
     IntegrationsModule,
+    ModelsModule,
     OpenRouterModule,
   ],
   controllers: [ChatController],

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -4,10 +4,17 @@ import { ChatService } from './chat.service.js';
 import { ChatController } from './chat.controller.js';
 import { DocumentsModule } from '../documents/documents.module.js';
 import { ConversationsModule } from '../conversations/conversations.module.js';
+import { IntegrationsModule } from '../integrations/integrations.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
-  imports: [ConfigModule, DocumentsModule, ConversationsModule, OpenRouterModule],
+  imports: [
+    ConfigModule,
+    DocumentsModule,
+    ConversationsModule,
+    IntegrationsModule,
+    OpenRouterModule,
+  ],
   controllers: [ChatController],
   providers: [ChatService],
 })

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -11,6 +11,9 @@ interface ChatResponse {
   content: string;
   reasoning_details?: unknown;
   totalTokens?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  /** Set by OpenRouter only; null for native BYOK / Custom endpoints. */
   totalCost?: number;
 }
 
@@ -19,6 +22,8 @@ interface ChatResponse {
 interface OpenRouterUsage {
   cost?: number;
   total_tokens?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
 }
 
 @Injectable()
@@ -83,6 +88,8 @@ export class ChatService {
         ? { reasoning_details: response.reasoning_details }
         : {}),
       totalTokens: usage?.total_tokens,
+      promptTokens: usage?.prompt_tokens,
+      completionTokens: usage?.completion_tokens,
       totalCost: usage?.cost,
     };
   }

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import OpenAI from 'openai';
+import { AnthropicClientService } from '../integrations/anthropic-client.service.js';
+import type { ChatTransportKind } from '../integrations/chat-transport.service.js';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -28,6 +30,8 @@ interface OpenRouterUsage {
 
 @Injectable()
 export class ChatService {
+  constructor(private readonly anthropic: AnthropicClientService) {}
+
   private makeClient(baseURL: string, apiKey: string): OpenAI {
     return new OpenAI({
       baseURL,
@@ -48,7 +52,28 @@ export class ChatService {
     context?: string,
     apiKey: string = '',
     baseURL: string = 'https://openrouter.ai/api/v1',
+    kind: ChatTransportKind = 'openai-sdk',
   ): Promise<ChatResponse> {
+    // Route to the Anthropic native SDK when the transport says so —
+    // Anthropic's Messages API isn't OpenAI-compatible, so we can't
+    // just point the OpenAI SDK at https://api.anthropic.com/v1.
+    if (kind === 'anthropic-sdk') {
+      const r = await this.anthropic.sendMessage(
+        messages.map((m) => ({ role: m.role, content: m.content })),
+        model,
+        apiKey,
+        context,
+      );
+      return {
+        content: r.content,
+        totalTokens: r.totalTokens,
+        promptTokens: r.promptTokens,
+        completionTokens: r.completionTokens,
+        // Anthropic doesn't return cost — controller estimates it via
+        // OpenRouter catalog pricing.
+      };
+    }
+
     const systemMessages: { role: 'system'; content: string }[] = [];
     if (context) {
       systemMessages.push({

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -23,10 +23,12 @@ interface OpenRouterUsage {
 
 @Injectable()
 export class ChatService {
-  private makeClient(apiKey?: string): OpenAI {
+  private makeClient(baseURL: string, apiKey: string): OpenAI {
     return new OpenAI({
-      baseURL: 'https://openrouter.ai/api/v1',
-      apiKey: apiKey ?? process.env['OPENROUTER_API_KEY'],
+      baseURL,
+      // OpenAI SDK rejects empty apiKey; pass a placeholder for endpoints
+      // that don't need auth (rare — local Ollama, internal vLLM, …).
+      apiKey: apiKey || 'no-auth',
       defaultHeaders: {
         'HTTP-Referer': process.env['SITE_URL'] || '',
         'X-Title': process.env['SITE_NAME'] || 'WorkenAI',
@@ -39,7 +41,8 @@ export class ChatService {
     model: string = 'moonshotai/kimi-k2.5',
     enableReasoning: boolean = true,
     context?: string,
-    apiKey?: string,
+    apiKey: string = '',
+    baseURL: string = 'https://openrouter.ai/api/v1',
   ): Promise<ChatResponse> {
     const systemMessages: { role: 'system'; content: string }[] = [];
     if (context) {
@@ -51,7 +54,7 @@ export class ChatService {
       });
     }
 
-    const completion = await this.makeClient(apiKey).chat.completions.create({
+    const completion = await this.makeClient(baseURL, apiKey).chat.completions.create({
       model,
       messages: [
         ...systemMessages,

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -24,6 +24,7 @@ import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { ChatTransportService } from '../integrations/chat-transport.service.js';
+import { OpenRouterCatalogService } from '../models/openrouter-catalog.service.js';
 import { ObservabilityService } from '../observability/observability.service.js';
 import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 import { CompareModelsService } from './compare-models.service.js';
@@ -87,6 +88,7 @@ export class CompareModelsController {
     private readonly compareModelsService: CompareModelsService,
     private readonly keyResolverService: KeyResolverService,
     private readonly chatTransport: ChatTransportService,
+    private readonly catalogService: OpenRouterCatalogService,
     private readonly observabilityService: ObservabilityService,
     @Inject(DATABASE) private readonly db: Database,
   ) {}
@@ -213,6 +215,32 @@ export class CompareModelsController {
               transport.baseURL,
             );
             const latencyMs = Date.now() - start;
+
+            // Estimate cost when the route bypassed OpenRouter (BYOK /
+            // Custom). Same logic as chat.controller — see commentary
+            // there. `model` (not `transport.model`) is what's looked
+            // up in the catalog; for BYOK we strip the vendor prefix
+            // before sending to the native endpoint, but the catalog
+            // still keys on the prefixed id.
+            let costUsd = response.totalCost ?? null;
+            let costEstimated = false;
+            if (
+              costUsd == null &&
+              transport.source !== 'openrouter' &&
+              response.promptTokens != null &&
+              response.completionTokens != null
+            ) {
+              const estimated = await this.catalogService.estimateCost(
+                model,
+                response.promptTokens,
+                response.completionTokens,
+              );
+              if (estimated != null) {
+                costUsd = estimated;
+                costEstimated = true;
+              }
+            }
+
             void this.observabilityService.recordLLMCall({
               userId: user.id,
               teamId,
@@ -220,13 +248,14 @@ export class CompareModelsController {
               model,
               provider: transport.provider,
               totalTokens: response.totalTokens,
-              costUsd: response.totalCost,
+              costUsd,
               latencyMs,
               success: true,
               prompt: body.question,
               metadata: {
                 hasContext: Boolean(body.context),
                 routingSource: transport.source,
+                costEstimated,
               },
             });
             return {
@@ -234,7 +263,7 @@ export class CompareModelsController {
               response,
               time: latencyMs,
               totalTokens: response.totalTokens,
-              totalCost: response.totalCost,
+              totalCost: costUsd ?? undefined,
             };
           } catch (err) {
             const latencyMs = Date.now() - start;

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -23,6 +23,7 @@ import { arenaRuns } from '@worken/database/schema';
 import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
 import { DATABASE, type Database } from '../database/database.module.js';
+import { ChatTransportService } from '../integrations/chat-transport.service.js';
 import { ObservabilityService } from '../observability/observability.service.js';
 import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 import { CompareModelsService } from './compare-models.service.js';
@@ -85,6 +86,7 @@ export class CompareModelsController {
   constructor(
     private readonly compareModelsService: CompareModelsService,
     private readonly keyResolverService: KeyResolverService,
+    private readonly chatTransport: ChatTransportService,
     private readonly observabilityService: ObservabilityService,
     @Inject(DATABASE) private readonly db: Database,
   ) {}
@@ -161,9 +163,12 @@ export class CompareModelsController {
     }
     body.expectedOutput = body.expectedOutput ?? '';
 
-    let apiKey: string;
+    // Resolve transport per model below (each can route differently:
+    // BYOK / Custom / OpenRouter). The evaluator at the bottom uses
+    // OpenRouter regardless, so we still need a base key for it.
+    let evaluatorApiKey: string;
     try {
-      apiKey = await this.keyResolverService.resolveUserKey(user.id);
+      evaluatorApiKey = await this.keyResolverService.resolveUserKey(user.id);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.error(`Key resolution failed for user ${user.id}: ${msg}`);
@@ -191,14 +196,21 @@ export class CompareModelsController {
     try {
       responses = await Promise.all(
         body.models.map(async (model) => {
+          // Each model resolves its own transport independently — one
+          // arena run can mix OpenRouter, BYOK, and Custom routes.
+          const transport = await this.chatTransport.resolve({
+            userId: user.id,
+            modelIdentifier: model,
+          });
           const start = Date.now();
           try {
             const response = await this.compareModelsService.sendQuestion(
               body.question,
-              model,
+              transport.model,
               false,
               body.context,
-              apiKey,
+              transport.apiKey,
+              transport.baseURL,
             );
             const latencyMs = Date.now() - start;
             void this.observabilityService.recordLLMCall({
@@ -206,12 +218,16 @@ export class CompareModelsController {
               teamId,
               eventType: 'arena_call',
               model,
+              provider: transport.provider,
               totalTokens: response.totalTokens,
               costUsd: response.totalCost,
               latencyMs,
               success: true,
               prompt: body.question,
-              metadata: { hasContext: Boolean(body.context) },
+              metadata: {
+                hasContext: Boolean(body.context),
+                routingSource: transport.source,
+              },
             });
             return {
               model,
@@ -228,11 +244,15 @@ export class CompareModelsController {
               teamId,
               eventType: 'arena_call',
               model,
+              provider: transport.provider,
               latencyMs,
               success: false,
               errorMessage: msg,
               prompt: body.question,
-              metadata: { hasContext: Boolean(body.context) },
+              metadata: {
+                hasContext: Boolean(body.context),
+                routingSource: transport.source,
+              },
             });
             throw err;
           }
@@ -258,7 +278,7 @@ export class CompareModelsController {
           body.expectedOutput,
           EVALUATOR_MODEL,
           false,
-          apiKey,
+          evaluatorApiKey,
         );
         void this.observabilityService.recordLLMCall({
           userId: user.id,

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -213,6 +213,7 @@ export class CompareModelsController {
               body.context,
               transport.apiKey,
               transport.baseURL,
+              transport.kind,
             );
             const latencyMs = Date.now() - start;
 

--- a/apps/api/src/compare-models/compare-models.module.ts
+++ b/apps/api/src/compare-models/compare-models.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { CompareModelsController } from './compare-models.controller.js';
 import { CompareModelsService } from './compare-models.service.js';
+import { IntegrationsModule } from '../integrations/integrations.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
-  imports: [ConfigModule, OpenRouterModule],
+  imports: [ConfigModule, IntegrationsModule, OpenRouterModule],
   controllers: [CompareModelsController],
   providers: [CompareModelsService],
 })

--- a/apps/api/src/compare-models/compare-models.module.ts
+++ b/apps/api/src/compare-models/compare-models.module.ts
@@ -3,10 +3,11 @@ import { ConfigModule } from '@nestjs/config';
 import { CompareModelsController } from './compare-models.controller.js';
 import { CompareModelsService } from './compare-models.service.js';
 import { IntegrationsModule } from '../integrations/integrations.module.js';
+import { ModelsModule } from '../models/models.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
-  imports: [ConfigModule, IntegrationsModule, OpenRouterModule],
+  imports: [ConfigModule, IntegrationsModule, ModelsModule, OpenRouterModule],
   controllers: [CompareModelsController],
   providers: [CompareModelsService],
 })

--- a/apps/api/src/compare-models/compare-models.service.ts
+++ b/apps/api/src/compare-models/compare-models.service.ts
@@ -6,6 +6,9 @@ interface QuestionResponse {
   content: string;
   reasoning_details?: unknown;
   totalTokens?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  /** OpenRouter only — null for native BYOK / Custom endpoints. */
   totalCost?: number;
 }
 
@@ -115,13 +118,18 @@ export class CompareModelsService {
     };
     const response = completion.choices[0].message as ORChatMessage;
 
+    const orCost = (completion.usage as OpenRouterUsage | undefined)?.cost;
     return {
       content: response.content || '',
       ...(response.reasoning_details
         ? { reasoning_details: response.reasoning_details }
         : {}),
       totalTokens: completion.usage?.total_tokens,
-      totalCost: (completion.usage as OpenRouterUsage | undefined)?.cost ?? 0,
+      promptTokens: completion.usage?.prompt_tokens,
+      completionTokens: completion.usage?.completion_tokens,
+      // Leave undefined when the upstream didn't return cost — controller
+      // estimates from the OpenRouter catalog for BYOK / Custom routes.
+      ...(orCost != null ? { totalCost: orCost } : {}),
     };
   }
 

--- a/apps/api/src/compare-models/compare-models.service.ts
+++ b/apps/api/src/compare-models/compare-models.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import OpenAI from 'openai';
 import { ChatCompletionMessageParam } from 'openai/resources';
+import { AnthropicClientService } from '../integrations/anthropic-client.service.js';
+import type { ChatTransportKind } from '../integrations/chat-transport.service.js';
 
 interface QuestionResponse {
   content: string;
@@ -32,6 +34,8 @@ function describeOpenRouterError(model: string, action: string, err: unknown): E
 
 @Injectable()
 export class CompareModelsService {
+  constructor(private readonly anthropic: AnthropicClientService) {}
+
   private makeClient(apiKey?: string, baseURL?: string): OpenAI {
     const resolved = apiKey ?? process.env['OPENROUTER_API_KEY'];
     if (!resolved) {
@@ -90,7 +94,23 @@ export class CompareModelsService {
     context?: string,
     apiKey?: string,
     baseURL?: string,
+    kind: ChatTransportKind = 'openai-sdk',
   ): Promise<QuestionResponse> {
+    // Native Anthropic path for BYOK on Claude.
+    if (kind === 'anthropic-sdk') {
+      const r = await this.anthropic.sendMessage(
+        [{ role: 'user', content: question }],
+        model,
+        apiKey ?? '',
+        context,
+      );
+      return {
+        content: r.content,
+        totalTokens: r.totalTokens,
+        promptTokens: r.promptTokens,
+        completionTokens: r.completionTokens,
+      };
+    }
     const systemMessages: { role: 'system'; content: string }[] = [];
     if (context) {
       systemMessages.push({

--- a/apps/api/src/compare-models/compare-models.service.ts
+++ b/apps/api/src/compare-models/compare-models.service.ts
@@ -29,16 +29,16 @@ function describeOpenRouterError(model: string, action: string, err: unknown): E
 
 @Injectable()
 export class CompareModelsService {
-  private makeClient(apiKey?: string): OpenAI {
+  private makeClient(apiKey?: string, baseURL?: string): OpenAI {
     const resolved = apiKey ?? process.env['OPENROUTER_API_KEY'];
     if (!resolved) {
       throw new Error(
-        'No OpenRouter API key available. Resolver returned empty and OPENROUTER_API_KEY env var is not set.',
+        'No API key available. Resolver returned empty and OPENROUTER_API_KEY env var is not set.',
       );
     }
     return new OpenAI({
-      baseURL: 'https://openrouter.ai/api/v1',
-      apiKey: resolved,
+      baseURL: baseURL ?? 'https://openrouter.ai/api/v1',
+      apiKey: resolved || 'no-auth',
       defaultHeaders: {
         'HTTP-Referer': process.env['SITE_URL'] || '',
         'X-Title': process.env['SITE_NAME'] || 'WorkenAI',
@@ -51,6 +51,8 @@ export class CompareModelsService {
     model: string,
     apiKey?: string,
   ): Promise<string> {
+    // OCR always uses OpenRouter (baidu/qianfan-ocr-fast:free), so no
+    // BYOK / Custom routing here.
     let completion;
     try {
       completion = await this.makeClient(apiKey).chat.completions.create({
@@ -84,6 +86,7 @@ export class CompareModelsService {
     enableReasoning: boolean = true,
     context?: string,
     apiKey?: string,
+    baseURL?: string,
   ): Promise<QuestionResponse> {
     const systemMessages: { role: 'system'; content: string }[] = [];
     if (context) {
@@ -97,7 +100,7 @@ export class CompareModelsService {
 
     let completion;
     try {
-      completion = await this.makeClient(apiKey).chat.completions.create({
+      completion = await this.makeClient(apiKey, baseURL).chat.completions.create({
         model,
         messages: [...systemMessages, { role: 'user', content: question }],
         ...(enableReasoning && { reasoning: { enabled: true } }),

--- a/apps/api/src/integrations/anthropic-client.service.ts
+++ b/apps/api/src/integrations/anthropic-client.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@nestjs/common';
+import Anthropic from '@anthropic-ai/sdk';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AnthropicChatResponse {
+  content: string;
+  totalTokens?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Native Anthropic SDK wrapper. Used when a user has a BYOK key for the
+ * "anthropic" provider — we bypass OpenRouter and call the Messages API
+ * directly so the user pays Anthropic rather than the OpenRouter
+ * markup.
+ *
+ * Anthropic's API differs from OpenAI's in two ways that matter here:
+ *
+ *   1. `system` is a top-level parameter, not a message with role
+ *      "system". We extract it from the messages array before calling.
+ *
+ *   2. `max_tokens` is REQUIRED. OpenAI infers a sensible default
+ *      server-side; Anthropic doesn't. We pass DEFAULT_MAX_TOKENS
+ *      unless the caller overrides.
+ *
+ * Reasoning details are not modeled — Anthropic has its own
+ * "extended thinking" feature with a different shape, which we'd
+ * surface separately when/if FE adds support for it.
+ */
+@Injectable()
+export class AnthropicClientService {
+  async sendMessage(
+    messages: ChatMessage[],
+    model: string,
+    apiKey: string,
+    context?: string,
+    maxTokens: number = DEFAULT_MAX_TOKENS,
+  ): Promise<AnthropicChatResponse> {
+    if (!apiKey) {
+      throw new Error('Anthropic API key is required for native routing');
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    // Pull any leading "system" message into the dedicated parameter.
+    // Our app currently injects context as a synthetic system message
+    // in chat.service; merge that with the explicit context arg.
+    const systemPieces: string[] = [];
+    if (context) systemPieces.push(context);
+    const filteredMessages = messages.filter((m) => {
+      if (m.role === ('system' as unknown)) {
+        systemPieces.push(m.content);
+        return false;
+      }
+      return true;
+    });
+
+    // Anthropic requires the conversation to start with a "user" role
+    // and alternate. Drop any leading non-user messages defensively.
+    while (
+      filteredMessages.length > 0 &&
+      filteredMessages[0].role !== 'user'
+    ) {
+      filteredMessages.shift();
+    }
+
+    const response = await client.messages.create({
+      model,
+      max_tokens: maxTokens,
+      ...(systemPieces.length > 0
+        ? { system: systemPieces.join('\n\n') }
+        : {}),
+      messages: filteredMessages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+    });
+
+    // Concatenate any text content blocks. Tool use / images would live
+    // alongside; we ignore them for now.
+    const text = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map((block) => block.text)
+      .join('');
+
+    const inputTokens = response.usage?.input_tokens ?? 0;
+    const outputTokens = response.usage?.output_tokens ?? 0;
+
+    return {
+      content: text,
+      promptTokens: inputTokens,
+      completionTokens: outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    };
+  }
+}

--- a/apps/api/src/integrations/anthropic-client.service.ts
+++ b/apps/api/src/integrations/anthropic-client.service.ts
@@ -60,21 +60,16 @@ export class AnthropicClientService {
     const client = new Anthropic({ apiKey });
     const nativeModel = toAnthropicModelId(model);
 
-    // Pull any leading "system" message into the dedicated parameter.
-    // Our app currently injects context as a synthetic system message
-    // in chat.service; merge that with the explicit context arg.
-    const systemPieces: string[] = [];
-    if (context) systemPieces.push(context);
-    const filteredMessages = messages.filter((m) => {
-      if (m.role === ('system' as unknown)) {
-        systemPieces.push(m.content);
-        return false;
-      }
-      return true;
-    });
+    // System content goes into Anthropic's dedicated `system` parameter,
+    // not into the messages array. Our callers pass it as the `context`
+    // arg; the messages array is always {user, assistant, …}.
+    const systemPiece = context ?? null;
 
     // Anthropic requires the conversation to start with a "user" role
-    // and alternate. Drop any leading non-user messages defensively.
+    // and alternate. Drop any leading non-user messages defensively
+    // (in practice this only fires if a future caller passes a stale
+    // assistant-led history fragment).
+    const filteredMessages = [...messages];
     while (
       filteredMessages.length > 0 &&
       filteredMessages[0].role !== 'user'
@@ -85,9 +80,7 @@ export class AnthropicClientService {
     const response = await client.messages.create({
       model: nativeModel,
       max_tokens: maxTokens,
-      ...(systemPieces.length > 0
-        ? { system: systemPieces.join('\n\n') }
-        : {}),
+      ...(systemPiece ? { system: systemPiece } : {}),
       messages: filteredMessages.map((m) => ({
         role: m.role,
         content: m.content,

--- a/apps/api/src/integrations/anthropic-client.service.ts
+++ b/apps/api/src/integrations/anthropic-client.service.ts
@@ -34,6 +34,16 @@ const DEFAULT_MAX_TOKENS = 4096;
  * "extended thinking" feature with a different shape, which we'd
  * surface separately when/if FE adds support for it.
  */
+/**
+ * OpenRouter model ids dot-separate version components
+ * ("claude-opus-4.7", "claude-sonnet-4.5"). Anthropic's native API
+ * uses hyphens ("claude-opus-4-7"). Translate before sending; if a
+ * future model breaks the convention we'll need a smarter map.
+ */
+function toAnthropicModelId(modelId: string): string {
+  return modelId.replace(/\./g, '-');
+}
+
 @Injectable()
 export class AnthropicClientService {
   async sendMessage(
@@ -48,6 +58,7 @@ export class AnthropicClientService {
     }
 
     const client = new Anthropic({ apiKey });
+    const nativeModel = toAnthropicModelId(model);
 
     // Pull any leading "system" message into the dedicated parameter.
     // Our app currently injects context as a synthetic system message
@@ -72,7 +83,7 @@ export class AnthropicClientService {
     }
 
     const response = await client.messages.create({
-      model,
+      model: nativeModel,
       max_tokens: maxTokens,
       ...(systemPieces.length > 0
         ? { system: systemPieces.join('\n\n') }

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -10,8 +10,16 @@ const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
 export type ChatRoutingSource = 'openrouter' | 'byok' | 'custom';
 
+/**
+ * Which client the chat layer should instantiate. `openai-sdk` is the
+ * default — works for OpenRouter, OpenAI-compatible BYOK, and Custom
+ * LLMs alike. `anthropic-sdk` triggers AnthropicClientService for
+ * Anthropic BYOK (their native API isn't OpenAI-compatible).
+ */
+export type ChatTransportKind = 'openai-sdk' | 'anthropic-sdk';
+
 export interface ChatTransport {
-  /** baseURL for the OpenAI SDK client. */
+  /** baseURL for the OpenAI SDK client. Unused when kind is 'anthropic-sdk'. */
   baseURL: string;
   /** Plaintext API key. Empty string means "no auth header" (rare). */
   apiKey: string;
@@ -21,6 +29,8 @@ export interface ChatTransport {
   provider: string;
   /** How the call was routed. */
   source: ChatRoutingSource;
+  /** Which SDK to use. */
+  kind: ChatTransportKind;
 }
 
 /**
@@ -93,6 +103,7 @@ export class ChatTransportService {
           model: modelIdentifier,
           provider: 'custom',
           source: 'custom',
+          kind: 'openai-sdk',
         };
       }
 
@@ -118,25 +129,41 @@ export class ChatTransportService {
 
       if (byok?.apiKeyEncrypted) {
         const native = NATIVE_ENDPOINTS[provider];
+        const bareModel = modelIdentifier.slice(provider.length + 1);
+        const apiKey = this.safeDecrypt(
+          byok.apiKeyEncrypted,
+          `BYOK ${provider}`,
+        );
+
+        // 2a. OpenAI-compatible providers go through the standard
+        // OpenAI SDK with a custom baseURL.
         if (native?.openAICompatible) {
-          const apiKey = this.safeDecrypt(
-            byok.apiKeyEncrypted,
-            `BYOK ${provider}`,
-          );
-          // Native endpoints expect the bare model name without the
-          // "vendor/" prefix that OpenRouter uses (e.g. OpenAI wants
-          // "gpt-5.5", not "openai/gpt-5.5"). Strip it.
-          const bareModel = modelIdentifier.slice(provider.length + 1);
           return {
             baseURL: native.baseURL,
             apiKey,
             model: bareModel,
             provider,
             source: 'byok',
+            kind: 'openai-sdk',
           };
         }
+
+        // 2b. Providers we have a dedicated SDK shim for (currently
+        // Anthropic). The chat layer recognises kind === 'anthropic-sdk'
+        // and routes to AnthropicClientService instead of OpenAI SDK.
+        if (native?.nativeSdkAvailable) {
+          return {
+            baseURL: native.baseURL, // unused by the SDK path
+            apiKey,
+            model: bareModel,
+            provider,
+            source: 'byok',
+            kind: 'anthropic-sdk',
+          };
+        }
+
         this.logger.warn(
-          `${provider} has a BYOK key set but its native API isn't OpenAI-compatible — falling back to OpenRouter for ${modelIdentifier}.`,
+          `${provider} has a BYOK key set but no native transport available — falling back to OpenRouter for ${modelIdentifier}.`,
         );
       }
     }
@@ -152,6 +179,7 @@ export class ChatTransportService {
       model: modelIdentifier,
       provider: provider ?? 'unknown',
       source: 'openrouter',
+      kind: 'openai-sdk',
     };
   }
 

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -1,0 +1,168 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import { integrations, modelConfigs } from '@worken/database/schema';
+import { DATABASE, type Database } from '../database/database.module.js';
+import { EncryptionService } from '../openrouter/encryption.service.js';
+import { KeyResolverService } from '../openrouter/key-resolver.service.js';
+import { NATIVE_ENDPOINTS, providerOfModel } from './native-endpoints.js';
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+export type ChatRoutingSource = 'openrouter' | 'byok' | 'custom';
+
+export interface ChatTransport {
+  /** baseURL for the OpenAI SDK client. */
+  baseURL: string;
+  /** Plaintext API key. Empty string means "no auth header" (rare). */
+  apiKey: string;
+  /** Model id to pass to the SDK. May differ from input for custom routes. */
+  model: string;
+  /** Provider label for observability. */
+  provider: string;
+  /** How the call was routed. */
+  source: ChatRoutingSource;
+}
+
+/**
+ * Resolves which (baseURL, apiKey, model) tuple a chat call should use.
+ *
+ * Routing rules, in order:
+ *
+ *   1. **Custom LLM** — if the user has a `model_configs` row for this
+ *      model with `integrationId` set, the alias is bound to a specific
+ *      Custom LLM endpoint. Use that integration's apiUrl + decrypted
+ *      apiKey.
+ *
+ *   2. **BYOK** — if the model id has a slash (e.g. "anthropic/…"), look
+ *      for an enabled, key-bearing `integrations` row matching the
+ *      provider. Use the provider's native endpoint from
+ *      NATIVE_ENDPOINTS — but only if it's openAICompatible. Anthropic /
+ *      Google / Qwen native APIs aren't OpenAI-compatible, so BYOK keys
+ *      are stored but the chat path skips them and falls through.
+ *
+ *   3. **OpenRouter** — fallback. Resolves the per-team or per-user
+ *      OpenRouter key via the existing KeyResolverService.
+ */
+@Injectable()
+export class ChatTransportService {
+  private readonly logger = new Logger(ChatTransportService.name);
+
+  constructor(
+    @Inject(DATABASE) private readonly db: Database,
+    private readonly encryptionService: EncryptionService,
+    private readonly keyResolverService: KeyResolverService,
+  ) {}
+
+  async resolve(input: {
+    userId: string;
+    modelIdentifier: string;
+    /** Optional. When set, used to resolve the OpenRouter key for the
+     *  fallback path (team key vs user key). */
+    projectId?: string | null;
+  }): Promise<ChatTransport> {
+    const { userId, modelIdentifier, projectId } = input;
+
+    // 1. Custom LLM — alias explicitly bound to a Custom integration row.
+    const [alias] = await this.db
+      .select({
+        integrationId: modelConfigs.integrationId,
+      })
+      .from(modelConfigs)
+      .where(
+        and(
+          eq(modelConfigs.ownerId, userId),
+          eq(modelConfigs.modelIdentifier, modelIdentifier),
+        ),
+      )
+      .limit(1);
+
+    if (alias?.integrationId) {
+      const [integration] = await this.db
+        .select()
+        .from(integrations)
+        .where(eq(integrations.id, alias.integrationId))
+        .limit(1);
+
+      if (integration && integration.isEnabled && integration.apiUrl) {
+        const apiKey = integration.apiKeyEncrypted
+          ? this.safeDecrypt(integration.apiKeyEncrypted, 'custom integration')
+          : '';
+        return {
+          baseURL: integration.apiUrl,
+          apiKey,
+          model: modelIdentifier,
+          provider: 'custom',
+          source: 'custom',
+        };
+      }
+
+      this.logger.warn(
+        `Alias ${modelIdentifier} pointed at integration ${alias.integrationId}, but it's missing/disabled — falling through.`,
+      );
+    }
+
+    // 2. BYOK — user has a key for the model's native provider.
+    const provider = providerOfModel(modelIdentifier);
+    if (provider) {
+      const [byok] = await this.db
+        .select()
+        .from(integrations)
+        .where(
+          and(
+            eq(integrations.ownerId, userId),
+            eq(integrations.providerId, provider),
+            eq(integrations.isEnabled, true),
+          ),
+        )
+        .limit(1);
+
+      if (byok?.apiKeyEncrypted) {
+        const native = NATIVE_ENDPOINTS[provider];
+        if (native?.openAICompatible) {
+          const apiKey = this.safeDecrypt(
+            byok.apiKeyEncrypted,
+            `BYOK ${provider}`,
+          );
+          // Native endpoints expect the bare model name without the
+          // "vendor/" prefix that OpenRouter uses (e.g. OpenAI wants
+          // "gpt-5.5", not "openai/gpt-5.5"). Strip it.
+          const bareModel = modelIdentifier.slice(provider.length + 1);
+          return {
+            baseURL: native.baseURL,
+            apiKey,
+            model: bareModel,
+            provider,
+            source: 'byok',
+          };
+        }
+        this.logger.warn(
+          `${provider} has a BYOK key set but its native API isn't OpenAI-compatible — falling back to OpenRouter for ${modelIdentifier}.`,
+        );
+      }
+    }
+
+    // 3. OpenRouter fallback.
+    const apiKey = projectId
+      ? await this.keyResolverService.resolveForProject(projectId, userId)
+      : await this.keyResolverService.resolveUserKey(userId);
+
+    return {
+      baseURL: OPENROUTER_BASE_URL,
+      apiKey,
+      model: modelIdentifier,
+      provider: provider ?? 'unknown',
+      source: 'openrouter',
+    };
+  }
+
+  private safeDecrypt(encrypted: string, context: string): string {
+    try {
+      return this.encryptionService.decrypt(encrypted);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Failed to decrypt ${context} key: ${msg}. OPENROUTER_ENCRYPTION_KEY may have changed since the key was stored.`,
+      );
+    }
+  }
+}

--- a/apps/api/src/integrations/integrations.controller.ts
+++ b/apps/api/src/integrations/integrations.controller.ts
@@ -1,0 +1,76 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthenticatedUser } from '../auth/types.js';
+import { IntegrationsService } from './integrations.service.js';
+
+@Controller('integrations')
+export class IntegrationsController {
+  constructor(private readonly integrationsService: IntegrationsService) {}
+
+  /** Public catalog of predefined providers (no per-user state). */
+  @Get('providers')
+  listProviders() {
+    return this.integrationsService.listPredefined();
+  }
+
+  /** User's integration cards: predefined (always present) + custom LLMs. */
+  @Get()
+  list(@CurrentUser() user: AuthenticatedUser) {
+    return this.integrationsService.listForUser(user.id);
+  }
+
+  /**
+   * Create custom LLM (providerId="custom" + apiUrl) or upsert BYOK
+   * settings on a predefined provider (providerId="openai", apiKey, …).
+   */
+  @Post()
+  create(
+    @Body()
+    body: {
+      providerId: string;
+      apiUrl?: string;
+      apiKey?: string;
+      isEnabled?: boolean;
+    },
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    if (typeof body?.providerId !== 'string' || !body.providerId) {
+      throw new BadRequestException('`providerId` is required');
+    }
+    return this.integrationsService.upsert(user.id, {
+      providerId: body.providerId,
+      apiUrl: body.apiUrl,
+      apiKey: body.apiKey,
+      isEnabled: body.isEnabled,
+    });
+  }
+
+  /** Toggle is_enabled and/or update the BYOK key. */
+  @Patch(':id')
+  update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() body: { isEnabled?: boolean; apiKey?: string | null },
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.integrationsService.update(user.id, id, body);
+  }
+
+  /** Custom LLMs only — predefined rows can be disabled but not removed. */
+  @Delete(':id')
+  remove(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.integrationsService.remove(user.id, id);
+  }
+}

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
+import { ChatTransportService } from './chat-transport.service.js';
 import { IntegrationsController } from './integrations.controller.js';
 import { IntegrationsService } from './integrations.service.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
-  imports: [OpenRouterModule], // brings in EncryptionService
+  imports: [OpenRouterModule], // EncryptionService + KeyResolverService
   controllers: [IntegrationsController],
-  providers: [IntegrationsService],
-  exports: [IntegrationsService],
+  providers: [IntegrationsService, ChatTransportService],
+  exports: [IntegrationsService, ChatTransportService],
 })
 export class IntegrationsModule {}

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { AnthropicClientService } from './anthropic-client.service.js';
 import { ChatTransportService } from './chat-transport.service.js';
 import { IntegrationsController } from './integrations.controller.js';
 import { IntegrationsService } from './integrations.service.js';
@@ -7,7 +8,15 @@ import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 @Module({
   imports: [OpenRouterModule], // EncryptionService + KeyResolverService
   controllers: [IntegrationsController],
-  providers: [IntegrationsService, ChatTransportService],
-  exports: [IntegrationsService, ChatTransportService],
+  providers: [
+    IntegrationsService,
+    ChatTransportService,
+    AnthropicClientService,
+  ],
+  exports: [
+    IntegrationsService,
+    ChatTransportService,
+    AnthropicClientService,
+  ],
 })
 export class IntegrationsModule {}

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { IntegrationsController } from './integrations.controller.js';
+import { IntegrationsService } from './integrations.service.js';
+import { OpenRouterModule } from '../openrouter/openrouter.module.js';
+
+@Module({
+  imports: [OpenRouterModule], // brings in EncryptionService
+  controllers: [IntegrationsController],
+  providers: [IntegrationsService],
+  exports: [IntegrationsService],
+})
+export class IntegrationsModule {}

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -1,0 +1,306 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, eq, gte, sql } from 'drizzle-orm';
+import {
+  integrations,
+  observabilityEvents,
+} from '@worken/database/schema';
+import { DATABASE, type Database } from '../database/database.module.js';
+import { EncryptionService } from '../openrouter/encryption.service.js';
+import {
+  PREDEFINED_PROVIDERS,
+  isPredefinedProvider,
+  type PredefinedProvider,
+} from './predefined-providers.js';
+
+interface IntegrationStats {
+  successRate: number; // 0..1
+  apiCalls: number;
+  rateLimit: number;
+}
+
+export interface IntegrationView {
+  id: string | null; // null when no row exists yet (predefined, untouched)
+  providerId: string;
+  displayName: string;
+  description: string;
+  iconHint: string;
+  apiUrl: string | null; // only set for "custom"
+  hasApiKey: boolean; // never expose the key itself
+  isEnabled: boolean;
+  isCustom: boolean;
+  stats: IntegrationStats;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+@Injectable()
+export class IntegrationsService {
+  constructor(
+    @Inject(DATABASE) private readonly db: Database,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  /** Catalog of predefined providers, in canonical UI order. */
+  listPredefined(): PredefinedProvider[] {
+    return PREDEFINED_PROVIDERS;
+  }
+
+  /**
+   * Returns one card-row per provider for the Integration tab.
+   *
+   * Predefined providers always appear (even when the user hasn't touched
+   * them yet — id=null, isEnabled=true, no key). Custom LLMs are appended
+   * after, one row each.
+   */
+  async listForUser(userId: string): Promise<IntegrationView[]> {
+    const rows = await this.db
+      .select()
+      .from(integrations)
+      .where(eq(integrations.ownerId, userId));
+
+    const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // 30d
+    const statsRows = await this.db
+      .select({
+        provider: observabilityEvents.provider,
+        successCount: sql<number>`count(*) filter (where ${observabilityEvents.success}=true)::int`,
+        totalCount: sql<number>`count(*)::int`,
+        thisMonth: sql<number>`count(*) filter (where ${observabilityEvents.createdAt} >= date_trunc('month', now()))::int`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          eq(observabilityEvents.userId, userId),
+          gte(observabilityEvents.createdAt, since),
+        ),
+      )
+      .groupBy(observabilityEvents.provider);
+
+    const statsByProvider = new Map<
+      string,
+      { successCount: number; totalCount: number; thisMonth: number }
+    >();
+    for (const r of statsRows) {
+      if (!r.provider) continue;
+      statsByProvider.set(r.provider, {
+        successCount: Number(r.successCount ?? 0),
+        totalCount: Number(r.totalCount ?? 0),
+        thisMonth: Number(r.thisMonth ?? 0),
+      });
+    }
+
+    const buildStats = (providerId: string, rateLimit: number): IntegrationStats => {
+      const s = statsByProvider.get(providerId);
+      const successRate =
+        s && s.totalCount > 0 ? s.successCount / s.totalCount : 0;
+      return {
+        successRate,
+        apiCalls: s?.thisMonth ?? 0,
+        rateLimit,
+      };
+    };
+
+    const out: IntegrationView[] = [];
+
+    // Predefined first, in catalog order.
+    for (const p of PREDEFINED_PROVIDERS) {
+      const row = rows.find(
+        (r) => r.providerId === p.id && r.apiUrl === null,
+      );
+      out.push({
+        id: row?.id ?? null,
+        providerId: p.id,
+        displayName: p.displayName,
+        description: p.description,
+        iconHint: p.iconHint,
+        apiUrl: null,
+        hasApiKey: !!row?.apiKeyEncrypted,
+        isEnabled: row?.isEnabled ?? true, // default-on per UI mock
+        isCustom: false,
+        stats: buildStats(p.id, p.defaultRateLimit),
+        createdAt: row?.createdAt?.toISOString() ?? null,
+        updatedAt: row?.updatedAt?.toISOString() ?? null,
+      });
+    }
+
+    // Custom LLMs after, sorted by created_at asc.
+    const customs = rows
+      .filter((r) => r.providerId === 'custom' && r.apiUrl !== null)
+      .sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      );
+    for (const r of customs) {
+      out.push({
+        id: r.id,
+        providerId: 'custom',
+        displayName: deriveCustomDisplayName(r.apiUrl ?? ''),
+        description: r.apiUrl ?? '',
+        iconHint: 'custom',
+        apiUrl: r.apiUrl,
+        hasApiKey: !!r.apiKeyEncrypted,
+        isEnabled: r.isEnabled,
+        isCustom: true,
+        stats: buildStats('custom', 0),
+        createdAt: r.createdAt.toISOString(),
+        updatedAt: r.updatedAt.toISOString(),
+      });
+    }
+
+    return out;
+  }
+
+  /**
+   * Create or upsert an integration row.
+   * - For predefined providers: upsert by (ownerId, providerId).
+   * - For custom: always insert a new row (apiUrl required).
+   */
+  async upsert(
+    userId: string,
+    input: {
+      providerId: string;
+      apiUrl?: string | null;
+      apiKey?: string | null;
+      isEnabled?: boolean;
+    },
+  ): Promise<IntegrationView> {
+    const isCustom = input.providerId === 'custom';
+    if (!isCustom && !isPredefinedProvider(input.providerId)) {
+      throw new BadRequestException(`Unknown provider: ${input.providerId}`);
+    }
+    if (isCustom) {
+      if (!input.apiUrl?.trim()) {
+        throw new BadRequestException('Custom LLM requires apiUrl');
+      }
+      try {
+        new URL(input.apiUrl);
+      } catch {
+        throw new BadRequestException('apiUrl is not a valid URL');
+      }
+    }
+
+    const apiKeyEncrypted = input.apiKey?.trim()
+      ? this.encryptionService.encrypt(input.apiKey.trim())
+      : null;
+
+    if (isCustom) {
+      await this.db.insert(integrations).values({
+        ownerId: userId,
+        providerId: 'custom',
+        apiUrl: input.apiUrl!,
+        apiKeyEncrypted,
+        isEnabled: input.isEnabled ?? true,
+      });
+    } else {
+      // Upsert: try update, else insert.
+      const [existing] = await this.db
+        .select()
+        .from(integrations)
+        .where(
+          and(
+            eq(integrations.ownerId, userId),
+            eq(integrations.providerId, input.providerId),
+          ),
+        );
+
+      if (existing) {
+        const updates: Record<string, unknown> = {
+          updatedAt: new Date(),
+        };
+        if (input.isEnabled !== undefined) updates.isEnabled = input.isEnabled;
+        if (apiKeyEncrypted !== null) updates.apiKeyEncrypted = apiKeyEncrypted;
+        if (apiKeyEncrypted === null && input.apiKey === '') {
+          // Empty string explicitly clears the key.
+          updates.apiKeyEncrypted = null;
+        }
+        await this.db
+          .update(integrations)
+          .set(updates)
+          .where(eq(integrations.id, existing.id));
+      } else {
+        await this.db.insert(integrations).values({
+          ownerId: userId,
+          providerId: input.providerId,
+          apiUrl: null,
+          apiKeyEncrypted,
+          isEnabled: input.isEnabled ?? true,
+        });
+      }
+    }
+
+    const all = await this.listForUser(userId);
+    const view = isCustom
+      ? all.findLast((v) => v.providerId === 'custom') // newest custom
+      : all.find((v) => v.providerId === input.providerId);
+    return view!;
+  }
+
+  async update(
+    userId: string,
+    id: string,
+    input: { isEnabled?: boolean; apiKey?: string | null },
+  ): Promise<IntegrationView> {
+    const [row] = await this.db
+      .select()
+      .from(integrations)
+      .where(eq(integrations.id, id));
+    if (!row) throw new NotFoundException('Integration not found');
+    if (row.ownerId !== userId) {
+      throw new ForbiddenException('Not your integration');
+    }
+
+    const updates: Record<string, unknown> = {
+      updatedAt: new Date(),
+    };
+    if (input.isEnabled !== undefined) updates.isEnabled = input.isEnabled;
+    if (input.apiKey !== undefined) {
+      updates.apiKeyEncrypted = input.apiKey
+        ? this.encryptionService.encrypt(input.apiKey)
+        : null;
+    }
+    await this.db
+      .update(integrations)
+      .set(updates)
+      .where(eq(integrations.id, id));
+
+    const all = await this.listForUser(userId);
+    const view = all.find((v) => v.id === id);
+    if (!view) throw new NotFoundException('Integration not found after update');
+    return view;
+  }
+
+  async remove(userId: string, id: string): Promise<void> {
+    const [row] = await this.db
+      .select()
+      .from(integrations)
+      .where(eq(integrations.id, id));
+    if (!row) throw new NotFoundException('Integration not found');
+    if (row.ownerId !== userId) {
+      throw new ForbiddenException('Not your integration');
+    }
+    if (row.providerId !== 'custom') {
+      throw new BadRequestException(
+        'Predefined provider rows cannot be deleted — disable them instead.',
+      );
+    }
+    await this.db.delete(integrations).where(eq(integrations.id, id));
+  }
+}
+
+/**
+ * "https://api.together.xyz/v1/chat/completions" → "api.together.xyz"
+ * Used as a card title for custom LLMs since the dialog doesn't ask for
+ * a friendly name (Figma shows only the API Link field).
+ */
+function deriveCustomDisplayName(url: string): string {
+  try {
+    return new URL(url).hostname || 'Custom LLM';
+  } catch {
+    return 'Custom LLM';
+  }
+}

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -5,9 +5,10 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
 import {
   integrations,
+  modelConfigs,
   observabilityEvents,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
@@ -34,6 +35,19 @@ export interface IntegrationView {
   hasApiKey: boolean; // never expose the key itself
   isEnabled: boolean;
   isCustom: boolean;
+  /**
+   * Whether the provider's native API can be hit through the OpenAI SDK.
+   * `false` for Anthropic, Google, Qwen — BYOK key is stored but chat
+   * still routes through OpenRouter; FE uses this to show a disclaimer.
+   * Always true for "custom" rows (the user picked the URL, presumed
+   * OpenAI-compatible).
+   */
+  openAICompatible: boolean;
+  /**
+   * For custom rows only: how many model_configs aliases reference this
+   * integration. Drives the "delete will unlink N aliases" warning.
+   */
+  boundAliasCount: number;
   stats: IntegrationStats;
   createdAt: string | null;
   updatedAt: string | null;
@@ -105,6 +119,29 @@ export class IntegrationsService {
       };
     };
 
+    // For custom rows we surface boundAliasCount so the FE can warn
+    // before deletion ("N aliases will be unlinked"). One query for all
+    // customs at once.
+    const customIds = rows
+      .filter((r) => r.providerId === 'custom')
+      .map((r) => r.id);
+    const aliasCountByIntegration = new Map<string, number>();
+    if (customIds.length > 0) {
+      const aliasRows = await this.db
+        .select({
+          integrationId: modelConfigs.integrationId,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(modelConfigs)
+        .where(inArray(modelConfigs.integrationId, customIds))
+        .groupBy(modelConfigs.integrationId);
+      for (const r of aliasRows) {
+        if (r.integrationId) {
+          aliasCountByIntegration.set(r.integrationId, Number(r.count ?? 0));
+        }
+      }
+    }
+
     const out: IntegrationView[] = [];
 
     // Predefined first, in catalog order.
@@ -122,6 +159,8 @@ export class IntegrationsService {
         hasApiKey: !!row?.apiKeyEncrypted,
         isEnabled: row?.isEnabled ?? true, // default-on per UI mock
         isCustom: false,
+        openAICompatible: p.openAICompatible,
+        boundAliasCount: 0,
         stats: buildStats(p.id, p.defaultRateLimit),
         createdAt: row?.createdAt?.toISOString() ?? null,
         updatedAt: row?.updatedAt?.toISOString() ?? null,
@@ -146,6 +185,12 @@ export class IntegrationsService {
         hasApiKey: !!r.apiKeyEncrypted,
         isEnabled: r.isEnabled,
         isCustom: true,
+        // Custom URLs are presumed OpenAI-compatible — that's literally
+        // what the user signed up for by registering an OpenAI-style
+        // endpoint. (If it's not, the chat will fail at request time
+        // and the humanizer surfaces the error.)
+        openAICompatible: true,
+        boundAliasCount: aliasCountByIntegration.get(r.id) ?? 0,
         stats: buildStats('custom', 0),
         createdAt: r.createdAt.toISOString(),
         updatedAt: r.updatedAt.toISOString(),

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -20,9 +20,16 @@ import {
 } from './predefined-providers.js';
 
 interface IntegrationStats {
-  successRate: number; // 0..1
+  successRate: number; // 0..1 over last 30 days
+  /** Calls in the current calendar month. */
   apiCalls: number;
-  rateLimit: number;
+  /**
+   * Peak calls in any single day over the last 30 days. Empirical
+   * "burst" signal — replaces a hardcoded provider rate limit because
+   * neither OpenRouter nor the native APIs expose per-key quotas in a
+   * way we can read uniformly.
+   */
+  peakDailyCalls: number;
 }
 
 export interface IntegrationView {
@@ -99,9 +106,36 @@ export class IntegrationsService {
       )
       .groupBy(observabilityEvents.provider);
 
+    // Peak calls in a single day over the last 30 days, per provider.
+    // Two-step aggregate: count per (provider, day), then max over days.
+    const peakRows = await this.db.execute<{
+      provider: string;
+      peak: number;
+    }>(sql`
+      SELECT provider, MAX(daily_count)::int AS peak
+      FROM (
+        SELECT
+          ${observabilityEvents.provider} AS provider,
+          DATE_TRUNC('day', ${observabilityEvents.createdAt}) AS day,
+          COUNT(*) AS daily_count
+        FROM ${observabilityEvents}
+        WHERE
+          ${observabilityEvents.userId} = ${userId}
+          AND ${observabilityEvents.createdAt} >= ${since}
+          AND ${observabilityEvents.provider} IS NOT NULL
+        GROUP BY provider, day
+      ) AS daily
+      GROUP BY provider
+    `);
+
     const statsByProvider = new Map<
       string,
-      { successCount: number; totalCount: number; thisMonth: number }
+      {
+        successCount: number;
+        totalCount: number;
+        thisMonth: number;
+        peakDaily: number;
+      }
     >();
     for (const r of statsRows) {
       if (!r.provider) continue;
@@ -109,17 +143,34 @@ export class IntegrationsService {
         successCount: Number(r.successCount ?? 0),
         totalCount: Number(r.totalCount ?? 0),
         thisMonth: Number(r.thisMonth ?? 0),
+        peakDaily: 0,
       });
     }
+    // peakRows shape varies by drizzle adapter; the typed fields above
+    // are what we expect, but the runtime row may have lowercase keys.
+    const peakRowList = (peakRows as { rows?: unknown[] }).rows ?? peakRows;
+    if (Array.isArray(peakRowList)) {
+      for (const r of peakRowList as { provider: string; peak: number }[]) {
+        if (!r.provider) continue;
+        const existing = statsByProvider.get(r.provider) ?? {
+          successCount: 0,
+          totalCount: 0,
+          thisMonth: 0,
+          peakDaily: 0,
+        };
+        existing.peakDaily = Number(r.peak ?? 0);
+        statsByProvider.set(r.provider, existing);
+      }
+    }
 
-    const buildStats = (providerId: string, rateLimit: number): IntegrationStats => {
+    const buildStats = (providerId: string): IntegrationStats => {
       const s = statsByProvider.get(providerId);
       const successRate =
         s && s.totalCount > 0 ? s.successCount / s.totalCount : 0;
       return {
         successRate,
         apiCalls: s?.thisMonth ?? 0,
-        rateLimit,
+        peakDailyCalls: s?.peakDaily ?? 0,
       };
     };
 
@@ -166,7 +217,7 @@ export class IntegrationsService {
         openAICompatible: p.openAICompatible,
         byokSupported: p.byokSupported,
         boundAliasCount: 0,
-        stats: buildStats(p.id, p.defaultRateLimit),
+        stats: buildStats(p.id),
         createdAt: row?.createdAt?.toISOString() ?? null,
         updatedAt: row?.updatedAt?.toISOString() ?? null,
       });
@@ -197,7 +248,7 @@ export class IntegrationsService {
         openAICompatible: true,
         byokSupported: true,
         boundAliasCount: aliasCountByIntegration.get(r.id) ?? 0,
-        stats: buildStats('custom', 0),
+        stats: buildStats('custom'),
         createdAt: r.createdAt.toISOString(),
         updatedAt: r.updatedAt.toISOString(),
       });

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -36,13 +36,17 @@ export interface IntegrationView {
   isEnabled: boolean;
   isCustom: boolean;
   /**
-   * Whether the provider's native API can be hit through the OpenAI SDK.
-   * `false` for Anthropic, Google, Qwen — BYOK key is stored but chat
-   * still routes through OpenRouter; FE uses this to show a disclaimer.
-   * Always true for "custom" rows (the user picked the URL, presumed
-   * OpenAI-compatible).
+   * Whether the provider's native API speaks OpenAI Chat Completions
+   * verbatim. Factual flag.
    */
   openAICompatible: boolean;
+  /**
+   * Whether we can honour a BYOK key end-to-end (OpenAI SDK against the
+   * native baseURL, or a dedicated SDK shim like AnthropicClientService).
+   * FE uses this to decide whether to show the "key is stored but chat
+   * still routes through OpenRouter" disclaimer.
+   */
+  byokSupported: boolean;
   /**
    * For custom rows only: how many model_configs aliases reference this
    * integration. Drives the "delete will unlink N aliases" warning.
@@ -160,6 +164,7 @@ export class IntegrationsService {
         isEnabled: row?.isEnabled ?? true, // default-on per UI mock
         isCustom: false,
         openAICompatible: p.openAICompatible,
+        byokSupported: p.byokSupported,
         boundAliasCount: 0,
         stats: buildStats(p.id, p.defaultRateLimit),
         createdAt: row?.createdAt?.toISOString() ?? null,
@@ -190,6 +195,7 @@ export class IntegrationsService {
         // endpoint. (If it's not, the chat will fail at request time
         // and the humanizer surfaces the error.)
         openAICompatible: true,
+        byokSupported: true,
         boundAliasCount: aliasCountByIntegration.get(r.id) ?? 0,
         stats: buildStats('custom', 0),
         createdAt: r.createdAt.toISOString(),

--- a/apps/api/src/integrations/native-endpoints.ts
+++ b/apps/api/src/integrations/native-endpoints.ts
@@ -17,7 +17,22 @@
  */
 export interface NativeEndpoint {
   baseURL: string;
+  /** True when the native API speaks OpenAI Chat Completions verbatim. */
   openAICompatible: boolean;
+  /**
+   * True when we have a dedicated SDK shim for this provider's
+   * non-OpenAI-compatible API. Currently only "anthropic" via
+   * AnthropicClientService — chat-transport.service routes those calls
+   * to a separate transportKind that the chat layer recognises.
+   */
+  nativeSdkAvailable?: boolean;
+}
+
+/** True when we can honour a BYOK key for this provider end-to-end. */
+export function isByokSupported(providerId: string): boolean {
+  const ep = NATIVE_ENDPOINTS[providerId];
+  if (!ep) return false;
+  return ep.openAICompatible || ep.nativeSdkAvailable === true;
 }
 
 export const NATIVE_ENDPOINTS: Record<string, NativeEndpoint> = {
@@ -50,6 +65,7 @@ export const NATIVE_ENDPOINTS: Record<string, NativeEndpoint> = {
   anthropic: {
     baseURL: "https://api.anthropic.com/v1",
     openAICompatible: false,
+    nativeSdkAvailable: true,
   },
   google: {
     baseURL: "https://generativelanguage.googleapis.com/v1beta",

--- a/apps/api/src/integrations/native-endpoints.ts
+++ b/apps/api/src/integrations/native-endpoints.ts
@@ -1,0 +1,75 @@
+/**
+ * Map of provider id → native API endpoint metadata.
+ *
+ * Used by the chat resolver when a user has a BYOK key set for that
+ * provider in `integrations`: instead of routing through OpenRouter we
+ * point the OpenAI SDK at the native baseURL with the user's own key.
+ *
+ * `openAICompatible: false` means the provider's native API doesn't
+ * speak the OpenAI Chat Completions wire format, so the OpenAI SDK
+ * can't talk to it directly — for those, BYOK keys are stored but the
+ * chat path keeps falling back to OpenRouter (with a logged hint).
+ * Lifting that limitation needs either the provider's own SDK or
+ * OpenRouter's "Bring Your Own Provider Key" registration flow.
+ *
+ * Provider ids must match `predefined-providers.ts` and
+ * `observability_events.provider`.
+ */
+export interface NativeEndpoint {
+  baseURL: string;
+  openAICompatible: boolean;
+}
+
+export const NATIVE_ENDPOINTS: Record<string, NativeEndpoint> = {
+  openai: {
+    baseURL: "https://api.openai.com/v1",
+    openAICompatible: true,
+  },
+  deepseek: {
+    baseURL: "https://api.deepseek.com/v1",
+    openAICompatible: true,
+  },
+  mistralai: {
+    baseURL: "https://api.mistral.ai/v1",
+    openAICompatible: true,
+  },
+  perplexity: {
+    baseURL: "https://api.perplexity.ai",
+    openAICompatible: true,
+  },
+  "x-ai": {
+    baseURL: "https://api.x.ai/v1",
+    openAICompatible: true,
+  },
+  github: {
+    baseURL: "https://models.inference.ai.azure.com",
+    openAICompatible: true,
+  },
+  // Stored but not honored as direct BYOK — non-OpenAI-compatible.
+  // Falls through to OpenRouter routing.
+  anthropic: {
+    baseURL: "https://api.anthropic.com/v1",
+    openAICompatible: false,
+  },
+  google: {
+    baseURL: "https://generativelanguage.googleapis.com/v1beta",
+    openAICompatible: false,
+  },
+  qwen: {
+    baseURL: "https://dashscope.aliyuncs.com/api/v1",
+    openAICompatible: false,
+  },
+};
+
+/**
+ * Extract the provider id from an OpenRouter-style model identifier.
+ * "anthropic/claude-opus-4.7" → "anthropic"
+ * "openai/gpt-5.5" → "openai"
+ * Returns null when the identifier has no slash (e.g. a custom model id
+ * that lives at a Custom LLM endpoint).
+ */
+export function providerOfModel(modelId: string): string | null {
+  const idx = modelId.indexOf("/");
+  if (idx === -1) return null;
+  return modelId.slice(0, idx);
+}

--- a/apps/api/src/integrations/predefined-providers.ts
+++ b/apps/api/src/integrations/predefined-providers.ts
@@ -12,7 +12,7 @@
  * lower-case strings, ideally matching the OpenRouter provider slug so
  * we can correlate with `observability_events.provider` for stats.
  */
-import { NATIVE_ENDPOINTS } from './native-endpoints.js';
+import { NATIVE_ENDPOINTS, isByokSupported } from './native-endpoints.js';
 
 export interface PredefinedProvider {
   id: string;
@@ -30,16 +30,23 @@ export interface PredefinedProvider {
    */
   defaultRateLimit: number;
   /**
-   * Whether the provider's native API speaks OpenAI Chat Completions.
-   * When false, BYOK keys for this provider are stored but the chat
-   * path keeps falling back to OpenRouter — the FE shows a disclaimer
-   * in the Settings dialog so the user knows their key is dormant.
-   * Derived at module load time from NATIVE_ENDPOINTS.
+   * Whether the provider's native API speaks OpenAI Chat Completions
+   * verbatim. Factual flag — never changes per-deploy.
    */
   openAICompatible: boolean;
+  /**
+   * Whether we can honour a BYOK key end-to-end (either via OpenAI SDK
+   * with a custom baseURL, or via a native SDK shim). When false, the
+   * key is stored but chat falls back to OpenRouter and the Settings
+   * dialog shows a disclaimer.
+   */
+  byokSupported: boolean;
 }
 
-const PROVIDERS_RAW: Omit<PredefinedProvider, 'openAICompatible'>[] = [
+const PROVIDERS_RAW: Omit<
+  PredefinedProvider,
+  'openAICompatible' | 'byokSupported'
+>[] = [
   {
     id: 'google',
     displayName: 'Gemini',
@@ -109,6 +116,7 @@ export const PREDEFINED_PROVIDERS: PredefinedProvider[] = PROVIDERS_RAW.map(
   (p) => ({
     ...p,
     openAICompatible: NATIVE_ENDPOINTS[p.id]?.openAICompatible ?? false,
+    byokSupported: isByokSupported(p.id),
   }),
 );
 

--- a/apps/api/src/integrations/predefined-providers.ts
+++ b/apps/api/src/integrations/predefined-providers.ts
@@ -12,6 +12,8 @@
  * lower-case strings, ideally matching the OpenRouter provider slug so
  * we can correlate with `observability_events.provider` for stats.
  */
+import { NATIVE_ENDPOINTS } from './native-endpoints.js';
+
 export interface PredefinedProvider {
   id: string;
   displayName: string;
@@ -27,73 +29,88 @@ export interface PredefinedProvider {
    * expose a real per-key quota we can read.
    */
   defaultRateLimit: number;
+  /**
+   * Whether the provider's native API speaks OpenAI Chat Completions.
+   * When false, BYOK keys for this provider are stored but the chat
+   * path keeps falling back to OpenRouter — the FE shows a disclaimer
+   * in the Settings dialog so the user knows their key is dormant.
+   * Derived at module load time from NATIVE_ENDPOINTS.
+   */
+  openAICompatible: boolean;
 }
 
-export const PREDEFINED_PROVIDERS: PredefinedProvider[] = [
+const PROVIDERS_RAW: Omit<PredefinedProvider, 'openAICompatible'>[] = [
   {
-    id: "google",
-    displayName: "Gemini",
+    id: 'google',
+    displayName: 'Gemini',
     description: "Google's flagship models — Gemini Pro, Flash.",
-    iconHint: "gemini",
+    iconHint: 'gemini',
     defaultRateLimit: 4000,
   },
   {
-    id: "openai",
-    displayName: "Chat GPT",
+    id: 'openai',
+    displayName: 'Chat GPT',
     description: "OpenAI's GPT family — GPT-4, GPT-5, mini variants.",
-    iconHint: "chatgpt",
+    iconHint: 'chatgpt',
     defaultRateLimit: 4000,
   },
   {
-    id: "deepseek",
-    displayName: "Deepseek",
-    description: "Deepseek V4 family — fast and inexpensive.",
-    iconHint: "deepseek",
+    id: 'deepseek',
+    displayName: 'Deepseek',
+    description: 'Deepseek V4 family — fast and inexpensive.',
+    iconHint: 'deepseek',
     defaultRateLimit: 2000,
   },
   {
-    id: "mistralai",
-    displayName: "Mistral",
-    description: "Mistral / Codestral / Mixtral open-weight family.",
-    iconHint: "mistral",
+    id: 'mistralai',
+    displayName: 'Mistral',
+    description: 'Mistral / Codestral / Mixtral open-weight family.',
+    iconHint: 'mistral',
     defaultRateLimit: 3000,
   },
   {
-    id: "anthropic",
-    displayName: "Claude",
+    id: 'anthropic',
+    displayName: 'Claude',
     description: "Anthropic's Claude — Sonnet, Opus, Haiku.",
-    iconHint: "claude",
+    iconHint: 'claude',
     defaultRateLimit: 5000,
   },
   {
-    id: "perplexity",
-    displayName: "Preplexity",
-    description: "Perplexity Sonar — search-augmented chat.",
-    iconHint: "perplexity",
+    id: 'perplexity',
+    displayName: 'Preplexity',
+    description: 'Perplexity Sonar — search-augmented chat.',
+    iconHint: 'perplexity',
     defaultRateLimit: 1000,
   },
   {
-    id: "qwen",
-    displayName: "Qwen",
-    description: "Alibaba Qwen 3 family — open-weight strong code support.",
-    iconHint: "qwen",
+    id: 'qwen',
+    displayName: 'Qwen',
+    description: 'Alibaba Qwen 3 family — open-weight strong code support.',
+    iconHint: 'qwen',
     defaultRateLimit: 2000,
   },
   {
-    id: "github",
-    displayName: "Copilot",
-    description: "GitHub Copilot models for code-heavy workflows.",
-    iconHint: "copilot",
+    id: 'github',
+    displayName: 'Copilot',
+    description: 'GitHub Copilot models for code-heavy workflows.',
+    iconHint: 'copilot',
     defaultRateLimit: 4000,
   },
   {
-    id: "x-ai",
-    displayName: "Grok",
+    id: 'x-ai',
+    displayName: 'Grok',
     description: "xAI's Grok models.",
-    iconHint: "grok",
+    iconHint: 'grok',
     defaultRateLimit: 1500,
   },
 ];
+
+export const PREDEFINED_PROVIDERS: PredefinedProvider[] = PROVIDERS_RAW.map(
+  (p) => ({
+    ...p,
+    openAICompatible: NATIVE_ENDPOINTS[p.id]?.openAICompatible ?? false,
+  }),
+);
 
 export function isPredefinedProvider(id: string): boolean {
   return PREDEFINED_PROVIDERS.some((p) => p.id === id);

--- a/apps/api/src/integrations/predefined-providers.ts
+++ b/apps/api/src/integrations/predefined-providers.ts
@@ -1,0 +1,100 @@
+/**
+ * Catalog of predefined LLM providers exposed in Management → Integration.
+ *
+ * Each entry is the canonical list of every provider the UI cards can
+ * show. Order is preserved when surfacing the grid to the FE. Keep this
+ * file the single source of truth — the FE fetches it via
+ * GET /integrations/providers and renders cards from the response, so a
+ * new provider only needs an entry here (and a matching icon component
+ * on the FE side).
+ *
+ * `id` is what we store in `integrations.provider_id`. Use stable
+ * lower-case strings, ideally matching the OpenRouter provider slug so
+ * we can correlate with `observability_events.provider` for stats.
+ */
+export interface PredefinedProvider {
+  id: string;
+  displayName: string;
+  description: string;
+  /**
+   * Hint for the FE icon mapping. Identifier the FE switches on to pick
+   * the right SVG component.
+   */
+  iconHint: string;
+  /**
+   * Static rate-limit number shown on the settings dialog (requests/day).
+   * Not enforced — display only — until OpenRouter / native providers
+   * expose a real per-key quota we can read.
+   */
+  defaultRateLimit: number;
+}
+
+export const PREDEFINED_PROVIDERS: PredefinedProvider[] = [
+  {
+    id: "google",
+    displayName: "Gemini",
+    description: "Google's flagship models — Gemini Pro, Flash.",
+    iconHint: "gemini",
+    defaultRateLimit: 4000,
+  },
+  {
+    id: "openai",
+    displayName: "Chat GPT",
+    description: "OpenAI's GPT family — GPT-4, GPT-5, mini variants.",
+    iconHint: "chatgpt",
+    defaultRateLimit: 4000,
+  },
+  {
+    id: "deepseek",
+    displayName: "Deepseek",
+    description: "Deepseek V4 family — fast and inexpensive.",
+    iconHint: "deepseek",
+    defaultRateLimit: 2000,
+  },
+  {
+    id: "mistralai",
+    displayName: "Mistral",
+    description: "Mistral / Codestral / Mixtral open-weight family.",
+    iconHint: "mistral",
+    defaultRateLimit: 3000,
+  },
+  {
+    id: "anthropic",
+    displayName: "Claude",
+    description: "Anthropic's Claude — Sonnet, Opus, Haiku.",
+    iconHint: "claude",
+    defaultRateLimit: 5000,
+  },
+  {
+    id: "perplexity",
+    displayName: "Preplexity",
+    description: "Perplexity Sonar — search-augmented chat.",
+    iconHint: "perplexity",
+    defaultRateLimit: 1000,
+  },
+  {
+    id: "qwen",
+    displayName: "Qwen",
+    description: "Alibaba Qwen 3 family — open-weight strong code support.",
+    iconHint: "qwen",
+    defaultRateLimit: 2000,
+  },
+  {
+    id: "github",
+    displayName: "Copilot",
+    description: "GitHub Copilot models for code-heavy workflows.",
+    iconHint: "copilot",
+    defaultRateLimit: 4000,
+  },
+  {
+    id: "x-ai",
+    displayName: "Grok",
+    description: "xAI's Grok models.",
+    iconHint: "grok",
+    defaultRateLimit: 1500,
+  },
+];
+
+export function isPredefinedProvider(id: string): boolean {
+  return PREDEFINED_PROVIDERS.some((p) => p.id === id);
+}

--- a/apps/api/src/integrations/predefined-providers.ts
+++ b/apps/api/src/integrations/predefined-providers.ts
@@ -24,12 +24,6 @@ export interface PredefinedProvider {
    */
   iconHint: string;
   /**
-   * Static rate-limit number shown on the settings dialog (requests/day).
-   * Not enforced — display only — until OpenRouter / native providers
-   * expose a real per-key quota we can read.
-   */
-  defaultRateLimit: number;
-  /**
    * Whether the provider's native API speaks OpenAI Chat Completions
    * verbatim. Factual flag — never changes per-deploy.
    */
@@ -52,63 +46,54 @@ const PROVIDERS_RAW: Omit<
     displayName: 'Gemini',
     description: "Google's flagship models — Gemini Pro, Flash.",
     iconHint: 'gemini',
-    defaultRateLimit: 4000,
   },
   {
     id: 'openai',
     displayName: 'Chat GPT',
     description: "OpenAI's GPT family — GPT-4, GPT-5, mini variants.",
     iconHint: 'chatgpt',
-    defaultRateLimit: 4000,
   },
   {
     id: 'deepseek',
     displayName: 'Deepseek',
     description: 'Deepseek V4 family — fast and inexpensive.',
     iconHint: 'deepseek',
-    defaultRateLimit: 2000,
   },
   {
     id: 'mistralai',
     displayName: 'Mistral',
     description: 'Mistral / Codestral / Mixtral open-weight family.',
     iconHint: 'mistral',
-    defaultRateLimit: 3000,
   },
   {
     id: 'anthropic',
     displayName: 'Claude',
     description: "Anthropic's Claude — Sonnet, Opus, Haiku.",
     iconHint: 'claude',
-    defaultRateLimit: 5000,
   },
   {
     id: 'perplexity',
     displayName: 'Preplexity',
     description: 'Perplexity Sonar — search-augmented chat.',
     iconHint: 'perplexity',
-    defaultRateLimit: 1000,
   },
   {
     id: 'qwen',
     displayName: 'Qwen',
     description: 'Alibaba Qwen 3 family — open-weight strong code support.',
     iconHint: 'qwen',
-    defaultRateLimit: 2000,
   },
   {
     id: 'github',
     displayName: 'Copilot',
     description: 'GitHub Copilot models for code-heavy workflows.',
     iconHint: 'copilot',
-    defaultRateLimit: 4000,
   },
   {
     id: 'x-ai',
     displayName: 'Grok',
     description: "xAI's Grok models.",
     iconHint: 'grok',
-    defaultRateLimit: 1500,
   },
 ];
 

--- a/apps/api/src/models/models.controller.ts
+++ b/apps/api/src/models/models.controller.ts
@@ -87,6 +87,7 @@ export class ModelsController {
       customName: string;
       modelIdentifier: string;
       fallbackModels?: string[];
+      integrationId?: string | null;
     },
     @CurrentUser() user: AuthenticatedUser,
   ) {
@@ -102,6 +103,7 @@ export class ModelsController {
       modelIdentifier?: string;
       isActive?: boolean;
       fallbackModels?: string[];
+      integrationId?: string | null;
     },
     @CurrentUser() user: AuthenticatedUser,
   ) {

--- a/apps/api/src/models/models.controller.ts
+++ b/apps/api/src/models/models.controller.ts
@@ -35,6 +35,16 @@ export class ModelsController {
   }
 
   /**
+   * Per-user effective model list for FE pickers (arena / project chat).
+   * Combines the user's own model_configs aliases with any catalog
+   * model for a provider where the user has an enabled BYOK key.
+   */
+  @Get('effective')
+  effective(@CurrentUser() user: AuthenticatedUser) {
+    return this.modelsService.listEffectiveForUser(user.id);
+  }
+
+  /**
    * Admin: toggle a single model. The identifier travels in the body
    * (not the path) because OpenRouter model ids contain a slash, e.g.
    * "openai/gpt-4o", and Express + path-to-regexp 8 can't carry that

--- a/apps/api/src/models/models.module.ts
+++ b/apps/api/src/models/models.module.ts
@@ -6,6 +6,6 @@ import { OpenRouterCatalogService } from './openrouter-catalog.service.js';
 @Module({
   controllers: [ModelsController],
   providers: [ModelsService, OpenRouterCatalogService],
-  exports: [ModelsService],
+  exports: [ModelsService, OpenRouterCatalogService],
 })
 export class ModelsModule {}

--- a/apps/api/src/models/models.service.ts
+++ b/apps/api/src/models/models.service.ts
@@ -4,13 +4,40 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { eq, inArray } from 'drizzle-orm';
-import { enabledModels, modelConfigs, users } from '@worken/database/schema';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import {
+  enabledModels,
+  integrations,
+  modelConfigs,
+  users,
+} from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import {
   OpenRouterCatalogService,
   type CatalogModel,
 } from './openrouter-catalog.service.js';
+
+/**
+ * What a model picker (arena, project chat, …) should show for a user.
+ * Aliases first (preserve their custom name), then any catalog model
+ * for a provider where the user has an enabled BYOK key — those are
+ * implicitly unlocked because chat-transport routes them through the
+ * user's own provider account.
+ */
+export interface EffectiveModel {
+  id: string;
+  name: string;
+  /** "alias" = backed by a model_configs row; "byok" = unlocked via a
+   *  BYOK key on the model's provider; "custom" = bound to a Custom LLM
+   *  integration (alias with integrationId set). */
+  source: 'alias' | 'byok' | 'custom';
+  /** Set when source === "alias" or "custom". Lets the FE deep-link to
+   *  Models tab edit. */
+  aliasId?: string;
+  description?: string;
+  context_length?: number;
+  pricing?: { prompt?: string; completion?: string };
+}
 
 export interface CatalogEntry extends CatalogModel {
   enabled: boolean;
@@ -26,6 +53,82 @@ export class ModelsService {
 
   async findAll() {
     return this.db.select().from(modelConfigs);
+  }
+
+  /**
+   * Models the FE should surface in pickers (arena, project create, …)
+   * for a given user.
+   *
+   *  - Active model_configs aliases (one entry each, custom name as label).
+   *  - Plus every catalog model whose provider has an enabled BYOK row
+   *    with an api key in `integrations`. The user has explicitly opted
+   *    in to using their own provider account for that whole vendor;
+   *    surfacing the full catalog there saves them from manually
+   *    aliasing every model they want to try.
+   *
+   * Aliases dedupe over catalog entries on the same modelIdentifier —
+   * the user's custom name and (if present) Custom LLM binding take
+   * precedence.
+   */
+  async listEffectiveForUser(userId: string): Promise<EffectiveModel[]> {
+    const aliasRows = await this.db
+      .select()
+      .from(modelConfigs)
+      .where(
+        and(eq(modelConfigs.ownerId, userId), eq(modelConfigs.isActive, true)),
+      );
+
+    const byokRows = await this.db
+      .select({ providerId: integrations.providerId })
+      .from(integrations)
+      .where(
+        and(
+          eq(integrations.ownerId, userId),
+          eq(integrations.isEnabled, true),
+          isNotNull(integrations.apiKeyEncrypted),
+        ),
+      );
+    const byokProviders = new Set(
+      byokRows
+        .map((r) => r.providerId)
+        .filter((id) => id !== 'custom'), // custom routes via aliases, not provider lookup
+    );
+
+    const out: EffectiveModel[] = [];
+    const seen = new Set<string>();
+
+    for (const a of aliasRows) {
+      if (seen.has(a.modelIdentifier)) continue;
+      seen.add(a.modelIdentifier);
+      out.push({
+        id: a.modelIdentifier,
+        name: a.customName,
+        source: a.integrationId ? 'custom' : 'alias',
+        aliasId: a.id,
+      });
+    }
+
+    if (byokProviders.size > 0) {
+      const catalog = await this.catalogService.list();
+      for (const m of catalog) {
+        if (seen.has(m.id)) continue;
+        const slash = m.id.indexOf('/');
+        if (slash === -1) continue;
+        const provider = m.id.slice(0, slash);
+        if (!byokProviders.has(provider)) continue;
+        seen.add(m.id);
+        out.push({
+          id: m.id,
+          name: m.name,
+          source: 'byok',
+          description: m.description,
+          context_length: m.context_length,
+          pricing: m.pricing,
+        });
+      }
+    }
+
+    return out;
   }
 
   /**

--- a/apps/api/src/models/models.service.ts
+++ b/apps/api/src/models/models.service.ts
@@ -156,6 +156,7 @@ export class ModelsService {
       customName: string;
       modelIdentifier: string;
       fallbackModels?: string[];
+      integrationId?: string | null;
     },
   ) {
     const [model] = await this.db
@@ -165,6 +166,7 @@ export class ModelsService {
         customName: data.customName,
         modelIdentifier: data.modelIdentifier,
         fallbackModels: data.fallbackModels ?? [],
+        integrationId: data.integrationId ?? null,
       })
       .returning();
 
@@ -179,6 +181,7 @@ export class ModelsService {
       modelIdentifier?: string;
       isActive?: boolean;
       fallbackModels?: string[];
+      integrationId?: string | null;
     },
   ) {
     const [model] = await this.db
@@ -198,6 +201,8 @@ export class ModelsService {
     if (data.isActive !== undefined) updates.isActive = data.isActive;
     if (data.fallbackModels !== undefined)
       updates.fallbackModels = data.fallbackModels;
+    if (data.integrationId !== undefined)
+      updates.integrationId = data.integrationId;
 
     if (Object.keys(updates).length === 0) return model;
 

--- a/apps/api/src/models/openrouter-catalog.service.ts
+++ b/apps/api/src/models/openrouter-catalog.service.ts
@@ -58,4 +58,30 @@ export class OpenRouterCatalogService {
     await this.redis.del(CACHE_KEY);
     return this.list();
   }
+
+  /**
+   * Estimate USD cost of a chat call from the catalog's per-token
+   * pricing. Returns null when the model isn't in the catalog or has
+   * no pricing data — caller should leave costUsd null and not show a
+   * misleading zero on the dashboard.
+   *
+   * Used for BYOK / Custom routes where the upstream response doesn't
+   * include cost (only OpenRouter does), so observability would
+   * otherwise undercount spend.
+   */
+  async estimateCost(
+    modelId: string,
+    promptTokens: number,
+    completionTokens: number,
+  ): Promise<number | null> {
+    const catalog = await this.list();
+    const model = catalog.find((m) => m.id === modelId);
+    if (!model?.pricing) return null;
+    const promptPrice = Number(model.pricing.prompt ?? 0);
+    const completionPrice = Number(model.pricing.completion ?? 0);
+    if (!Number.isFinite(promptPrice) || !Number.isFinite(completionPrice)) {
+      return null;
+    }
+    return promptTokens * promptPrice + completionTokens * completionPrice;
+  }
 }

--- a/apps/api/src/openrouter/encryption.service.ts
+++ b/apps/api/src/openrouter/encryption.service.ts
@@ -2,43 +2,131 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 
+/**
+ * AES-256-GCM symmetric encryption for at-rest secrets (OpenRouter
+ * keys, BYOK provider keys, …).
+ *
+ * Ciphertext format (versioned):
+ *   v1:<iv-hex>:<ciphertext-hex>:<authTag-hex>
+ *
+ * The version prefix lets us rotate the master key without rewriting
+ * every column on the spot:
+ *   - v1: encrypted with OPENROUTER_ENCRYPTION_KEY (current)
+ *   - legacy (no prefix): encrypted with OPENROUTER_ENCRYPTION_KEY_PREVIOUS
+ *     OR with the current key if no previous is set (first migration
+ *     to the versioned scheme)
+ *
+ * To rotate:
+ *   1. Set OPENROUTER_ENCRYPTION_KEY_PREVIOUS = old key, set
+ *      OPENROUTER_ENCRYPTION_KEY = new key, restart.
+ *   2. Decrypt still works for both v1 (new) and legacy (old) ciphertexts.
+ *   3. Run the re-encrypt migration to lift legacy rows to v1 with the
+ *      new key (packages/database/backfill/reencrypt-legacy-secrets.ts).
+ *   4. Once migration completes, drop OPENROUTER_ENCRYPTION_KEY_PREVIOUS.
+ *
+ * Future bumps (v2, v3) can layer on the same prefix logic.
+ */
 @Injectable()
 export class EncryptionService implements OnModuleInit {
-  private key!: Buffer;
+  private currentKey!: Buffer;
+  private previousKey: Buffer | null = null;
 
   constructor(private readonly configService: ConfigService) {}
 
   onModuleInit() {
-    const hex = this.configService.get<string>('OPENROUTER_ENCRYPTION_KEY');
+    this.currentKey = this.requireKey('OPENROUTER_ENCRYPTION_KEY');
+    const prevHex = this.configService.get<string>(
+      'OPENROUTER_ENCRYPTION_KEY_PREVIOUS',
+    );
+    if (prevHex) {
+      if (prevHex.length !== 64) {
+        throw new Error(
+          'OPENROUTER_ENCRYPTION_KEY_PREVIOUS must be exactly 64 hex characters (32 bytes)',
+        );
+      }
+      this.previousKey = Buffer.from(prevHex, 'hex');
+    }
+  }
+
+  private requireKey(envName: string): Buffer {
+    const hex = this.configService.get<string>(envName);
     if (!hex || hex.length !== 64) {
       throw new Error(
-        'OPENROUTER_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes)',
+        `${envName} must be exactly 64 hex characters (32 bytes)`,
       );
     }
-    this.key = Buffer.from(hex, 'hex');
+    return Buffer.from(hex, 'hex');
   }
 
   encrypt(plaintext: string): string {
     const iv = randomBytes(12);
-    const cipher = createCipheriv('aes-256-gcm', this.key, iv);
+    const cipher = createCipheriv('aes-256-gcm', this.currentKey, iv);
     const encrypted = Buffer.concat([
       cipher.update(plaintext, 'utf8'),
       cipher.final(),
     ]);
     const authTag = cipher.getAuthTag();
     return [
+      'v1',
       iv.toString('hex'),
       encrypted.toString('hex'),
       authTag.toString('hex'),
     ].join(':');
   }
 
+  /**
+   * Whether `stored` is in the legacy (pre-versioned) format. Used by the
+   * re-encryption migration to find rows that need lifting to v1.
+   */
+  static isLegacy(stored: string): boolean {
+    return !stored.startsWith('v1:') && !stored.startsWith('v2:');
+  }
+
   decrypt(stored: string): string {
-    const [ivHex, ciphertextHex, authTagHex] = stored.split(':');
+    const parts = stored.split(':');
+
+    // v1:<iv>:<ct>:<authTag>
+    if (parts[0] === 'v1' && parts.length === 4) {
+      return this.decryptWithKey(this.currentKey, parts[1], parts[2], parts[3]);
+    }
+
+    // Legacy (no version prefix): <iv>:<ct>:<authTag>
+    if (parts.length === 3) {
+      // Prefer previous key if rotation is in progress; fall back to
+      // current (covers the common case where rotation hasn't happened).
+      const keyToTry = this.previousKey ?? this.currentKey;
+      try {
+        return this.decryptWithKey(keyToTry, parts[0], parts[1], parts[2]);
+      } catch (err) {
+        // If we tried previous and it failed, also try current — covers
+        // rotation periods where some rows are already on the new key.
+        if (this.previousKey) {
+          return this.decryptWithKey(
+            this.currentKey,
+            parts[0],
+            parts[1],
+            parts[2],
+          );
+        }
+        throw err;
+      }
+    }
+
+    throw new Error(
+      `Unknown ciphertext format (parts: ${parts.length}, prefix: ${parts[0]})`,
+    );
+  }
+
+  private decryptWithKey(
+    key: Buffer,
+    ivHex: string,
+    ciphertextHex: string,
+    authTagHex: string,
+  ): string {
     const iv = Buffer.from(ivHex, 'hex');
     const ciphertext = Buffer.from(ciphertextHex, 'hex');
     const authTag = Buffer.from(authTagHex, 'hex');
-    const decipher = createDecipheriv('aes-256-gcm', this.key, iv);
+    const decipher = createDecipheriv('aes-256-gcm', key, iv);
     decipher.setAuthTag(authTag);
     return Buffer.concat([
       decipher.update(ciphertext),

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -436,7 +436,21 @@ export default function CompareModelsPage() {
             )}
 
             {(loading || hasResults) && (
-              <div className="flex flex-wrap gap-4">
+              // Up to 3 cards per row, each 1/3 of the available width.
+              // 4th+ wrap to the next row at the same 1/3 width — so a
+              // single comparison never silently widens its cards just
+              // because the row is half-empty. With 1 or 2 cards we
+              // still cap columns at the active count so they fill the
+              // row evenly (full / half).
+              <div
+                className="grid gap-4"
+                style={{
+                  gridTemplateColumns: `repeat(${Math.min(
+                    Math.max(activeModels.length, 1),
+                    3,
+                  )}, minmax(0, 1fr))`,
+                }}
+              >
                 {activeModels.map((id) => (
                   <ResponseCard
                     key={id}
@@ -634,7 +648,7 @@ function ResponseCard({
   const provider = getModelProvider(modelId);
 
   return (
-    <article className="flex min-w-0 flex-1 basis-[320px] flex-col gap-2.5 rounded bg-bg-1 p-4">
+    <article className="flex min-w-0 flex-col gap-2.5 rounded bg-bg-1 p-4">
       {/* Header */}
       <header className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">

--- a/apps/web/src/components/add-model-dialog.tsx
+++ b/apps/web/src/components/add-model-dialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { GripVertical, MoreVertical, Trash2, ArrowUp, ArrowDown } from "lucide-react";
-import { createModel } from "@/lib/api";
+import { createModel, fetchIntegrations } from "@/lib/api";
 import { SettingsDialog } from "@/components/settings-dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -142,9 +142,21 @@ export function AddModelDialog({
   const [modelId, setModelId] = useState("");
   const [fallbacks, setFallbacks] = useState<string[]>([]);
   const [fallbackToAdd, setFallbackToAdd] = useState("");
+  const [integrationId, setIntegrationId] = useState<string>("");
   const queryClient = useQueryClient();
   const { models, isLoading: modelsLoading, getLabel: getModelLabel } =
     useAvailableModels();
+
+  // Custom LLMs the user has registered in Management → Integration.
+  // Listed as an optional binding so an alias can route to a self-hosted
+  // or BYOK endpoint instead of OpenRouter.
+  const { data: integrations } = useQuery({
+    queryKey: ["integrations"],
+    queryFn: fetchIntegrations,
+    enabled: open,
+  });
+  const customIntegrations =
+    integrations?.filter((i) => i.isCustom && i.isEnabled) ?? [];
 
   const mutation = useMutation({
     mutationFn: createModel,
@@ -153,6 +165,7 @@ export function AddModelDialog({
       setCustomName("Model 1");
       setModelId("");
       setFallbacks([]);
+      setIntegrationId("");
       setOpen(false);
     },
   });
@@ -206,6 +219,7 @@ export function AddModelDialog({
       customName: customName.trim(),
       modelIdentifier: modelId,
       fallbackModels: fallbacks,
+      integrationId: integrationId || null,
     });
   };
 
@@ -281,6 +295,47 @@ export function AddModelDialog({
                 className={`${inputClass} outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50`}
               />
             </div>
+
+            {/* Optional: bind to a Custom LLM endpoint registered in
+                Management → Integration. Hidden when the user has none —
+                it's an opt-in advanced setting that only matters for
+                self-hosted / BYOK endpoints. */}
+            {customIntegrations.length > 0 && (
+              <div>
+                <p className="text-[14px] font-normal leading-[20px] text-text-2 mb-2">
+                  Custom LLM endpoint{" "}
+                  <span className="text-text-3">(optional)</span>
+                </p>
+                <Select
+                  value={integrationId || "__none__"}
+                  onValueChange={(v) =>
+                    setIntegrationId(v === "__none__" ? "" : v)
+                  }
+                >
+                  <SelectTrigger className={modelSelectClass}>
+                    <SelectValue placeholder="OpenRouter (default)" />
+                  </SelectTrigger>
+                  <SelectContent className="p-0">
+                    <SelectItem value="__none__" className={selectItemClass}>
+                      OpenRouter (default)
+                    </SelectItem>
+                    {customIntegrations.map((i) => (
+                      <SelectItem
+                        key={i.id ?? i.providerId}
+                        value={i.id ?? ""}
+                        className={selectItemClass}
+                      >
+                        {i.displayName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-[12px] text-text-3">
+                  When set, chat calls for this alias route to the selected
+                  Custom LLM endpoint instead of OpenRouter.
+                </p>
+              </div>
+            )}
 
             {/* Fallback models */}
             <div>

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -201,12 +201,12 @@ function ProviderSettingsDialog({
           </div>
           <div>
             <p className="text-[16px] font-normal text-text-1 mb-0.5">
-              Rate limit:
+              Peak / day:
             </p>
             <p className="text-[18px] font-bold text-text-1">
-              {card.stats.rateLimit.toLocaleString()}
+              {card.stats.peakDailyCalls.toLocaleString()}
               <span className="text-[13px] font-normal text-text-3 ml-2">
-                requests/day
+                calls (30d max)
               </span>
             </p>
           </div>

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -212,17 +212,17 @@ function ProviderSettingsDialog({
           </div>
         </div>
 
-        {/* WorkenAI default note */}
+        {/* WorkenAI default note. Plain div on purpose — using a
+            textarea/input here gave it scroll behavior the moment the
+            text didn't fit, which we never want. The block now grows
+            to fit whatever copy lands in it. */}
         <div>
           <p className="text-[14px] font-normal leading-[20px] text-text-2 mb-1.5">
             Use WORKENAI API
           </p>
-          <textarea
-            readOnly
-            className="w-full rounded-lg bg-bg-3 px-[17px] py-[13px] text-[16px] leading-[24px] text-text-1 resize-none outline-none"
-            rows={1}
-            defaultValue="Additional costs on the WorkenAI subscription will be added."
-          />
+          <div className="w-full rounded-lg bg-bg-3 px-[17px] py-[13px] text-[15px] leading-[22px] text-text-1">
+            Additional costs on the WorkenAI subscription will be added.
+          </div>
         </div>
 
         {/* Own API key */}

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { AlertTriangle, BookOpen, Info, Loader2, Plus, Trash2 } from "lucide-react";
+import {
+  AlertTriangle,
+  BookOpen,
+  Check,
+  Info,
+  KeyRound,
+  Loader2,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -96,6 +105,10 @@ function ProviderSettingsDialog({
   const [useOwnKey, setUseOwnKey] = useState(card.hasApiKey);
   const [apiKey, setApiKey] = useState("");
   const [enabled, setEnabled] = useState(card.isEnabled);
+  // Editing mode: when a key is already saved, show a status panel by
+  // default and only reveal the input on explicit "Replace key" click.
+  // Avoids the user typing over an already-good key by accident.
+  const [editingKey, setEditingKey] = useState(!card.hasApiKey);
 
   const saveMutation = useMutation({
     mutationFn: async () => {
@@ -104,7 +117,14 @@ function ProviderSettingsDialog({
       if (card.id) {
         return updateIntegration(card.id, {
           isEnabled: enabled,
-          apiKey: useOwnKey ? (apiKey || undefined) : null,
+          // Only send apiKey when user is actually replacing it. Sending
+          // `undefined` means "leave existing key alone" (BE PATCH skips
+          // it). Sending null = explicit clear.
+          apiKey: !useOwnKey
+            ? null
+            : editingKey && apiKey
+              ? apiKey
+              : undefined,
         });
       }
       return upsertIntegration({
@@ -115,7 +135,11 @@ function ProviderSettingsDialog({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["integrations"] });
-      toast.success(`${card.displayName} settings saved.`);
+      toast.success(
+        editingKey && apiKey && useOwnKey
+          ? `${card.displayName} key saved.`
+          : `${card.displayName} settings saved.`,
+      );
       onClose();
     },
     onError: (err: Error) => {
@@ -207,25 +231,85 @@ function ProviderSettingsDialog({
             <input
               type="checkbox"
               checked={useOwnKey}
-              onChange={(e) => setUseOwnKey(e.target.checked)}
+              onChange={(e) => {
+                setUseOwnKey(e.target.checked);
+                // Toggling off and back on resets the editor — keeps
+                // the "key already saved" path visible until the user
+                // explicitly clicks Replace.
+                if (!e.target.checked) {
+                  setEditingKey(true);
+                  setApiKey("");
+                } else {
+                  setEditingKey(!card.hasApiKey);
+                }
+              }}
               className="h-3.5 w-3.5 rounded-[5px] border border-border-4 accent-success-7 cursor-pointer"
             />
             <span className="text-[14px] font-normal leading-[20px] text-text-2">
               Use your own API KEY
             </span>
           </label>
-          {useOwnKey && (
-            <input
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder={
-                card.hasApiKey
-                  ? "Enter a new key to replace the saved one"
-                  : "Enter your API key"
-              }
-              className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[16px] leading-[24px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
-            />
+
+          {useOwnKey && card.hasApiKey && !editingKey && (
+            // Status panel: the user has a key saved already. Show a
+            // clear "configured" state with masked dots, plus actions
+            // to replace or remove. Without this, after clicking
+            // Apply the dialog just closes and there's no visible
+            // signal that the key persisted.
+            <div className="flex items-center gap-3 rounded-lg border border-success-3 bg-success-1/40 px-4 py-3">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-success-7 text-white">
+                <Check className="h-4 w-4" strokeWidth={2.5} />
+              </span>
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="text-[13px] font-semibold text-success-7">
+                  API key configured
+                </span>
+                <span className="flex items-center gap-1.5 text-[13px] text-text-2">
+                  <KeyRound className="h-3.5 w-3.5 text-text-3" />
+                  <span className="font-mono tracking-wide">
+                    ••••••••••••••••
+                  </span>
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingKey(true);
+                  setApiKey("");
+                }}
+                className="text-[13px] font-medium text-primary-6 hover:underline"
+              >
+                Replace
+              </button>
+            </div>
+          )}
+
+          {useOwnKey && (editingKey || !card.hasApiKey) && (
+            <>
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={
+                  card.hasApiKey
+                    ? "Enter a new key to replace the saved one"
+                    : "Enter your API key"
+                }
+                className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[16px] leading-[24px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
+              />
+              {card.hasApiKey && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingKey(false);
+                    setApiKey("");
+                  }}
+                  className="text-[13px] text-text-3 hover:underline"
+                >
+                  Cancel — keep the saved key
+                </button>
+              )}
+            </>
           )}
         </div>
 
@@ -460,8 +544,21 @@ export function IntegrationTab() {
                 />
               </div>
 
+              {/* Persistent BYOK indicator: a small "Key set" pill so
+                  the user sees the saved state without opening the
+                  Settings dialog. */}
+              {card.hasApiKey && (
+                <span
+                  className="mt-2 inline-flex w-fit items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[11px] font-medium text-success-7"
+                  title="Your own API key is saved for this provider"
+                >
+                  <Check className="h-3 w-3" strokeWidth={2.5} />
+                  Key set
+                </span>
+              )}
+
               {/* Description */}
-              <p className="mt-3 text-[14px] font-normal text-text-2 line-clamp-2">
+              <p className="mt-2 text-[14px] font-normal text-text-2 line-clamp-2">
                 {card.description}
               </p>
 

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { BookOpen, Loader2, Plus, Trash2 } from "lucide-react";
+import { AlertTriangle, BookOpen, Info, Loader2, Plus, Trash2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -124,6 +124,7 @@ function ProviderSettingsDialog({
   });
 
   const successRatePct = (card.stats.successRate * 100).toFixed(1);
+  const showCompatibilityNotice = !card.openAICompatible && !card.isCustom;
 
   return (
     <SettingsDialog
@@ -138,6 +139,22 @@ function ProviderSettingsDialog({
       }
     >
       <div className="space-y-5">
+        {/* Compatibility disclaimer for non-OpenAI-compatible providers
+            (Anthropic, Google, Qwen). The BYOK key is saved but chat
+            calls keep going through OpenRouter for now — surface that
+            so the user knows their key is dormant. */}
+        {showCompatibilityNotice && (
+          <div className="flex items-start gap-2 rounded-lg border border-warning-3 bg-warning-1/40 px-3 py-2">
+            <Info className="h-4 w-4 shrink-0 text-warning-7 mt-0.5" />
+            <p className="text-[13px] text-warning-7 leading-snug">
+              {card.displayName}&rsquo;s native API isn&rsquo;t OpenAI-compatible
+              yet, so a BYOK key here is stored but chat calls still route
+              through OpenRouter. We&rsquo;ll honor it directly once native
+              support lands.
+            </p>
+          </div>
+        )}
+
         {/* Stats row */}
         <div className="flex items-start gap-8">
           <div>
@@ -275,6 +292,56 @@ function AddCustomLLMDialog({ onClose }: { onClose: () => void }) {
   );
 }
 
+/* ─── Delete-with-bound-aliases warning ────────────────────────────── */
+
+function DeleteCustomLLMDialog({
+  card,
+  onClose,
+  onConfirm,
+  isPending,
+}: {
+  card: IntegrationCard;
+  onClose: () => void;
+  onConfirm: () => void;
+  isPending: boolean;
+}) {
+  const n = card.boundAliasCount;
+  return (
+    <SettingsDialog
+      open
+      onClose={onClose}
+      onApply={onConfirm}
+      applyLabel={isPending ? "Deleting…" : n > 0 ? "Delete anyway" : "Delete"}
+      applyVariant="danger"
+      title={`Delete "${card.displayName}"?`}
+    >
+      <div className="space-y-3">
+        {n > 0 ? (
+          <div className="flex items-start gap-2 rounded-lg border border-danger-3 bg-danger-1/40 px-3 py-2">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-danger-6 mt-0.5" />
+            <p className="text-[13px] text-danger-6 leading-snug">
+              <strong>{n}</strong> model alias{n === 1 ? "" : "es"} currently
+              route to this Custom LLM. Deleting it will{" "}
+              <strong>unlink them</strong> — those aliases will fall back to
+              the default routing (OpenRouter), which will likely fail until
+              you point them at another endpoint or remove them.
+            </p>
+          </div>
+        ) : (
+          <p className="text-[14px] text-text-2">
+            This Custom LLM has no aliases bound to it. Removing it now is
+            safe.
+          </p>
+        )}
+        <p className="text-[13px] text-text-3">
+          The action cannot be undone. The endpoint URL and any saved API
+          key are deleted from this workspace.
+        </p>
+      </div>
+    </SettingsDialog>
+  );
+}
+
 /* ─── Main tab ──────────────────────────────────────────────────────── */
 
 export function IntegrationTab() {
@@ -282,6 +349,9 @@ export function IntegrationTab() {
   const [search, setSearch] = useState("");
   const [selected, setSelected] = useState<IntegrationCard | null>(null);
   const [showAddDialog, setShowAddDialog] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<IntegrationCard | null>(
+    null,
+  );
 
   const {
     data: cards,
@@ -315,7 +385,12 @@ export function IntegrationTab() {
     mutationFn: (id: string) => deleteIntegration(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["integrations"] });
+      // Aliases that were bound to this integration just had their
+      // integrationId set to null at the DB level — refresh Models tab
+      // so the badge disappears immediately.
+      queryClient.invalidateQueries({ queryKey: ["models"] });
       toast.success("Custom LLM removed.");
+      setPendingDelete(null);
     },
     onError: (err: Error) => {
       toast.error(err.message ?? "Couldn't delete.");
@@ -393,17 +468,18 @@ export function IntegrationTab() {
                     type="button"
                     onClick={(e) => {
                       e.stopPropagation();
-                      if (
-                        confirm(`Delete custom LLM "${card.displayName}"?`)
-                      ) {
-                        deleteCustomMutation.mutate(card.id!);
-                      }
+                      setPendingDelete(card);
                     }}
                     className="text-[13px] text-danger-6 hover:underline inline-flex items-center gap-1"
                     title="Delete custom LLM"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
                     Delete
+                    {card.boundAliasCount > 0 && (
+                      <span className="ml-1 rounded-full bg-danger-1 px-1.5 py-0 text-[10px] font-medium text-danger-6">
+                        {card.boundAliasCount}
+                      </span>
+                    )}
                   </button>
                 ) : (
                   <span />
@@ -434,6 +510,16 @@ export function IntegrationTab() {
       {/* Add custom LLM dialog */}
       {showAddDialog && (
         <AddCustomLLMDialog onClose={() => setShowAddDialog(false)} />
+      )}
+
+      {/* Delete-with-warning dialog (custom LLMs only) */}
+      {pendingDelete && pendingDelete.id && (
+        <DeleteCustomLLMDialog
+          card={pendingDelete}
+          onClose={() => setPendingDelete(null)}
+          onConfirm={() => deleteCustomMutation.mutate(pendingDelete.id!)}
+          isPending={deleteCustomMutation.isPending}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -124,7 +124,11 @@ function ProviderSettingsDialog({
   });
 
   const successRatePct = (card.stats.successRate * 100).toFixed(1);
-  const showCompatibilityNotice = !card.openAICompatible && !card.isCustom;
+  // Disclaimer fires when the provider can't honor BYOK end-to-end.
+  // openAICompatible=false alone doesn't cut it any more — Anthropic
+  // is non-compatible but routes through its native SDK, so the key
+  // IS honored. byokSupported is the right flag to gate on.
+  const showCompatibilityNotice = !card.byokSupported && !card.isCustom;
 
   return (
     <SettingsDialog

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -1,22 +1,28 @@
 "use client";
 
 import { useState } from "react";
-import { BookOpen, Plus } from "lucide-react";
+import { BookOpen, Loader2, Plus, Trash2 } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { Switch } from "@/components/ui/switch";
 import { SettingsDialog } from "@/components/settings-dialog";
+import {
+  deleteIntegration,
+  fetchIntegrations,
+  updateIntegration,
+  upsertIntegration,
+  type IntegrationCard,
+} from "@/lib/api";
 
-interface LLMProvider {
-  id: string;
-  name: string;
-  description: string;
-  enabled: boolean;
-  icon: React.ReactNode;
-  successRate: number;
-  apiCalls: number;
-  rateLimit: number;
-}
+/* ─── Icons ──────────────────────────────────────────────────────────────
+ *
+ * The brand SVGs live in the FE because they're visual assets, not data.
+ * Each predefined provider in the BE catalog carries an `iconHint` string
+ * (e.g. "gemini", "openai") that we switch on here. Custom LLMs and
+ * unknown hints get a neutral fallback.
+ */
 
 function GeminiIcon() {
   return (
@@ -51,69 +57,126 @@ function BrandIcon({ color, letter }: { color: string; letter: string }) {
   );
 }
 
-const INITIAL_PROVIDERS: LLMProvider[] = [
-  { id: "gemini", name: "Gemini", description: "Short text describing this", enabled: true, icon: <GeminiIcon />, successRate: 98.5, apiCalls: 3456, rateLimit: 4000 },
-  { id: "chatgpt", name: "Chat GPT", description: "Short text describing this", enabled: false, icon: <BrandIcon color="#10a37f" letter="G" />, successRate: 97.2, apiCalls: 1200, rateLimit: 4000 },
-  { id: "deepseek", name: "Deepseek", description: "Short text describing this", enabled: true, icon: <BrandIcon color="#1a73e8" letter="D" />, successRate: 95.1, apiCalls: 800, rateLimit: 2000 },
-  { id: "mistral", name: "Mistral", description: "Short text describing this", enabled: false, icon: <BrandIcon color="#f7931e" letter="M" />, successRate: 96.8, apiCalls: 540, rateLimit: 3000 },
-  { id: "claude", name: "Claude", description: "Short text describing this", enabled: false, icon: <BrandIcon color="#d97706" letter="C" />, successRate: 99.1, apiCalls: 2100, rateLimit: 5000 },
-  { id: "preplexity", name: "Preplexity", description: "Short text describing this", enabled: false, icon: <BrandIcon color="#20b2aa" letter="P" />, successRate: 94.3, apiCalls: 320, rateLimit: 1000 },
-  { id: "qwen", name: "Qwen", description: "Short text describing this", enabled: true, icon: <BrandIcon color="#7c3aed" letter="Q" />, successRate: 93.7, apiCalls: 670, rateLimit: 2000 },
-  { id: "copilot", name: "Copilot", description: "Short text describing this", enabled: false, icon: <BrandIcon color="#0078d4" letter="Co" />, successRate: 97.9, apiCalls: 1890, rateLimit: 4000 },
-  { id: "grok", name: "Grok", description: "Short text describing this", enabled: true, icon: <BrandIcon color="#1a1a1a" letter="X" />, successRate: 96.0, apiCalls: 430, rateLimit: 1500 },
-];
+function iconForHint(hint: string): React.ReactNode {
+  switch (hint) {
+    case "gemini":
+      return <GeminiIcon />;
+    case "chatgpt":
+      return <BrandIcon color="#10a37f" letter="G" />;
+    case "deepseek":
+      return <BrandIcon color="#1a73e8" letter="D" />;
+    case "mistral":
+      return <BrandIcon color="#f7931e" letter="M" />;
+    case "claude":
+      return <BrandIcon color="#d97706" letter="C" />;
+    case "perplexity":
+      return <BrandIcon color="#20b2aa" letter="P" />;
+    case "qwen":
+      return <BrandIcon color="#7c3aed" letter="Q" />;
+    case "copilot":
+      return <BrandIcon color="#0078d4" letter="Co" />;
+    case "grok":
+      return <BrandIcon color="#1a1a1a" letter="X" />;
+    case "custom":
+    default:
+      return <BrandIcon color="#64748b" letter="·" />;
+  }
+}
+
+/* ─── Provider Settings (BYOK) dialog ───────────────────────────────── */
 
 function ProviderSettingsDialog({
-  provider,
+  card,
   onClose,
-  onToggle,
 }: {
-  provider: LLMProvider;
+  card: IntegrationCard;
   onClose: () => void;
-  onToggle: () => void;
 }) {
-  const [useOwnKey, setUseOwnKey] = useState(false);
+  const queryClient = useQueryClient();
+  const [useOwnKey, setUseOwnKey] = useState(card.hasApiKey);
   const [apiKey, setApiKey] = useState("");
+  const [enabled, setEnabled] = useState(card.isEnabled);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      // Card has no DB row yet (untouched predefined): create on first save.
+      // Otherwise patch the existing one.
+      if (card.id) {
+        return updateIntegration(card.id, {
+          isEnabled: enabled,
+          apiKey: useOwnKey ? (apiKey || undefined) : null,
+        });
+      }
+      return upsertIntegration({
+        providerId: card.providerId,
+        apiKey: useOwnKey && apiKey ? apiKey : undefined,
+        isEnabled: enabled,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
+      toast.success(`${card.displayName} settings saved.`);
+      onClose();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message ?? "Couldn't save settings.");
+    },
+  });
+
+  const successRatePct = (card.stats.successRate * 100).toFixed(1);
 
   return (
     <SettingsDialog
       open
       onClose={onClose}
-      title={provider.name}
-      description={`Configure ${provider.name} integration settings.`}
-      headerIcon={provider.icon}
+      onApply={() => saveMutation.mutate()}
+      title={card.displayName}
+      description={`Configure ${card.displayName} integration settings.`}
+      headerIcon={iconForHint(card.iconHint)}
       headerContent={
-        <Switch checked={provider.enabled} onCheckedChange={onToggle} />
+        <Switch checked={enabled} onCheckedChange={setEnabled} />
       }
     >
       <div className="space-y-5">
         {/* Stats row */}
         <div className="flex items-start gap-8">
           <div>
-            <p className="text-[16px] font-normal text-text-1 mb-0.5">Success rate:</p>
-            <p className="text-[18px] font-bold text-text-1">{provider.successRate}%</p>
+            <p className="text-[16px] font-normal text-text-1 mb-0.5">
+              Success rate:
+            </p>
+            <p className="text-[18px] font-bold text-text-1">{successRatePct}%</p>
           </div>
           <div>
-            <p className="text-[16px] font-normal text-text-1 mb-0.5">API calls:</p>
-            <p className="text-[18px] font-bold text-text-1">{provider.apiCalls}</p>
-          </div>
-          <div>
-            <p className="text-[16px] font-normal text-text-1 mb-0.5">Rate limit:</p>
+            <p className="text-[16px] font-normal text-text-1 mb-0.5">
+              API calls:
+            </p>
             <p className="text-[18px] font-bold text-text-1">
-              {provider.rateLimit}
-              <span className="text-[13px] font-normal text-text-3 ml-2">requests/day</span>
+              {card.stats.apiCalls.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <p className="text-[16px] font-normal text-text-1 mb-0.5">
+              Rate limit:
+            </p>
+            <p className="text-[18px] font-bold text-text-1">
+              {card.stats.rateLimit.toLocaleString()}
+              <span className="text-[13px] font-normal text-text-3 ml-2">
+                requests/day
+              </span>
             </p>
           </div>
         </div>
 
-        {/* WorkenAI API */}
+        {/* WorkenAI default note */}
         <div>
-          <p className="text-[14px] font-normal leading-[20px] text-text-2 mb-1.5">Use WORKENAI API</p>
+          <p className="text-[14px] font-normal leading-[20px] text-text-2 mb-1.5">
+            Use WORKENAI API
+          </p>
           <textarea
             readOnly
             className="w-full rounded-lg bg-bg-3 px-[17px] py-[13px] text-[16px] leading-[24px] text-text-1 resize-none outline-none"
             rows={1}
-            defaultValue="additional costs on his WorkenAI subscription will be added"
+            defaultValue="Additional costs on the WorkenAI subscription will be added."
           />
         </div>
 
@@ -126,52 +189,84 @@ function ProviderSettingsDialog({
               onChange={(e) => setUseOwnKey(e.target.checked)}
               className="h-3.5 w-3.5 rounded-[5px] border border-border-4 accent-success-7 cursor-pointer"
             />
-            <span className="text-[14px] font-normal leading-[20px] text-text-2">Use your own API KEY</span>
+            <span className="text-[14px] font-normal leading-[20px] text-text-2">
+              Use your own API KEY
+            </span>
           </label>
           {useOwnKey && (
             <input
-              type="text"
+              type="password"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
-              placeholder="Enter your API key"
+              placeholder={
+                card.hasApiKey
+                  ? "Enter a new key to replace the saved one"
+                  : "Enter your API key"
+              }
               className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[16px] leading-[24px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
-            />
-          )}
-          {!useOwnKey && (
-            <input
-              type="text"
-              readOnly
-              value="12er1te2r1sa3df1ó5a5s1fd5ad5as"
-              className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[16px] leading-[24px] text-text-1 outline-none"
             />
           )}
         </div>
 
         <p className="text-[16px] font-normal leading-[24px] text-text-1">
-          API calls will incur a small Technology fee
+          API calls will incur a small Technology fee.
         </p>
       </div>
     </SettingsDialog>
   );
 }
 
+/* ─── Add Custom LLM dialog ─────────────────────────────────────────── */
+
 function AddCustomLLMDialog({ onClose }: { onClose: () => void }) {
-  const [apiLink, setApiLink] = useState("");
+  const [apiUrl, setApiUrl] = useState("");
+  const queryClient = useQueryClient();
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      upsertIntegration({
+        providerId: "custom",
+        apiUrl: apiUrl.trim(),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
+      toast.success("Custom LLM added.");
+      onClose();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message ?? "Couldn't add custom LLM.");
+    },
+  });
 
   return (
-    <SettingsDialog open onClose={onClose} title="Add Custom LLM">
+    <SettingsDialog
+      open
+      onClose={onClose}
+      onApply={() => createMutation.mutate()}
+      title="Add Custom LLM"
+    >
       <div className="space-y-4">
         <div>
           <p className="text-[14px] font-normal text-text-2 mb-1.5">API Link</p>
           <input
             type="text"
-            value={apiLink}
-            onChange={(e) => setApiLink(e.target.value)}
+            value={apiUrl}
+            onChange={(e) => setApiUrl(e.target.value)}
             placeholder="Put link here"
             className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[13px] text-text-1 placeholder:text-text-3 placeholder:text-[13px] placeholder:font-normal outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
           />
         </div>
-        <button className="inline-flex h-[48px] items-center gap-2 rounded-md border border-border-2 px-4 text-[16px] font-normal text-text-1 hover:bg-bg-1 transition-colors">
+        <button
+          type="button"
+          className="inline-flex h-[48px] items-center gap-2 rounded-md border border-border-2 px-4 text-[16px] font-normal text-text-1 hover:bg-bg-1 transition-colors"
+          onClick={() =>
+            window.open(
+              "https://openrouter.ai/docs/api-reference/overview",
+              "_blank",
+              "noopener,noreferrer",
+            )
+          }
+        >
           <BookOpen className="h-4 w-4 text-success-7" />
           Integration documentation
         </button>
@@ -180,23 +275,55 @@ function AddCustomLLMDialog({ onClose }: { onClose: () => void }) {
   );
 }
 
+/* ─── Main tab ──────────────────────────────────────────────────────── */
+
 export function IntegrationTab() {
+  const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
-  const [providers, setProviders] = useState<LLMProvider[]>(INITIAL_PROVIDERS);
-  const [selected, setSelected] = useState<LLMProvider | null>(null);
+  const [selected, setSelected] = useState<IntegrationCard | null>(null);
   const [showAddDialog, setShowAddDialog] = useState(false);
 
-  const toggle = (id: string) => {
-    setProviders((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, enabled: !p.enabled } : p)),
-    );
-    if (selected?.id === id) {
-      setSelected((prev) => (prev ? { ...prev, enabled: !prev.enabled } : null));
-    }
-  };
+  const {
+    data: cards,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["integrations"],
+    queryFn: fetchIntegrations,
+  });
 
-  const filtered = providers.filter((p) =>
-    p.name.toLowerCase().includes(search.toLowerCase()),
+  // Optimistic-ish toggle: PATCH and let React Query refetch.
+  const toggleMutation = useMutation({
+    mutationFn: ({ card, next }: { card: IntegrationCard; next: boolean }) => {
+      if (card.id) {
+        return updateIntegration(card.id, { isEnabled: next });
+      }
+      return upsertIntegration({
+        providerId: card.providerId,
+        isEnabled: next,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message ?? "Couldn't toggle integration.");
+    },
+  });
+
+  const deleteCustomMutation = useMutation({
+    mutationFn: (id: string) => deleteIntegration(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
+      toast.success("Custom LLM removed.");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message ?? "Couldn't delete.");
+    },
+  });
+
+  const filtered = (cards ?? []).filter((c) =>
+    c.displayName.toLowerCase().includes(search.toLowerCase()),
   );
 
   return (
@@ -215,50 +342,92 @@ export function IntegrationTab() {
         </Button>
       </div>
 
+      {/* Loading / error states */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-text-3" />
+        </div>
+      )}
+      {error && (
+        <div className="py-12 text-center text-sm text-danger-6">
+          Failed to load integrations. Is the API running?
+        </div>
+      )}
+
       {/* Grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {filtered.map((provider) => (
-          <div
-            key={provider.id}
-            className="flex flex-col rounded-[4px] border border-border-3 bg-bg-white p-5 h-[165px] cursor-pointer hover:border-border-4 transition-colors"
-            onClick={() => setSelected(provider)}
-          >
-            {/* Header: icon + name + toggle */}
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                {provider.icon}
-                <span className="text-[16px] font-normal text-text-1">{provider.name}</span>
+      {!isLoading && !error && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {filtered.map((card) => (
+            <div
+              key={`${card.providerId}-${card.id ?? "new"}`}
+              className="flex flex-col rounded-[4px] border border-border-3 bg-bg-white p-5 h-[165px] cursor-pointer hover:border-border-4 transition-colors"
+              onClick={() => setSelected(card)}
+            >
+              {/* Header: icon + name + toggle */}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 min-w-0">
+                  {iconForHint(card.iconHint)}
+                  <span className="truncate text-[16px] font-normal text-text-1">
+                    {card.displayName}
+                  </span>
+                </div>
+                <Switch
+                  checked={card.isEnabled}
+                  onCheckedChange={(next) =>
+                    toggleMutation.mutate({ card, next })
+                  }
+                  onClick={(e) => e.stopPropagation()}
+                  disabled={toggleMutation.isPending}
+                />
               </div>
-              <Switch
-                checked={provider.enabled}
-                onCheckedChange={() => toggle(provider.id)}
-                onClick={(e) => e.stopPropagation()}
-              />
+
+              {/* Description */}
+              <p className="mt-3 text-[14px] font-normal text-text-2 line-clamp-2">
+                {card.description}
+              </p>
+
+              {/* Footer: settings link + (custom only) delete */}
+              <div className="mt-auto flex items-center justify-between">
+                {card.isCustom && card.id ? (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (
+                        confirm(`Delete custom LLM "${card.displayName}"?`)
+                      ) {
+                        deleteCustomMutation.mutate(card.id!);
+                      }
+                    }}
+                    className="text-[13px] text-danger-6 hover:underline inline-flex items-center gap-1"
+                    title="Delete custom LLM"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Delete
+                  </button>
+                ) : (
+                  <span />
+                )}
+                <span className="text-[14px] font-normal text-text-3">
+                  Settings
+                </span>
+              </div>
             </div>
+          ))}
 
-            {/* Description */}
-            <p className="mt-3 text-[16px] font-normal text-text-2">{provider.description}</p>
-
-            {/* Settings link */}
-            <div className="mt-auto flex justify-end">
-              <span className="text-[14px] font-normal text-text-3">Settings</span>
+          {filtered.length === 0 && (
+            <div className="col-span-full py-12 text-center text-sm text-text-3">
+              No integrations match your search.
             </div>
-          </div>
-        ))}
-
-        {filtered.length === 0 && (
-          <div className="col-span-full py-12 text-center text-sm text-text-3">
-            No integrations match your search.
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
       {/* Provider settings dialog */}
       {selected && (
         <ProviderSettingsDialog
-          provider={providers.find((p) => p.id === selected.id) ?? selected}
+          card={selected}
           onClose={() => setSelected(null)}
-          onToggle={() => toggle(selected.id)}
         />
       )}
 

--- a/apps/web/src/components/management/model-row.tsx
+++ b/apps/web/src/components/management/model-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { MoreVertical, Eye, Trash2, Bot } from "lucide-react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { MoreVertical, Eye, Trash2, Bot, KeySquare, Globe } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -10,7 +10,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
-import { updateModel, deleteModel, type ModelConfig } from "@/lib/api";
+import {
+  deleteModel,
+  fetchIntegrations,
+  updateModel,
+  type ModelConfig,
+} from "@/lib/api";
+
+function providerOf(modelId: string): string | null {
+  const idx = modelId.indexOf("/");
+  return idx === -1 ? null : modelId.slice(0, idx);
+}
 
 export function ModelRow({ model }: { model: ModelConfig }) {
   const queryClient = useQueryClient();
@@ -30,6 +40,28 @@ export function ModelRow({ model }: { model: ModelConfig }) {
   });
 
   const fallbacks = (model.fallbackModels ?? []) as string[];
+
+  // Routing inference: if the alias is bound to a Custom LLM, show "Custom".
+  // If not but the user has a BYOK key for the model's provider, show "BYOK".
+  // The badge is a read-only hint; the actual routing happens BE-side in
+  // ChatTransportService.
+  const { data: integrations } = useQuery({
+    queryKey: ["integrations"],
+    queryFn: fetchIntegrations,
+    staleTime: 60 * 1000,
+  });
+
+  const customIntegration = model.integrationId
+    ? integrations?.find((i) => i.id === model.integrationId)
+    : null;
+
+  const provider = providerOf(model.modelIdentifier);
+  const byokIntegration =
+    !customIntegration && provider
+      ? integrations?.find(
+          (i) => i.providerId === provider && i.hasApiKey && i.isEnabled,
+        )
+      : null;
 
   return (
     <tr className="h-14 border-b border-bg-1 transition-colors hover:bg-bg-1/50">
@@ -57,6 +89,24 @@ export function ModelRow({ model }: { model: ModelConfig }) {
           <span className="text-base font-normal text-text-1">
             {model.modelIdentifier}
           </span>
+          {customIntegration && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-primary-1 px-2 py-0.5 text-[11px] font-medium text-primary-7"
+              title={`Routes to Custom LLM at ${customIntegration.apiUrl ?? "—"}`}
+            >
+              <Globe className="h-3 w-3" />
+              Custom
+            </span>
+          )}
+          {byokIntegration && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[11px] font-medium text-success-7"
+              title={`Routes through your ${byokIntegration.displayName} key (BYOK)`}
+            >
+              <KeySquare className="h-3 w-3" />
+              BYOK
+            </span>
+          )}
         </div>
       </td>
       {/* Fallback models */}

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -36,7 +36,7 @@ export function SettingsDialog({
 }: SettingsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
-      <DialogContent className="max-w-md p-0 gap-0 overflow-hidden" showCloseButton={false}>
+      <DialogContent className="max-w-xl p-0 gap-0 overflow-hidden" showCloseButton={false}>
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">
           {description ?? `${title} settings`}

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -13,6 +13,8 @@ interface SettingsDialogProps {
   open: boolean;
   onClose: () => void;
   onApply?: () => void;
+  applyLabel?: string;
+  applyVariant?: "default" | "danger";
   title: string;
   description?: string;
   headerIcon?: React.ReactNode;
@@ -24,6 +26,8 @@ export function SettingsDialog({
   open,
   onClose,
   onApply,
+  applyLabel = "Apply",
+  applyVariant = "default",
   title,
   description,
   headerIcon,
@@ -64,9 +68,13 @@ export function SettingsDialog({
           </Button>
           <Button
             onClick={onApply ?? onClose}
-            className="h-[43px] bg-primary-6 text-white text-[16px] font-normal hover:bg-primary-6/90"
+            className={
+              applyVariant === "danger"
+                ? "h-[43px] bg-danger-6 text-white text-[16px] font-normal hover:bg-danger-6/90"
+                : "h-[43px] bg-primary-6 text-white text-[16px] font-normal hover:bg-primary-6/90"
+            }
           >
-            Apply
+            {applyLabel}
           </Button>
         </div>
       </DialogContent>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1810,3 +1810,86 @@ export function fetchObservabilityGuardrailActivity(
     `/observability/guardrail-activity?range=${range}`,
   );
 }
+
+// ─── Integrations (Management → Integration) ──────────────────────────────
+
+export interface PredefinedProvider {
+  id: string;
+  displayName: string;
+  description: string;
+  iconHint: string;
+  defaultRateLimit: number;
+}
+
+export interface IntegrationCard {
+  id: string | null; // null when no DB row exists yet (untouched predefined)
+  providerId: string;
+  displayName: string;
+  description: string;
+  iconHint: string;
+  apiUrl: string | null;
+  hasApiKey: boolean;
+  isEnabled: boolean;
+  isCustom: boolean;
+  stats: {
+    successRate: number; // 0..1
+    apiCalls: number;
+    rateLimit: number;
+  };
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export async function fetchIntegrationProviders(): Promise<PredefinedProvider[]> {
+  const res = await apiFetch("/integrations/providers");
+  if (!res.ok) throw new Error("Failed to fetch provider catalog");
+  return res.json();
+}
+
+export async function fetchIntegrations(): Promise<IntegrationCard[]> {
+  const res = await apiFetch("/integrations");
+  if (!res.ok) throw new Error("Failed to fetch integrations");
+  return res.json();
+}
+
+export async function upsertIntegration(input: {
+  providerId: string;
+  apiUrl?: string;
+  apiKey?: string;
+  isEnabled?: boolean;
+}): Promise<IntegrationCard> {
+  const res = await apiFetch("/integrations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || "Failed to save integration");
+  }
+  return res.json();
+}
+
+export async function updateIntegration(
+  id: string,
+  input: { isEnabled?: boolean; apiKey?: string | null },
+): Promise<IntegrationCard> {
+  const res = await apiFetch(`/integrations/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || "Failed to update integration");
+  }
+  return res.json();
+}
+
+export async function deleteIntegration(id: string): Promise<void> {
+  const res = await apiFetch(`/integrations/${id}`, { method: "DELETE" });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || "Failed to delete integration");
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1863,9 +1863,11 @@ export interface IntegrationCard {
   /** For custom rows: how many model_configs aliases reference this integration. */
   boundAliasCount: number;
   stats: {
-    successRate: number; // 0..1
+    successRate: number; // 0..1 over last 30 days
+    /** Calls in the current calendar month. */
     apiCalls: number;
-    rateLimit: number;
+    /** Peak calls in any single day over the last 30 days. */
+    peakDailyCalls: number;
   };
   createdAt: string | null;
   updatedAt: string | null;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -796,6 +796,9 @@ export interface ModelConfig {
   modelIdentifier: string;
   isActive: boolean;
   fallbackModels: string[];
+  /** When set, chat calls for this alias route through the linked Custom
+   *  LLM integration instead of OpenRouter. */
+  integrationId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -863,6 +866,7 @@ export async function createModel(data: {
   customName: string;
   modelIdentifier: string;
   fallbackModels?: string[];
+  integrationId?: string | null;
 }): Promise<ModelConfig> {
   const res = await apiFetch("/models", {
     method: "POST",
@@ -880,6 +884,7 @@ export async function updateModel(
     modelIdentifier?: string;
     isActive?: boolean;
     fallbackModels?: string[];
+    integrationId?: string | null;
   },
 ): Promise<ModelConfig> {
   const res = await apiFetch(`/models/${id}`, {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1836,8 +1836,14 @@ export interface IntegrationCard {
   hasApiKey: boolean;
   isEnabled: boolean;
   isCustom: boolean;
-  /** When false, BYOK key is stored but chat still routes through OpenRouter. */
+  /** Whether the provider's native API speaks OpenAI Chat Completions. */
   openAICompatible: boolean;
+  /**
+   * Whether the BYOK key is honored end-to-end (OpenAI SDK or a native
+   * SDK shim like Anthropic's). When false the key is stored but chat
+   * still routes through OpenRouter — Settings dialog shows a disclaimer.
+   */
+  byokSupported: boolean;
   /** For custom rows: how many model_configs aliases reference this integration. */
   boundAliasCount: number;
   stats: {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1836,6 +1836,10 @@ export interface IntegrationCard {
   hasApiKey: boolean;
   isEnabled: boolean;
   isCustom: boolean;
+  /** When false, BYOK key is stored but chat still routes through OpenRouter. */
+  openAICompatible: boolean;
+  /** For custom rows: how many model_configs aliases reference this integration. */
+  boundAliasCount: number;
   stats: {
     successRate: number; // 0..1
     apiCalls: number;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -830,6 +830,22 @@ export async function fetchAvailableModels(): Promise<AvailableModel[]> {
   return res.json();
 }
 
+export interface EffectiveModel extends AvailableModel {
+  source: "alias" | "byok" | "custom";
+  aliasId?: string;
+}
+
+/**
+ * Per-user effective model list — drives the model pickers in the arena
+ * and project chat. Includes the user's model aliases (Models tab) plus
+ * any catalog model for a provider where the user has BYOK enabled.
+ */
+export async function fetchEffectiveModels(): Promise<EffectiveModel[]> {
+  const res = await apiFetch("/models/effective");
+  if (!res.ok) throw new Error("Failed to fetch effective models");
+  return res.json();
+}
+
 export async function fetchModelsCatalog(): Promise<CatalogModel[]> {
   const res = await apiFetch("/models/catalog");
   if (!res.ok) throw new Error("Failed to fetch models catalog");

--- a/apps/web/src/lib/chat-errors.ts
+++ b/apps/web/src/lib/chat-errors.ts
@@ -72,8 +72,15 @@ export function humanizeChatError(err: unknown): string {
     );
   }
 
+  // Custom LLM endpoint requires an API key but none was configured.
+  // BE annotates the message; pass it through verbatim so the user
+  // sees "Open Management → Integration → … and add your key."
+  if (/requires an API key/i.test(raw)) {
+    return raw;
+  }
+
   if (/\b401\b/.test(raw) || /invalid api key/i.test(raw) || /authentication/i.test(raw)) {
-    return "The OpenRouter key for this team is invalid. Please contact an admin.";
+    return "The API key for this provider is invalid. Open Management → Integration, click Settings on the provider card and update it.";
   }
 
   if (

--- a/apps/web/src/lib/hooks/use-user-models.ts
+++ b/apps/web/src/lib/hooks/use-user-models.ts
@@ -1,19 +1,27 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { fetchModels, type AvailableModel } from "@/lib/api";
+import { fetchEffectiveModels, type AvailableModel } from "@/lib/api";
 
-const STALE_TIME_MS = 60 * 1000; // 1 min — user can edit Models tab live
+const STALE_TIME_MS = 60 * 1000; // 1 min — list moves when user edits Models or Integration tabs
 
 /**
- * The user's active model_configs aliases, exposed in the same shape as
- * useAvailableModels() so consumers can swap one for the other.
+ * Effective model list for the current user — used by the arena, the
+ * project pickers, and anything else that lets the user pick a model
+ * to chat with.
  *
- * Used by the Compare Models arena, where we only want to allow choosing
- * among models the user has explicitly added under Management → Models
- * (i.e. their custom aliases). Two aliases that point at the same upstream
- * modelIdentifier are deduped to the first one, since selectedModels in
- * the arena is keyed on upstream id.
+ * Sources (BE-merged via /models/effective):
+ *   - Active model_configs aliases (Models tab) — custom name preserved.
+ *   - Catalog models for any provider with an enabled BYOK key in
+ *     Integration tab — auto-unlocked, no per-model alias needed.
+ *
+ * Returns an empty list when the user has neither aliases nor BYOK
+ * keys; UI should treat that as a setup-required state (the arena
+ * already does — it gates on `< 2 models`).
+ *
+ * The hook keeps the same shape as useAvailableModels for drop-in
+ * compatibility — consumers that just need {id, name, getLabel} don't
+ * need to know about the new EffectiveModel.source field.
  */
 export function useUserModels(): {
   models: AvailableModel[];
@@ -22,23 +30,22 @@ export function useUserModels(): {
   getLabel: (id: string) => string;
 } {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["models", "user", "active"],
-    queryFn: fetchModels,
+    queryKey: ["models", "effective"],
+    queryFn: fetchEffectiveModels,
     staleTime: STALE_TIME_MS,
   });
 
   const all = data ?? [];
-  const seen = new Set<string>();
-  const models: AvailableModel[] = [];
-  for (const cfg of all) {
-    if (!cfg.isActive) continue;
-    if (seen.has(cfg.modelIdentifier)) continue;
-    seen.add(cfg.modelIdentifier);
-    models.push({
-      id: cfg.modelIdentifier,
-      name: cfg.customName,
-    });
-  }
+  // Strip the BE-only `source` / `aliasId` fields for callers that only
+  // know AvailableModel. Order is BE-controlled: aliases first, then
+  // BYOK catalog entries.
+  const models: AvailableModel[] = all.map((m) => ({
+    id: m.id,
+    name: m.name,
+    description: m.description,
+    context_length: m.context_length,
+    pricing: m.pricing,
+  }));
 
   const getLabel = (id: string) =>
     models.find((m) => m.id === id)?.name ?? id;

--- a/packages/database/backfill/reencrypt-legacy-secrets.ts
+++ b/packages/database/backfill/reencrypt-legacy-secrets.ts
@@ -1,0 +1,169 @@
+/**
+ * Encryption-key rotation migration.
+ *
+ * Walks every column we encrypt at rest and lifts rows still in the
+ * legacy (pre-versioned) ciphertext format to the v1 format under the
+ * current OPENROUTER_ENCRYPTION_KEY. Idempotent: rows already starting
+ * with `v1:` are skipped.
+ *
+ * Tables/columns covered:
+ *   users.openrouter_key_encrypted
+ *   teams.openrouter_key_encrypted
+ *   integrations.api_key_encrypted
+ *
+ * How to run (from repo root):
+ *   pnpm tsx packages/database/backfill/reencrypt-legacy-secrets.ts --dry-run
+ *   pnpm tsx packages/database/backfill/reencrypt-legacy-secrets.ts
+ *
+ * Required env (typically already in .env):
+ *   DATABASE_URL                    Postgres connection string
+ *   OPENROUTER_ENCRYPTION_KEY       64-hex current key (target)
+ *
+ * Optional env (only when rotating):
+ *   OPENROUTER_ENCRYPTION_KEY_PREVIOUS  64-hex old key — set when the
+ *                                       legacy rows were encrypted with
+ *                                       a different key than the current
+ *                                       one. Without this env, decrypt
+ *                                       falls back to the current key.
+ */
+import { Pool } from 'pg';
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from 'crypto';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  'postgresql://worken:worken@localhost:5432/worken';
+const CURRENT_KEY_HEX = process.env.OPENROUTER_ENCRYPTION_KEY;
+const PREVIOUS_KEY_HEX = process.env.OPENROUTER_ENCRYPTION_KEY_PREVIOUS;
+const DRY_RUN = process.argv.includes('--dry-run');
+
+if (!CURRENT_KEY_HEX || CURRENT_KEY_HEX.length !== 64) {
+  console.error(
+    'OPENROUTER_ENCRYPTION_KEY must be 64 hex characters. Aborting.',
+  );
+  process.exit(1);
+}
+
+const currentKey = Buffer.from(CURRENT_KEY_HEX, 'hex');
+const previousKey =
+  PREVIOUS_KEY_HEX && PREVIOUS_KEY_HEX.length === 64
+    ? Buffer.from(PREVIOUS_KEY_HEX, 'hex')
+    : null;
+
+function isLegacy(stored: string): boolean {
+  return !stored.startsWith('v1:') && !stored.startsWith('v2:');
+}
+
+function decryptLegacy(stored: string): string {
+  const [ivHex, ctHex, authTagHex] = stored.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const ct = Buffer.from(ctHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+  const tryWith = (key: Buffer): string => {
+    const d = createDecipheriv('aes-256-gcm', key, iv);
+    d.setAuthTag(authTag);
+    return Buffer.concat([d.update(ct), d.final()]).toString('utf8');
+  };
+  if (previousKey) {
+    try {
+      return tryWith(previousKey);
+    } catch {
+      return tryWith(currentKey);
+    }
+  }
+  return tryWith(currentKey);
+}
+
+function encryptV1(plain: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', currentKey, iv);
+  const ct = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [
+    'v1',
+    iv.toString('hex'),
+    ct.toString('hex'),
+    authTag.toString('hex'),
+  ].join(':');
+}
+
+interface Target {
+  table: string;
+  column: string;
+}
+
+const TARGETS: Target[] = [
+  { table: 'users', column: 'openrouter_key_encrypted' },
+  { table: 'teams', column: 'openrouter_key_encrypted' },
+  { table: 'integrations', column: 'api_key_encrypted' },
+];
+
+async function main(): Promise<void> {
+  const safeUrl = DATABASE_URL.replace(/:\/\/([^:]+):([^@]+)@/, '://$1:***@');
+  console.log(`DB:   ${safeUrl}`);
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN (no writes)' : 'LIVE'}`);
+  console.log(`Previous key set: ${previousKey ? 'yes' : 'no'}`);
+  console.log('');
+
+  const pool = new Pool({ connectionString: DATABASE_URL });
+
+  let totalUpdated = 0;
+  let totalSkipped = 0;
+  let totalFailed = 0;
+
+  for (const t of TARGETS) {
+    console.log(`── ${t.table}.${t.column} ──`);
+    const { rows } = await pool.query<{ id: string; value: string | null }>(
+      `SELECT id, ${t.column} AS value FROM ${t.table} WHERE ${t.column} IS NOT NULL`,
+    );
+    let updated = 0;
+    let skipped = 0;
+    let failed = 0;
+    for (const r of rows) {
+      if (!r.value) continue;
+      if (!isLegacy(r.value)) {
+        skipped++;
+        continue;
+      }
+      try {
+        const plain = decryptLegacy(r.value);
+        const v1 = encryptV1(plain);
+        if (!DRY_RUN) {
+          await pool.query(
+            `UPDATE ${t.table} SET ${t.column} = $1 WHERE id = $2`,
+            [v1, r.id],
+          );
+        }
+        updated++;
+        console.log(
+          `  ${DRY_RUN ? '[dry] would update' : '✓ updated'} ${t.table}/${r.id}`,
+        );
+      } catch (err) {
+        failed++;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`  ✗ ${t.table}/${r.id} decrypt failed: ${msg}`);
+      }
+    }
+    console.log(
+      `  → ${updated} updated, ${skipped} already v1, ${failed} failed\n`,
+    );
+    totalUpdated += updated;
+    totalSkipped += skipped;
+    totalFailed += failed;
+  }
+
+  console.log('');
+  console.log(
+    `Done: ${totalUpdated} re-encrypted, ${totalSkipped} skipped, ${totalFailed} failed.`,
+  );
+  await pool.end();
+  if (totalFailed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Migration crashed:', err);
+  process.exit(1);
+});

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   pgTable,
   text,
@@ -5,6 +6,7 @@ import {
   uuid,
   vector,
   index,
+  uniqueIndex,
   boolean,
   jsonb,
   integer,
@@ -387,15 +389,32 @@ export const enabledModels = pgTable("enabled_models", {
  * `apiKeyEncrypted` is the user's own key (BYOK). When null, calls fall
  * back to the workspace's WorkenAI / OpenRouter key.
  */
-export const integrations = pgTable("integrations", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  ownerId: uuid("owner_id")
-    .references(() => users.id, { onDelete: "cascade" })
-    .notNull(),
-  providerId: text("provider_id").notNull(),
-  apiUrl: text("api_url"),
-  apiKeyEncrypted: text("api_key_encrypted"),
-  isEnabled: boolean("is_enabled").notNull().default(true),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
+export const integrations = pgTable(
+  "integrations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ownerId: uuid("owner_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    providerId: text("provider_id").notNull(),
+    apiUrl: text("api_url"),
+    apiKeyEncrypted: text("api_key_encrypted"),
+    isEnabled: boolean("is_enabled").notNull().default(true),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    // Partial unique index: at most one row per (owner, predefined
+    // provider). Custom LLMs share `providerId='custom'` and need to
+    // stay non-unique (a user can register many custom endpoints), so
+    // the WHERE clause excludes them via `api_url IS NULL`.
+    //
+    // Without this, IntegrationsService.upsert (select-then-insert) is
+    // racy under concurrent saves and could land two predefined rows
+    // for the same provider; the BYOK lookup would then silently pick
+    // whichever the planner returns first.
+    uniqueIndex("integrations_owner_provider_predef_unique")
+      .on(table.ownerId, table.providerId)
+      .where(sql`${table.apiUrl} IS NULL`),
+  ],
+);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -359,3 +359,34 @@ export const enabledModels = pgTable("enabled_models", {
   }),
   enabledAt: timestamp("enabled_at").defaultNow().notNull(),
 });
+
+/**
+ * Per-user (BYOK) configuration for third-party LLM providers.
+ *
+ * Two flavors share this table:
+ *
+ *  - **Predefined providers** (Gemini, ChatGPT, Deepseek, Mistral, Claude,
+ *    Perplexity, Qwen, Copilot, Grok). The catalog of these lives as a
+ *    BE constant — see apps/api/src/integrations/predefined-providers.ts.
+ *    `apiUrl` is null for these (we use the provider's well-known endpoint
+ *    on the BE side). Unique on (ownerId, providerId).
+ *
+ *  - **Custom LLMs** — anything OpenAI-API-compatible the user runs
+ *    themselves (Ollama, vLLM, Together, Fireworks, …). `providerId`
+ *    is the literal string "custom"; `apiUrl` is required.
+ *
+ * `apiKeyEncrypted` is the user's own key (BYOK). When null, calls fall
+ * back to the workspace's WorkenAI / OpenRouter key.
+ */
+export const integrations = pgTable("integrations", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  ownerId: uuid("owner_id")
+    .references(() => users.id, { onDelete: "cascade" })
+    .notNull(),
+  providerId: text("provider_id").notNull(),
+  apiUrl: text("api_url"),
+  apiKeyEncrypted: text("api_key_encrypted"),
+  isEnabled: boolean("is_enabled").notNull().default(true),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -344,6 +344,15 @@ export const modelConfigs = pgTable("model_configs", {
   modelIdentifier: text("model_identifier").notNull(),
   isActive: boolean("is_active").notNull().default(true),
   fallbackModels: jsonb("fallback_models").notNull().default([]),
+  // When set, chat calls for this alias route through the linked
+  // integration (a Custom LLM the user registered in Management →
+  // Integration). When null, routing falls back to BYOK (if the user
+  // has a key for the alias's predefined provider) or OpenRouter.
+  // ON DELETE SET NULL so deleting a Custom LLM doesn't delete aliases
+  // pointing at it — they revert to OpenRouter routing.
+  integrationId: uuid("integration_id").references(() => integrations.id, {
+    onDelete: "set null",
+  }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9522,7 +9522,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -9549,7 +9549,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9564,13 +9564,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9585,7 +9585,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
 # Integration tab — provider toggles, BYOK, Custom LLM endpoints

 Wires Management → Integration end-to-end. Replaces a fully-mock placeholder (hardcoded providers, fake stats, toggles that didn't persist) with real persistence, real chat routing, and honest observability. 
  ## Schema

  - `integrations` table: per-user row keyed on (owner, providerId). Holds API URL (custom only), AES-encrypted BYOK key, enabled flag.
  - `model_configs.integrationId` (FK, ON DELETE SET NULL) — alias can bind to a specific Custom LLM endpoint.

  ## Backend

  - `GET /integrations/providers` — canonical catalog of 9 predefined providers (BE-driven; FE has no hardcoded list).
  - `GET /integrations` — user's cards with stats from `observability_events` (30-day success rate, current-month calls, **empirical peak/day** — no more fake "5,000 requests/day").
  - `GET /models/effective` — model picker source: user's aliases **plus** every catalog model from any provider with an enabled BYOK key.
  - `POST/PATCH/DELETE /integrations` — create custom, upsert BYOK on predefined, toggle, delete. Custom rows can be deleted (SET NULL on bound aliases); predefined rows can only be disabled.

  ## Chat routing

  New `ChatTransportService` resolves `(baseURL, apiKey, model, kind)` per call:

  1. **Custom LLM** — alias → integration's URL + key.
  2. **BYOK predefined**:
     - OpenAI-compatible (OpenAI, Deepseek, Mistral, Perplexity, x-AI, Copilot) → OpenAI SDK + native baseURL.
     - **Anthropic** → native `@anthropic-ai/sdk` shim (`AnthropicClientService`) — translates message format and dot→hyphen model ids (`claude-opus-4.7` → `claude-opus-4-7`).
     - Google / Qwen native APIs aren't OpenAI-compatible and have no SDK shim yet — keys stored, chat falls back to OpenRouter (Settings dialog disclaimer).
  3. **OpenRouter** — fallback.

  Compare-models resolves transport per model so one arena run can mix routes. Observability records `provider` and `metadata.routingSource: 'openrouter' | 'byok' | 'custom'`. BYOK / Custom calls without
  upstream cost are estimated from the cached OpenRouter catalog (`metadata.costEstimated: true`).

  ## Frontend

  - Integration tab rewritten on React Query. Settings dialog persists toggle + BYOK key.
  - **"Key set" pill** on cards + clear "API key configured" status panel in the dialog (Replace / Cancel-keep-key) so saved state is visible without opening Settings.
  - Add Custom LLM dialog (single API Link input) creates a card immediately.
  - Delete custom dialog warns about bound aliases (count + danger button).
  - Add Model dialog gets an optional "Custom LLM endpoint" select. Models tab rows show `Custom` / `BYOK` badges.
  - Disclaimer banner only on `!byokSupported` cards (Google / Qwen) — Anthropic now BYOK-supported.
  - Drive-by: arena response grid switched to `grid-cols-N` (N = min(active, 3)), so 3 models stay side-by-side at 1/3 width and the 4th wraps cleanly.
  - Drive-by: WorkenAI default note in Settings dialog is a plain `<div>` (was a `<textarea>` that grew a scrollbar); dialog widened to `max-w-xl`.

  ## Security

  - `EncryptionService` ciphertext is now versioned: `v1:<iv>:<ct>:<authTag>`. Rotation supports `OPENROUTER_ENCRYPTION_KEY_PREVIOUS` and `packages/database/backfill/reencrypt-legacy-secrets.ts` (with
  `--dry-run`) lifts legacy rows.
  - BYOK / Custom keys are AES-256-GCM at rest. FE only sees `hasApiKey: boolean`, never plaintext.

  ## Out of scope (follow-up)

  - Native SDK shims for Google and Qwen (same pattern as Anthropic).
  - Streaming responses.
  - Real per-key rate limit (currently shown as empirical 30-day peak).


