### PR TITLE
Improve Onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@ REDIS_URL=redis://localhost:6379
 # Public origin of the web app. Used by the API to build links (e.g. verify
 # email links in outgoing mails) and by OAuth callbacks to bounce the user
 # back to the right environment.
+#
+# IMPORTANT for production: branded outgoing emails (verification,
+# password reset, org invitation) embed `${FRONTEND_URL}/full-logo.png`
+# as the brand image. Email clients fetch this URL from the recipient's
+# device — it MUST be a publicly reachable URL, not an internal
+# hostname like `http://web:3000` or a docker-internal address. If the
+# image fails to load the email still renders, but the brand wordmark
+# is missing.
 FRONTEND_URL=http://localhost:3000
 
 # Public origin of the API itself. Used inside emails to construct links to
@@ -36,3 +44,10 @@ MAIL_HOST=
 MAIL_USER=
 MAIL_PASSWORD=
 MAIL_FROM=no-reply@workenai.local
+
+# Optional — when set, the "Follow Us" footer at the bottom of branded
+# emails (verification / password reset / org invitation) renders with
+# linked LinkedIn / Twitter labels. Leave both blank to omit the footer
+# entirely (recommended until we have real social accounts wired up).
+LINKEDIN_URL=
+TWITTER_URL=

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -519,12 +519,13 @@ export class AuthService {
       inviteStatus: user.inviteStatus,
       emailVerified: !!user.emailVerifiedAt,
       profileType: user.profileType as 'company' | 'personal' | null,
-      // Back-compat: users who completed the legacy single-step profile-type
-      // flow have profileType set but no onboardingCompletedAt. Treat them
-      // as onboarded so the guard doesn't bounce them through the new
-      // wizard. Can drop once we backfill onboarding_completed_at.
-      onboardingCompleted:
-        !!user.onboardingCompletedAt || !!user.profileType,
+      // Strict gate: only users who reached step 6 of the wizard and
+      // submitted (which atomically stamps onboarding_completed_at) are
+      // admitted to the app. Picking a profile type and bailing earlier
+      // is no longer enough — those users come back into the wizard at
+      // the step they have data for. Legacy single-step users were
+      // backfilled by `packages/database/backfill/backfill-legacy-onboarding-completed.sql`.
+      onboardingCompleted: !!user.onboardingCompletedAt,
       canCreateProject,
     };
   }

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -54,13 +54,14 @@ export class ChatController {
       projectId: conversation.projectId,
     });
 
-    // Block calls when the budget-bearing entity (team or user) has
-    // openrouterKeyId set but monthlyBudgetCents = 0 — the "Managed
-    // Cloud, awaiting admin approval" state seeded at onboarding.
+    // Block calls when the budget-bearing entity (team or user) is
+    // managed-cloud with monthlyBudgetCents = 0 — awaiting admin
+    // approval. Project-scoped chats gate on the team budget; personal
+    // chats gate on the user's budget.
     await this.chatTransport.assertManagedBudgetApproved(
       transport,
       user.id,
-      conversation.projectId,
+      { projectId: conversation.projectId },
     );
 
     // 3. Map stored messages to OpenRouter format

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -54,6 +54,15 @@ export class ChatController {
       projectId: conversation.projectId,
     });
 
+    // Block calls when the budget-bearing entity (team or user) has
+    // openrouterKeyId set but monthlyBudgetCents = 0 — the "Managed
+    // Cloud, awaiting admin approval" state seeded at onboarding.
+    await this.chatTransport.assertManagedBudgetApproved(
+      transport,
+      user.id,
+      conversation.projectId,
+    );
+
     // 3. Map stored messages to OpenRouter format
     const apiMessages = conversation.messages.map((m) => ({
       role: m.role as 'user' | 'assistant',

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -204,6 +204,13 @@ export class CompareModelsController {
             userId: user.id,
             modelIdentifier: model,
           });
+          // Same pending-approval gate as /chat — blocks Managed Cloud
+          // calls until an admin sets a budget. BYOK/Custom routes
+          // skip the gate (their billing is external).
+          await this.chatTransport.assertManagedBudgetApproved(
+            transport,
+            user.id,
+          );
           const start = Date.now();
           try {
             const response = await this.compareModelsService.sendQuestion(

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -206,10 +206,14 @@ export class CompareModelsController {
           });
           // Same pending-approval gate as /chat — blocks Managed Cloud
           // calls until an admin sets a budget. BYOK/Custom routes
-          // skip the gate (their billing is external).
+          // skip the gate (their billing is external). Pass the
+          // resolved teamId (if the user picked one in the composer)
+          // so the gate uses the team budget rather than the user's
+          // personal one.
           await this.chatTransport.assertManagedBudgetApproved(
             transport,
             user.id,
+            { teamId },
           );
           const start = Date.now();
           try {

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -1,10 +1,24 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { HttpException, Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq } from 'drizzle-orm';
-import { integrations, modelConfigs } from '@worken/database/schema';
+import {
+  integrations,
+  modelConfigs,
+  projects,
+  teams,
+  users,
+} from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
 import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 import { NATIVE_ENDPOINTS, providerOfModel } from './native-endpoints.js';
+
+/**
+ * Marker string the FE chat-error humanizer matches on to render the
+ * "ask your admin to approve a budget" message instead of the generic
+ * "monthly budget exhausted" one. Exported so it stays a single source
+ * of truth on both sides.
+ */
+export const PENDING_APPROVAL_MARKER = 'BUDGET_PENDING_APPROVAL';
 
 const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 
@@ -181,6 +195,72 @@ export class ChatTransportService {
       source: 'openrouter',
       kind: 'openai-sdk',
     };
+  }
+
+  /**
+   * Pending-approval gate for Managed Cloud (OpenRouter-routed) calls.
+   *
+   * After onboarding sets up an OpenRouter sub-account with `limit: 0`,
+   * the user has a real key but can't actually spend until an admin
+   * raises the budget in Management → Users. Without this gate the user
+   * would hit a generic 402 from OpenRouter and the FE humanizer would
+   * say "monthly budget exhausted" — confusing, since they never had a
+   * budget to begin with.
+   *
+   * Skip for BYOK / Custom routes — those have their own external
+   * billing and don't go through our budget tracking.
+   */
+  async assertManagedBudgetApproved(
+    transport: ChatTransport,
+    userId: string,
+    projectId?: string | null,
+  ): Promise<void> {
+    if (transport.source !== 'openrouter') return;
+
+    // Project under a team → team budget gates the spend.
+    if (projectId) {
+      const [proj] = await this.db
+        .select({ teamId: projects.teamId })
+        .from(projects)
+        .where(eq(projects.id, projectId))
+        .limit(1);
+
+      if (proj?.teamId) {
+        const [team] = await this.db
+          .select({
+            budgetCents: teams.monthlyBudgetCents,
+            keyId: teams.openrouterKeyId,
+          })
+          .from(teams)
+          .where(eq(teams.id, proj.teamId))
+          .limit(1);
+
+        if (team?.keyId && team.budgetCents === 0) {
+          throw new HttpException(
+            `${PENDING_APPROVAL_MARKER}: This team is pending budget approval. Ask an admin to set a monthly budget in Management → Teams so members can use AI.`,
+            402,
+          );
+        }
+        return;
+      }
+    }
+
+    // No project, or project without a team → fall back to per-user budget.
+    const [u] = await this.db
+      .select({
+        budgetCents: users.monthlyBudgetCents,
+        keyId: users.openrouterKeyId,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (u?.keyId && u.budgetCents === 0) {
+      throw new HttpException(
+        `${PENDING_APPROVAL_MARKER}: Your account is pending budget approval. Ask your admin to set a monthly budget in Management → Users so you can start using AI.`,
+        402,
+      );
+    }
   }
 
   private safeDecrypt(encrypted: string, context: string): string {

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -200,62 +200,76 @@ export class ChatTransportService {
   /**
    * Pending-approval gate for Managed Cloud (OpenRouter-routed) calls.
    *
-   * After onboarding sets up an OpenRouter sub-account with `limit: 0`,
-   * the user has a real key but can't actually spend until an admin
-   * raises the budget in Management → Users. Without this gate the user
-   * would hit a generic 402 from OpenRouter and the FE humanizer would
-   * say "monthly budget exhausted" — confusing, since they never had a
-   * budget to begin with.
+   * Managed-Cloud users sit at `monthlyBudgetCents = 0` from onboarding
+   * until an admin explicitly approves a budget — at which point
+   * `users.service.updateBudget` provisions or patches the OpenRouter
+   * key with that budget. Without this gate, the user's first chat
+   * either trips a generic 402 from OpenRouter ("budget exhausted",
+   * misleading — they never had a budget) or sends `key-resolver`
+   * lazy-provisioning a key behind the admin's back.
+   *
+   * Predicate is keyed on `infraChoice` not `openrouterKeyId` so the
+   * gate fires equally for users whose onboarding-time provisioning
+   * failed (no key + budget=0) and for those whose key exists with
+   * budget=0 — both need admin approval before any spend.
    *
    * Skip for BYOK / Custom routes — those have their own external
    * billing and don't go through our budget tracking.
+   *
+   * @param teamId pass when the call is scoped to a specific team
+   *   (compare-models with explicit teamId). For project-routed chats,
+   *   pass `projectId` instead and the team is looked up from there.
    */
   async assertManagedBudgetApproved(
     transport: ChatTransport,
     userId: string,
-    projectId?: string | null,
+    options: { projectId?: string | null; teamId?: string | null } = {},
   ): Promise<void> {
     if (transport.source !== 'openrouter') return;
 
-    // Project under a team → team budget gates the spend.
-    if (projectId) {
+    // Resolve the team scope: explicit teamId wins, otherwise look up
+    // from project. Either way, team budget gates the spend.
+    let teamId = options.teamId ?? null;
+    if (!teamId && options.projectId) {
       const [proj] = await this.db
         .select({ teamId: projects.teamId })
         .from(projects)
-        .where(eq(projects.id, projectId))
+        .where(eq(projects.id, options.projectId))
         .limit(1);
-
-      if (proj?.teamId) {
-        const [team] = await this.db
-          .select({
-            budgetCents: teams.monthlyBudgetCents,
-            keyId: teams.openrouterKeyId,
-          })
-          .from(teams)
-          .where(eq(teams.id, proj.teamId))
-          .limit(1);
-
-        if (team?.keyId && team.budgetCents === 0) {
-          throw new HttpException(
-            `${PENDING_APPROVAL_MARKER}: This team is pending budget approval. Ask an admin to set a monthly budget in Management → Teams so members can use AI.`,
-            402,
-          );
-        }
-        return;
-      }
+      teamId = proj?.teamId ?? null;
     }
 
-    // No project, or project without a team → fall back to per-user budget.
+    if (teamId) {
+      const [team] = await this.db
+        .select({ budgetCents: teams.monthlyBudgetCents })
+        .from(teams)
+        .where(eq(teams.id, teamId))
+        .limit(1);
+
+      if (team && team.budgetCents === 0) {
+        throw new HttpException(
+          `${PENDING_APPROVAL_MARKER}: This team is pending budget approval. Ask an admin to set a monthly budget in Management → Teams so members can use AI.`,
+          402,
+        );
+      }
+      return;
+    }
+
+    // No team scope → personal call. Gate fires for managed-cloud users
+    // with budget=0 regardless of whether their key was provisioned.
     const [u] = await this.db
       .select({
         budgetCents: users.monthlyBudgetCents,
-        keyId: users.openrouterKeyId,
+        infraChoice: users.infraChoice,
       })
       .from(users)
       .where(eq(users.id, userId))
       .limit(1);
 
-    if (u?.keyId && u.budgetCents === 0) {
+    if (
+      u?.infraChoice === 'managed' &&
+      u.budgetCents === 0
+    ) {
       throw new HttpException(
         `${PENDING_APPROVAL_MARKER}: Your account is pending budget approval. Ask your admin to set a monthly budget in Management → Users so you can start using AI.`,
         402,

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -307,40 +307,42 @@ export class IntegrationsService {
         isEnabled: input.isEnabled ?? true,
       });
     } else {
-      // Upsert: try update, else insert.
-      const [existing] = await this.db
-        .select()
-        .from(integrations)
-        .where(
-          and(
-            eq(integrations.ownerId, userId),
-            eq(integrations.providerId, input.providerId),
-          ),
-        );
+      // Atomic upsert against the partial unique index
+      // `(owner_id, provider_id) WHERE api_url IS NULL`. Replaces an
+      // earlier select-then-insert which had a thin race window where
+      // two concurrent toggles could land on either side of the SELECT
+      // and leave the FE state out of sync.
+      //
+      // Build the on-conflict SET clause to preserve the 3-state
+      // semantic of `apiKey`:
+      //   - undefined → don't touch the stored key
+      //   - empty string → clear the stored key (set null)
+      //   - non-empty → encrypt and store
+      // and similarly for isEnabled (undefined → don't touch).
+      const conflictUpdates: Record<string, unknown> = {
+        updatedAt: new Date(),
+      };
+      if (input.isEnabled !== undefined) {
+        conflictUpdates.isEnabled = input.isEnabled;
+      }
+      if (input.apiKey !== undefined) {
+        conflictUpdates.apiKeyEncrypted = apiKeyEncrypted;
+      }
 
-      if (existing) {
-        const updates: Record<string, unknown> = {
-          updatedAt: new Date(),
-        };
-        if (input.isEnabled !== undefined) updates.isEnabled = input.isEnabled;
-        if (apiKeyEncrypted !== null) updates.apiKeyEncrypted = apiKeyEncrypted;
-        if (apiKeyEncrypted === null && input.apiKey === '') {
-          // Empty string explicitly clears the key.
-          updates.apiKeyEncrypted = null;
-        }
-        await this.db
-          .update(integrations)
-          .set(updates)
-          .where(eq(integrations.id, existing.id));
-      } else {
-        await this.db.insert(integrations).values({
+      await this.db
+        .insert(integrations)
+        .values({
           ownerId: userId,
           providerId: input.providerId,
           apiUrl: null,
           apiKeyEncrypted,
           isEnabled: input.isEnabled ?? true,
+        })
+        .onConflictDoUpdate({
+          target: [integrations.ownerId, integrations.providerId],
+          targetWhere: sql`${integrations.apiUrl} IS NULL`,
+          set: conflictUpdates,
         });
-      }
     }
 
     const all = await this.listForUser(userId);

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -204,6 +204,7 @@ export class IntegrationsService {
       const row = rows.find(
         (r) => r.providerId === p.id && r.apiUrl === null,
       );
+      const hasApiKey = !!row?.apiKeyEncrypted;
       out.push({
         id: row?.id ?? null,
         providerId: p.id,
@@ -211,8 +212,16 @@ export class IntegrationsService {
         description: p.description,
         iconHint: p.iconHint,
         apiUrl: null,
-        hasApiKey: !!row?.apiKeyEncrypted,
-        isEnabled: row?.isEnabled ?? true, // default-on per UI mock
+        hasApiKey,
+        // A provider can only be considered "enabled" if it has a key
+        // saved — without one, BYOK routing in chat-transport falls
+        // straight through to OpenRouter, so a green toggle without a
+        // key is a lie about what the system will actually do. We
+        // default to OFF for untouched providers AND clamp stored
+        // is_enabled = true with no key down to false. Adding a key
+        // via the Settings dialog flips this back on through the
+        // upsert default.
+        isEnabled: hasApiKey && (row?.isEnabled ?? true),
         isCustom: false,
         openAICompatible: p.openAICompatible,
         byokSupported: p.byokSupported,

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -204,7 +204,6 @@ export class IntegrationsService {
       const row = rows.find(
         (r) => r.providerId === p.id && r.apiUrl === null,
       );
-      const hasApiKey = !!row?.apiKeyEncrypted;
       out.push({
         id: row?.id ?? null,
         providerId: p.id,
@@ -212,16 +211,16 @@ export class IntegrationsService {
         description: p.description,
         iconHint: p.iconHint,
         apiUrl: null,
-        hasApiKey,
-        // A provider can only be considered "enabled" if it has a key
-        // saved — without one, BYOK routing in chat-transport falls
-        // straight through to OpenRouter, so a green toggle without a
-        // key is a lie about what the system will actually do. We
-        // default to OFF for untouched providers AND clamp stored
-        // is_enabled = true with no key down to false. Adding a key
-        // via the Settings dialog flips this back on through the
-        // upsert default.
-        isEnabled: hasApiKey && (row?.isEnabled ?? true),
+        hasApiKey: !!row?.apiKeyEncrypted,
+        // Default OFF for providers the user has never touched. Once
+        // they exist in the table, respect whatever toggle state they
+        // chose — independent of whether a BYOK key is set, because
+        // "enabled without a key" is a meaningful state: it makes the
+        // provider's models available in the picker / arena and the
+        // chat call routes through the shared WorkenAI OpenRouter
+        // account instead of BYOK. The key is an optional upgrade,
+        // not a prerequisite.
+        isEnabled: row?.isEnabled ?? false,
         isCustom: false,
         openAICompatible: p.openAICompatible,
         byokSupported: p.byokSupported,

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -118,11 +118,12 @@ export class MailService {
     // Matches Figma frame 4110-16154: 800px container, white bg, centered
     // inner card (30px padding, 30px radius), blue (#178ACA) CTA, IBM Plex
     // Sans type. Inlined styles because email clients don't run CSS files.
+    // The Follow Us footer renders only when at least one social URL is
+    // configured (LINKEDIN_URL / TWITTER_URL) so unconfigured envs don't
+    // show empty/dead links.
     const html = `
       <div style="font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 800px; margin: 0 auto; background: #ffffff; padding: 30px 100px;">
-        <div style="display: flex; align-items: center; gap: 6px; height: 48px; margin-bottom: 30px;">
-          <span style="font-size: 26px; font-weight: 700; color: #1D2129; letter-spacing: -0.01em;">WorkenAI</span>
-        </div>
+        ${this.brandedHeader(frontendUrl)}
         <div style="background: #ffffff; border-radius: 30px; padding: 30px 60px; text-align: center;">
           <h1 style="font-size: 32px; font-weight: 700; color: #1D2129; margin: 0 0 30px; line-height: 1.3;">Hi ${escapeHtml(greetingName)},</h1>
           <p style="font-size: 23px; font-weight: 400; color: #1D2129; margin: 0 0 30px; line-height: 1.3;">Thanks for joining WorkenAI</p>
@@ -134,6 +135,7 @@ export class MailService {
           <p style="font-size: 16px; font-weight: 400; color: #86909C; margin: 0 0 30px; line-height: 1.3; word-break: break-all;">${verifyUrl}</p>
           <p style="font-size: 14px; font-weight: 400; color: #4E5969; margin: 0; line-height: 1.3;">Best,<br/>WorkenAI Team</p>
         </div>
+        ${this.brandedFooter()}
       </div>
     `;
 
@@ -143,10 +145,51 @@ export class MailService {
       subject: 'Confirm your email address',
       html,
     });
+  }
 
-    // Reference frontend URL so the import stays useful even when the
-    // template later links back into app flows.
-    void frontendUrl;
+  /**
+   * Brand header — logo image at 106×29 (matching Figma frame 4110-16154).
+   * Email clients fetch the image from the public assets bundle, so it
+   * needs FRONTEND_URL pointed at a publicly reachable host in prod.
+   * Falls back to a plain text wordmark when the image can't load (most
+   * desktop clients block remote images by default until the user opts in).
+   */
+  private brandedHeader(frontendUrl: string): string {
+    return `
+      <div style="height: 48px; margin-bottom: 30px;">
+        <img src="${frontendUrl}/full-logo.png" alt="WorkenAI" width="106" height="29" style="display: block; border: 0; outline: none; text-decoration: none; height: 29px; width: 106px;" />
+      </div>
+    `;
+  }
+
+  /**
+   * Brand footer — "Follow Us" + social icons. Renders only when at least
+   * one social URL env var is configured. Each icon is a plain Unicode
+   * glyph wrapped in an anchor; SVG/IMG icons require a hosted asset
+   * pipeline (Mailchimp-style) and email clients block remote SVGs
+   * inconsistently anyway.
+   */
+  private brandedFooter(): string {
+    const linkedin = this.config.get<string>('LINKEDIN_URL');
+    const twitter = this.config.get<string>('TWITTER_URL');
+    if (!linkedin && !twitter) return '';
+
+    const link = (href: string, label: string) =>
+      `<a href="${href}" style="display: inline-block; margin: 0 8px; color: #4E5969; text-decoration: none; font-size: 14px;">${label}</a>`;
+
+    const links = [
+      linkedin ? link(linkedin, 'LinkedIn') : '',
+      twitter ? link(twitter, 'Twitter') : '',
+    ]
+      .filter(Boolean)
+      .join('');
+
+    return `
+      <div style="margin-top: 30px; text-align: center;">
+        <p style="font-size: 12px; font-weight: 600; color: #86909C; letter-spacing: 0.08em; text-transform: uppercase; margin: 0 0 8px;">Follow Us</p>
+        <div>${links}</div>
+      </div>
+    `;
   }
 
   async sendPasswordResetEmail({ to, name, token }: PasswordResetEmailParams) {
@@ -161,9 +204,7 @@ export class MailService {
 
     const html = `
       <div style="font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 800px; margin: 0 auto; background: #ffffff; padding: 30px 100px;">
-        <div style="display: flex; align-items: center; gap: 6px; height: 48px; margin-bottom: 30px;">
-          <span style="font-size: 26px; font-weight: 700; color: #1D2129; letter-spacing: -0.01em;">WorkenAI</span>
-        </div>
+        ${this.brandedHeader(frontendUrl)}
         <div style="background: #ffffff; border-radius: 30px; padding: 30px 60px; text-align: center;">
           <h1 style="font-size: 32px; font-weight: 700; color: #1D2129; margin: 0 0 30px; line-height: 1.3;">Hi ${escapeHtml(greetingName)},</h1>
           <p style="font-size: 23px; font-weight: 400; color: #1D2129; margin: 0 0 30px; line-height: 1.3;">Reset your WorkenAI password</p>
@@ -176,6 +217,7 @@ export class MailService {
           <p style="font-size: 14px; font-weight: 400; color: #4E5969; margin: 0 0 8px; line-height: 1.3;">If you didn't request this, you can safely ignore this email.</p>
           <p style="font-size: 14px; font-weight: 400; color: #4E5969; margin: 0; line-height: 1.3;">Best,<br/>WorkenAI Team</p>
         </div>
+        ${this.brandedFooter()}
       </div>
     `;
 
@@ -202,9 +244,7 @@ export class MailService {
 
     const html = `
       <div style="font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 800px; margin: 0 auto; background: #ffffff; padding: 30px 100px;">
-        <div style="display: flex; align-items: center; gap: 6px; height: 48px; margin-bottom: 30px;">
-          <span style="font-size: 26px; font-weight: 700; color: #1D2129; letter-spacing: -0.01em;">WorkenAI</span>
-        </div>
+        ${this.brandedHeader(frontendUrl)}
         <div style="background: #ffffff; border-radius: 30px; padding: 30px 60px; text-align: center;">
           <h1 style="font-size: 32px; font-weight: 700; color: #1D2129; margin: 0 0 30px; line-height: 1.3;">You've been invited to WorkenAI</h1>
           <p style="font-size: 16px; font-weight: 400; color: #4E5969; margin: 0 0 30px; line-height: 1.6;">
@@ -223,6 +263,7 @@ export class MailService {
         <p style="font-size: 12px; color: #94a3b8; text-align: center; margin-top: 24px;">
           This invitation was sent to ${escapeHtml(to)}. If you weren't expecting this, you can safely ignore it.
         </p>
+        ${this.brandedFooter()}
       </div>
     `;
 

--- a/apps/api/src/models/models.service.ts
+++ b/apps/api/src/models/models.service.ts
@@ -78,18 +78,24 @@ export class ModelsService {
         and(eq(modelConfigs.ownerId, userId), eq(modelConfigs.isActive, true)),
       );
 
-    const byokRows = await this.db
+    // Every predefined provider the user has toggled ON, regardless of
+    // whether they've also added a BYOK key. With a key, chat-transport
+    // routes directly to the provider's native endpoint; without a key,
+    // the BYOK path falls through and the call goes via the shared
+    // WorkenAI OpenRouter account. Either way the user's intent is
+    // "give me this provider's models in my picker", so the effective
+    // list should reflect that intent independent of key presence.
+    const enabledRows = await this.db
       .select({ providerId: integrations.providerId })
       .from(integrations)
       .where(
         and(
           eq(integrations.ownerId, userId),
           eq(integrations.isEnabled, true),
-          isNotNull(integrations.apiKeyEncrypted),
         ),
       );
-    const byokProviders = new Set(
-      byokRows
+    const enabledProviders = new Set(
+      enabledRows
         .map((r) => r.providerId)
         .filter((id) => id !== 'custom'), // custom routes via aliases, not provider lookup
     );
@@ -108,14 +114,14 @@ export class ModelsService {
       });
     }
 
-    if (byokProviders.size > 0) {
+    if (enabledProviders.size > 0) {
       const catalog = await this.catalogService.list();
       for (const m of catalog) {
         if (seen.has(m.id)) continue;
         const slash = m.id.indexOf('/');
         if (slash === -1) continue;
         const provider = m.id.slice(0, slash);
-        if (!byokProviders.has(provider)) continue;
+        if (!enabledProviders.has(provider)) continue;
         seen.add(m.id);
         out.push({
           id: m.id,

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
@@ -18,6 +19,7 @@ import {
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
+import { OpenRouterProvisioningService } from '../openrouter/openrouter-provisioning.service.js';
 
 type ProfileType = 'company' | 'personal';
 type InfraChoice = 'managed' | 'on-premise';
@@ -59,9 +61,12 @@ function sanitizeFilename(raw: string): string {
 
 @Injectable()
 export class OnboardingService {
+  private readonly logger = new Logger(OnboardingService.name);
+
   constructor(
     @Inject(DATABASE) private readonly db: Database,
     private readonly encryption: EncryptionService,
+    private readonly provisioning: OpenRouterProvisioningService,
   ) {}
 
   async complete(
@@ -197,6 +202,44 @@ export class OnboardingService {
         });
       }
     });
+
+    // Managed Cloud provisioning. Runs after the DB transaction so we don't
+    // hold the transaction open during the OpenRouter HTTP round-trip.
+    //
+    // Best-effort, mirroring the teams.create pattern: if OpenRouter is down
+    // at this exact moment we still let onboarding succeed — the
+    // `updateBudget` self-heal in users.service kicks in the first time an
+    // admin sets a real budget, and `key-resolver.service` self-heals on
+    // the first chat call too. The key is provisioned with `limit: 0` so
+    // no spend is allowed until an admin explicitly raises the budget,
+    // which matches the product decision to require manual approval.
+    if (
+      payload.infraChoice === 'managed' &&
+      !current.openrouterKeyId
+    ) {
+      try {
+        const { key, hash } = await this.provisioning.createKey(
+          `user-${userId}`,
+          0,
+        );
+        const encrypted = this.encryption.encrypt(key);
+        await this.db
+          .update(users)
+          .set({
+            openrouterKeyId: hash,
+            openrouterKeyEncrypted: encrypted,
+          })
+          .where(eq(users.id, userId));
+        this.logger.log(
+          `Provisioned OpenRouter key for user ${userId} with limit=0 (admin must set budget).`,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `Failed to provision OpenRouter key for user ${userId} during onboarding: ${msg}. Will self-heal on next updateBudget.`,
+        );
+      }
+    }
   }
 
   /**

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -44,6 +44,28 @@ const VALID_PROVIDERS: Provider[] = [
   'anthropic',
   'private-vpc',
 ];
+
+// Whitelisted enum values for the company-branch dropdowns. Must stay in
+// sync with apps/web/src/app/setup-profile/step-2/page.tsx — the FE
+// dropdown values are the source of truth, and the BE enforces them so
+// direct API calls can't seed garbage like industry: "anything goes lol".
+const VALID_INDUSTRIES = [
+  'technology',
+  'finance',
+  'healthcare',
+  'government',
+  'manufacturing',
+  'retail',
+  'other',
+] as const;
+const VALID_TEAM_SIZES = [
+  '1-10',
+  '11-50',
+  '51-200',
+  '201-1000',
+  '1000+',
+] as const;
+
 const UPLOADS_ROOT = join(process.cwd(), 'uploads', 'knowledge');
 
 // Defense-in-depth against path traversal: multer's originalname is whatever
@@ -334,6 +356,28 @@ export class OnboardingService {
     if (p.profileType === 'company') {
       if (!p.companyName?.trim()) {
         throw new BadRequestException('companyName is required for Company');
+      }
+      // industry/teamSize stay optional (Figma shows no asterisk), but
+      // when supplied they must be one of the FE dropdown values.
+      if (
+        p.industry &&
+        !VALID_INDUSTRIES.includes(
+          p.industry as (typeof VALID_INDUSTRIES)[number],
+        )
+      ) {
+        throw new BadRequestException(
+          `industry must be one of: ${VALID_INDUSTRIES.join(', ')}`,
+        );
+      }
+      if (
+        p.teamSize &&
+        !VALID_TEAM_SIZES.includes(
+          p.teamSize as (typeof VALID_TEAM_SIZES)[number],
+        )
+      ) {
+        throw new BadRequestException(
+          `teamSize must be one of: ${VALID_TEAM_SIZES.join(', ')}`,
+        );
       }
     }
     if (p.profileType === 'personal' && !p.fullName?.trim()) {

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -6,7 +6,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNotNull, isNull } from 'drizzle-orm';
 import { copyFile, mkdir, rename, stat, unlink } from 'fs/promises';
 import { createReadStream } from 'fs';
 import { resolve } from 'path';
@@ -14,7 +14,7 @@ import { randomUUID } from 'crypto';
 import { join, posix as pathPosix } from 'path';
 import {
   users,
-  userLlmCredentials,
+  integrations,
   knowledgeDocuments,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
@@ -205,14 +205,36 @@ export class OnboardingService {
         })
         .where(eq(users.id, userId));
 
+      // Write step-5 keys directly into the `integrations` table so they
+      // show up in Management → Integration as enabled rows. Without
+      // this, the keys would be stranded — the chat-transport BYOK path
+      // and the Integration tab both read from `integrations`, while
+      // the legacy `user_llm_credentials` table this used to write to is
+      // unused for routing.
+      //
+      // Mapping note: the step-5 buttons (openai / azure / anthropic /
+      // private-vpc) don't all line up with the predefined providers
+      // catalog. `openai` and `anthropic` map directly. `azure` and
+      // `private-vpc` need extra fields (Azure deployment URL, VPC
+      // endpoint) that the wizard doesn't collect — those keys are
+      // dropped here and the user must finish setup in the Integration
+      // tab. Logged so it's visible in onboarding telemetry.
       if (payload.apiKeys) {
         for (const [provider, key] of Object.entries(payload.apiKeys)) {
           if (!key || !key.trim()) continue;
           if (!VALID_PROVIDERS.includes(provider as Provider)) continue;
-          await tx.insert(userLlmCredentials).values({
-            userId,
-            provider,
+          if (provider !== 'openai' && provider !== 'anthropic') {
+            this.logger.warn(
+              `Onboarding step-5: ${provider} key supplied but no matching predefined provider — skipping. User ${userId} can finish setup in Management → Integration.`,
+            );
+            continue;
+          }
+          await tx.insert(integrations).values({
+            ownerId: userId,
+            providerId: provider,
+            apiUrl: null,
             apiKeyEncrypted: this.encryption.encrypt(key.trim()),
+            isEnabled: true,
           });
         }
       }
@@ -307,14 +329,25 @@ export class OnboardingService {
       .where(eq(users.id, userId));
     if (!u) throw new NotFoundException('User not found');
 
+    // Connected providers shown on My Account. Read from `integrations`
+    // (the same table the Integration tab uses) so this section reflects
+    // what the user has actually configured. Filter to predefined
+    // providers with a key set — Custom LLMs aren't conceptually
+    // "connected providers" in the My Account sense.
     const providers = await this.db
       .select({
-        id: userLlmCredentials.id,
-        provider: userLlmCredentials.provider,
-        createdAt: userLlmCredentials.createdAt,
+        id: integrations.id,
+        provider: integrations.providerId,
+        createdAt: integrations.createdAt,
       })
-      .from(userLlmCredentials)
-      .where(eq(userLlmCredentials.userId, userId));
+      .from(integrations)
+      .where(
+        and(
+          eq(integrations.ownerId, userId),
+          isNotNull(integrations.apiKeyEncrypted),
+          isNull(integrations.apiUrl),
+        ),
+      );
 
     const documents = await this.db
       .select({

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -6,7 +6,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { and, eq, isNotNull, isNull } from 'drizzle-orm';
+import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import { copyFile, mkdir, rename, stat, unlink } from 'fs/promises';
 import { createReadStream } from 'fs';
 import { resolve } from 'path';
@@ -19,7 +19,6 @@ import {
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
-import { OpenRouterProvisioningService } from '../openrouter/openrouter-provisioning.service.js';
 
 type ProfileType = 'company' | 'personal';
 type InfraChoice = 'managed' | 'on-premise';
@@ -88,7 +87,6 @@ export class OnboardingService {
   constructor(
     @Inject(DATABASE) private readonly db: Database,
     private readonly encryption: EncryptionService,
-    private readonly provisioning: OpenRouterProvisioningService,
   ) {}
 
   async complete(
@@ -229,13 +227,27 @@ export class OnboardingService {
             );
             continue;
           }
-          await tx.insert(integrations).values({
-            ownerId: userId,
-            providerId: provider,
-            apiUrl: null,
-            apiKeyEncrypted: this.encryption.encrypt(key.trim()),
-            isEnabled: true,
-          });
+          // onConflictDoNothing on the partial unique index
+          // `(owner_id, provider_id) WHERE api_url IS NULL` so a
+          // re-run of onboarding (e.g. support-action that cleared
+          // onboarding_completed_at after the legacy backfill SQL was
+          // applied) doesn't crash the whole transaction with 23505
+          // and orphan the just-uploaded knowledge documents. The
+          // existing row is left as-is — the user can update keys
+          // from Management → Integration.
+          await tx
+            .insert(integrations)
+            .values({
+              ownerId: userId,
+              providerId: provider,
+              apiUrl: null,
+              apiKeyEncrypted: this.encryption.encrypt(key.trim()),
+              isEnabled: true,
+            })
+            .onConflictDoNothing({
+              target: [integrations.ownerId, integrations.providerId],
+              where: sql`${integrations.apiUrl} IS NULL`,
+            });
         }
       }
 
@@ -247,43 +259,24 @@ export class OnboardingService {
       }
     });
 
-    // Managed Cloud provisioning. Runs after the DB transaction so we don't
-    // hold the transaction open during the OpenRouter HTTP round-trip.
+    // Managed Cloud users are NOT provisioned an OpenRouter key here.
+    // The original design provisioned with `limit: 0`, but OpenRouter's
+    // API treats `limit: 0` ambiguously (and `limit: null` as
+    // unenforced — see backfill-openrouter-limits.ts), so a key created
+    // up front would be one bypassed gate away from uncapped spend.
     //
-    // Best-effort, mirroring the teams.create pattern: if OpenRouter is down
-    // at this exact moment we still let onboarding succeed — the
-    // `updateBudget` self-heal in users.service kicks in the first time an
-    // admin sets a real budget, and `key-resolver.service` self-heals on
-    // the first chat call too. The key is provisioned with `limit: 0` so
-    // no spend is allowed until an admin explicitly raises the budget,
-    // which matches the product decision to require manual approval.
-    if (
-      payload.infraChoice === 'managed' &&
-      !current.openrouterKeyId
-    ) {
-      try {
-        const { key, hash } = await this.provisioning.createKey(
-          `user-${userId}`,
-          0,
-        );
-        const encrypted = this.encryption.encrypt(key);
-        await this.db
-          .update(users)
-          .set({
-            openrouterKeyId: hash,
-            openrouterKeyEncrypted: encrypted,
-          })
-          .where(eq(users.id, userId));
-        this.logger.log(
-          `Provisioned OpenRouter key for user ${userId} with limit=0 (admin must set budget).`,
-        );
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        this.logger.error(
-          `Failed to provision OpenRouter key for user ${userId} during onboarding: ${msg}. Will self-heal on next updateBudget.`,
-        );
-      }
-    }
+    // Instead we leave openrouterKeyId NULL and rely on:
+    //   1. The pending-approval banner on Management → Users (predicate
+    //      `infraChoice = 'managed' AND monthlyBudgetCents = 0`) to
+    //      surface the user to the admin.
+    //   2. `users.service.updateBudget` to provision the key the moment
+    //      the admin sets a real budget — that path already creates a
+    //      key matching the requested limit, so the OpenRouter cap and
+    //      our DB stay in sync.
+    //   3. `assertManagedBudgetApproved` and the lazy-provision guard
+    //      in `key-resolver.resolveUserKey` to make any chat attempt
+    //      before approval fail with a 402 + BUDGET_PENDING_APPROVAL
+    //      marker rather than silently creating a key.
   }
 
   /**

--- a/apps/api/src/openrouter/key-resolver.service.ts
+++ b/apps/api/src/openrouter/key-resolver.service.ts
@@ -92,10 +92,25 @@ export class KeyResolverService {
       return this.safeDecrypt(user.openrouterKeyEncrypted, `user ${userId}`);
     }
 
+    // Lazy-provision MUST match what the admin has approved. Without
+    // this guard, a managed-cloud user whose onboarding-time
+    // provisioning was never done would get a $10 key created here
+    // behind the admin's back — bypassing the explicit "admin must
+    // approve a budget" gate. Admins set the budget via
+    // users.service.updateBudget, which then provisions or patches
+    // the key with the approved limit. Until that happens, this path
+    // throws so the chat layer can surface the pending-approval 402.
+    const budgetUsd = (user.monthlyBudgetCents ?? 0) / 100;
+    if (budgetUsd <= 0) {
+      throw new Error(
+        `Could not obtain an OpenRouter key for user ${userId}: monthly budget is 0. An admin must approve a budget in Management → Users before this user can make AI calls.`,
+      );
+    }
+
     try {
       const { key, hash } = await this.provisioningService.createKey(
         `user-${userId}`,
-        10,
+        budgetUsd,
       );
       const encrypted = this.encryptionService.encrypt(key);
       await this.db

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -167,8 +167,14 @@ export class TeamsService {
     userId: string,
     budgetUsd: number,
   ): Promise<{ monthlyBudgetCents: number }> {
-    if (typeof budgetUsd !== 'number' || budgetUsd <= 0) {
-      throw new BadRequestException('budgetUsd must be a positive number');
+    if (
+      typeof budgetUsd !== 'number' ||
+      budgetUsd < 0 ||
+      !Number.isFinite(budgetUsd)
+    ) {
+      throw new BadRequestException(
+        'budgetUsd must be a non-negative finite number',
+      );
     }
 
     const [team] = await this.db
@@ -183,13 +189,19 @@ export class TeamsService {
       throw new ForbiddenException('Only the team owner can update the budget');
     }
 
-    // Self-heal: if the team has no OpenRouter key (provisioning failed at
-    // create time, or this is a legacy team), provision one now using the
-    // budget the owner just submitted. If it still fails, surface a clear
-    // error instead of silently saving a budget that OpenRouter doesn't
-    // know about.
+    // Suspend semantic: budgetUsd === 0 means "block this team from
+    // spending anything until I raise the budget again". The chat
+    // gate (assertManagedBudgetApproved) trips on team.budget=0 at
+    // request time. We still patch OpenRouter to a $0.01 floor as
+    // defense-in-depth — see users.service.updateBudget for the same
+    // pattern and rationale.
+    const upstreamLimitUsd = budgetUsd === 0 ? 0.01 : budgetUsd;
+
     let openrouterKeyId = team.openrouterKeyId;
-    if (!openrouterKeyId) {
+    if (!openrouterKeyId && budgetUsd > 0) {
+      // Self-heal: provision a key when the owner sets a real budget
+      // for a team that doesn't have one yet (failed create-time
+      // provisioning, or a legacy team).
       try {
         const { key, hash } = await this.provisioningService.createKey(
           `team-${team.id}`,
@@ -205,20 +217,25 @@ export class TeamsService {
           .where(eq(teams.id, teamId));
         openrouterKeyId = hash;
         this.logger.log(
-          `Reprovisioned OpenRouter key for team ${teamId} during budget update.`,
+          `Provisioned OpenRouter key for team ${teamId} during budget update.`,
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         this.logger.error(
-          `Failed to reprovision OpenRouter key for team ${teamId}: ${msg}`,
+          `Failed to provision OpenRouter key for team ${teamId}: ${msg}`,
         );
         throw new ServiceUnavailableException(
           'Could not provision an OpenRouter key for this team. Please try again in a moment.',
         );
       }
-    } else {
-      await this.provisioningService.updateKey(openrouterKeyId, budgetUsd);
+    } else if (openrouterKeyId) {
+      await this.provisioningService.updateKey(
+        openrouterKeyId,
+        upstreamLimitUsd,
+      );
     }
+    // else: budget=0 AND no key — nothing to provision, gate handles
+    // the block. Owner can raise the budget later to enable.
 
     const budgetCents = Math.round(budgetUsd * 100);
     await this.db

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -98,10 +98,23 @@ export class UsersController {
   }
 
   @Patch(':id/budget')
-  updateBudget(
+  async updateBudget(
     @Param('id') id: string,
     @Body() body: { budgetUsd: number },
+    @CurrentUser() caller: AuthenticatedUser,
   ) {
+    // Budget changes flip a real spend cap on the user's OpenRouter
+    // sub-account — basic / advanced users must not be able to lift
+    // each other's caps. Mirror the role gate used on /users delete.
+    const [callerUser] = await this.db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, caller.id));
+    if (!callerUser || callerUser.role !== 'admin') {
+      throw new ForbiddenException(
+        'Only admins can change a user\'s monthly budget.',
+      );
+    }
     return this.usersService.updateBudget(id, body.budgetUsd);
   }
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -118,6 +118,35 @@ export class UsersController {
     return this.usersService.updateBudget(id, body.budgetUsd);
   }
 
+  @Patch(':id/role')
+  async updateRole(
+    @Param('id') id: string,
+    @Body() body: { role: string },
+    @CurrentUser() caller: AuthenticatedUser,
+  ) {
+    // Admin-only — role determines permissions across the entire org
+    // (project creation, team management, user removal). Only an
+    // existing admin can grant or revoke roles.
+    const [callerUser] = await this.db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, caller.id));
+    if (!callerUser || callerUser.role !== 'admin') {
+      throw new ForbiddenException(
+        'Only admins can change a user\'s organization role.',
+      );
+    }
+    // Block self-mutation: prevents an admin from accidentally
+    // demoting themselves into a basic / advanced lockout. They have
+    // to be demoted by another admin.
+    if (id === caller.id) {
+      throw new BadRequestException(
+        'You cannot change your own role. Ask another admin to do it.',
+      );
+    }
+    return this.usersService.updateRole(id, body.role);
+  }
+
   @Delete(':id')
   async remove(
     @Param('id') id: string,

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -61,7 +61,7 @@ export class UsersService {
         role: users.role,
         inviteStatus: users.inviteStatus,
         monthlyBudgetCents: users.monthlyBudgetCents,
-        openrouterKeyId: users.openrouterKeyId,
+        infraChoice: users.infraChoice,
         createdAt: users.createdAt,
       })
       .from(users);
@@ -115,13 +115,16 @@ export class UsersService {
         status: membership?.status ?? 'accepted',
         teams: membership?.teams ?? [],
         monthlyBudgetCents: u.monthlyBudgetCents,
-        // True when the user finished Managed-Cloud onboarding (so they
-        // have a provisioned OpenRouter key) but no admin has set a
-        // budget yet — every chat call would otherwise 402. Drives the
-        // "N users awaiting budget approval" banner on Management →
-        // Users.
+        // Managed-Cloud users sit in this state from the moment they
+        // finish onboarding until an admin explicitly sets a budget
+        // in Management → Users (which provisions or patches their
+        // OpenRouter key). Drives the "N users awaiting budget
+        // approval" banner. Predicate is keyed on `infraChoice` rather
+        // than `openrouterKeyId` so users whose onboarding-time
+        // provisioning failed still surface — they need admin action
+        // just as much as the success path.
         pendingBudgetApproval:
-          !!u.openrouterKeyId && u.monthlyBudgetCents === 0,
+          u.infraChoice === 'managed' && u.monthlyBudgetCents === 0,
         spentCents: 0, // TODO: integrate with OpenRouter usage API
         projectedCents: 0, // TODO: integrate with OpenRouter usage API
         createdAt: u.createdAt,

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -250,8 +250,14 @@ export class UsersService {
     userId: string,
     budgetUsd: number,
   ): Promise<{ monthlyBudgetCents: number }> {
-    if (typeof budgetUsd !== 'number' || budgetUsd <= 0) {
-      throw new BadRequestException('budgetUsd must be a positive number');
+    if (
+      typeof budgetUsd !== 'number' ||
+      budgetUsd < 0 ||
+      !Number.isFinite(budgetUsd)
+    ) {
+      throw new BadRequestException(
+        'budgetUsd must be a non-negative finite number',
+      );
     }
 
     const [user] = await this.db
@@ -263,13 +269,26 @@ export class UsersService {
       throw new NotFoundException('User not found');
     }
 
-    // Self-heal: if the user has no OpenRouter key (provisioning failed at
-    // signup, or this is a legacy user), provision one now using the
-    // budget the admin just submitted. Without this the budget would be
-    // stored only in our DB while OpenRouter has no enforcement at all.
+    // Suspend semantic: budgetUsd === 0 means "block this user from
+    // spending anything until I raise the budget again".
+    // assertManagedBudgetApproved already trips on budget=0+managed at
+    // request time, so the suspend is enforced at our layer. We still
+    // patch the OpenRouter cap to a $0.01 floor (not 0 — OpenRouter
+    // treats `limit: null` as unenforced and the `0` case is
+    // undocumented) as defense-in-depth: if our gate is ever
+    // bypassed, the upstream cap stops runaway spend at 1 cent.
+    const upstreamLimitUsd = budgetUsd === 0 ? 0.01 : budgetUsd;
+
     if (user.openrouterKeyId) {
-      await this.provisioningService.updateKey(user.openrouterKeyId, budgetUsd);
-    } else {
+      await this.provisioningService.updateKey(
+        user.openrouterKeyId,
+        upstreamLimitUsd,
+      );
+    } else if (budgetUsd > 0) {
+      // Self-heal: provision a key when the admin sets a real budget
+      // for a user that doesn't have one yet (failed onboarding-time
+      // provisioning, or a managed-cloud user under the new design
+      // where onboarding deliberately skips provisioning).
       try {
         const { key, hash } = await this.provisioningService.createKey(
           `user-${userId}`,
@@ -284,18 +303,20 @@ export class UsersService {
           })
           .where(eq(users.id, userId));
         this.logger.log(
-          `Reprovisioned OpenRouter key for user ${userId} during budget update.`,
+          `Provisioned OpenRouter key for user ${userId} during budget update.`,
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         this.logger.error(
-          `Failed to reprovision OpenRouter key for user ${userId}: ${msg}`,
+          `Failed to provision OpenRouter key for user ${userId}: ${msg}`,
         );
         throw new ServiceUnavailableException(
           'Could not provision an OpenRouter key for this user. Please try again in a moment.',
         );
       }
     }
+    // else: budget=0 AND no key — nothing to provision, our gate
+    // handles the block. Admin can raise the budget later to enable.
 
     const budgetCents = Math.round(budgetUsd * 100);
     await this.db
@@ -304,6 +325,32 @@ export class UsersService {
       .where(eq(users.id, userId));
 
     return { monthlyBudgetCents: budgetCents };
+  }
+
+  /**
+   * Promote / demote a user's organization-level role. Caller-side
+   * checks (admin guard, self-mutation block) live in the controller;
+   * here we just validate the value and write.
+   */
+  async updateRole(
+    userId: string,
+    role: string,
+  ): Promise<{ id: string; role: string }> {
+    const validRoles = ['basic', 'advanced', 'admin'];
+    if (!validRoles.includes(role)) {
+      throw new BadRequestException(
+        `Role must be one of: ${validRoles.join(', ')}`,
+      );
+    }
+
+    const [updated] = await this.db
+      .update(users)
+      .set({ role, updatedAt: new Date() })
+      .where(eq(users.id, userId))
+      .returning({ id: users.id, role: users.role });
+
+    if (!updated) throw new NotFoundException('User not found');
+    return updated;
   }
 
   async remove(userId: string, callerId: string) {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -60,6 +60,7 @@ export class UsersService {
         role: users.role,
         inviteStatus: users.inviteStatus,
         monthlyBudgetCents: users.monthlyBudgetCents,
+        openrouterKeyId: users.openrouterKeyId,
         createdAt: users.createdAt,
       })
       .from(users);
@@ -113,6 +114,13 @@ export class UsersService {
         status: membership?.status ?? 'accepted',
         teams: membership?.teams ?? [],
         monthlyBudgetCents: u.monthlyBudgetCents,
+        // True when the user finished Managed-Cloud onboarding (so they
+        // have a provisioned OpenRouter key) but no admin has set a
+        // budget yet — every chat call would otherwise 402. Drives the
+        // "N users awaiting budget approval" banner on Management →
+        // Users.
+        pendingBudgetApproval:
+          !!u.openrouterKeyId && u.monthlyBudgetCents === 0,
         spentCents: 0, // TODO: integrate with OpenRouter usage API
         projectedCents: 0, // TODO: integrate with OpenRouter usage API
         createdAt: u.createdAt,

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -411,7 +411,9 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     if (budgetInput === null) return;
     const raw = budgetInput.replace(/\./g, "").replace(",", ".");
     const num = parseFloat(raw);
-    if (!isNaN(num) && num > 0 && num !== budget) budgetMutation.mutate(num);
+    // 0 is allowed as a "suspend" gesture — blocks all spend until the
+    // owner raises the budget again. BE enforces non-negative.
+    if (!isNaN(num) && num >= 0 && num !== budget) budgetMutation.mutate(num);
     setBudgetInput(null);
   };
 

--- a/apps/web/src/app/(app)/teams/page.tsx
+++ b/apps/web/src/app/(app)/teams/page.tsx
@@ -241,8 +241,10 @@ export default function TeamsPage() {
             Managed-Cloud onboarding but still have monthlyBudgetCents = 0
             — they can't make AI calls until an admin sets a budget. The
             banner is clickable: it filters the table to just those rows
-            so the action is one click away. */}
-        {pendingApprovalCount > 0 && (
+            so the action is one click away. Admin-only because only
+            admins can mutate budgets — basic / advanced users seeing
+            this would have no way to act on it. */}
+        {user?.role === "admin" && pendingApprovalCount > 0 && (
           <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-warning-7/30 bg-warning-1 px-4 py-3">
             <p className="text-[13px] text-text-1">
               <strong className="font-semibold">

--- a/apps/web/src/app/(app)/teams/page.tsx
+++ b/apps/web/src/app/(app)/teams/page.tsx
@@ -40,6 +40,9 @@ export default function TeamsPage() {
   const [teamSearch, setTeamSearch] = useState("");
   const [userSearch, setUserSearch] = useState("");
   const [modelSearch, setModelSearch] = useState("");
+  // When the "X users awaiting budget approval" banner is clicked, the
+  // table narrows to just those rows so the admin can quickly action them.
+  const [showPendingOnly, setShowPendingOnly] = useState(false);
 
   const {
     data: teams = [],
@@ -63,11 +66,19 @@ export default function TeamsPage() {
     t.name.toLowerCase().includes(teamSearch.toLowerCase()),
   );
 
-  const filteredUsers = orgUsers.filter(
-    (u) =>
-      u.email.toLowerCase().includes(userSearch.toLowerCase()) ||
-      (u.name ?? "").toLowerCase().includes(userSearch.toLowerCase()),
-  );
+  const filteredUsers = orgUsers
+    .filter((u) =>
+      showPendingOnly ? u.pendingBudgetApproval : true,
+    )
+    .filter(
+      (u) =>
+        u.email.toLowerCase().includes(userSearch.toLowerCase()) ||
+        (u.name ?? "").toLowerCase().includes(userSearch.toLowerCase()),
+    );
+
+  const pendingApprovalCount = orgUsers.filter(
+    (u) => u.pendingBudgetApproval,
+  ).length;
 
   const {
     data: models = [],
@@ -226,6 +237,31 @@ export default function TeamsPage() {
             </InviteUserDialog>
           </DisabledReasonTooltip>
         </div>
+        {/* Pending-budget-approval banner. Surfaces users who finished
+            Managed-Cloud onboarding but still have monthlyBudgetCents = 0
+            — they can't make AI calls until an admin sets a budget. The
+            banner is clickable: it filters the table to just those rows
+            so the action is one click away. */}
+        {pendingApprovalCount > 0 && (
+          <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-warning-7/30 bg-warning-1 px-4 py-3">
+            <p className="text-[13px] text-text-1">
+              <strong className="font-semibold">
+                {pendingApprovalCount}{" "}
+                {pendingApprovalCount === 1 ? "user is" : "users are"}
+              </strong>{" "}
+              awaiting budget approval — set a monthly budget for{" "}
+              {pendingApprovalCount === 1 ? "them" : "each"} to enable AI
+              access.
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowPendingOnly((v) => !v)}
+              className="shrink-0 rounded-md px-3 py-1 text-[12px] font-medium text-warning-7 transition-colors hover:bg-warning-7/10"
+            >
+              {showPendingOnly ? "Show all users" : "Show pending only"}
+            </button>
+          </div>
+        )}
         <div className="overflow-x-auto bg-bg-white rounded-lg">
           <table className="w-full min-w-[850px]">
             <thead>

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -24,7 +24,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { fetchOrgUser, updateMemberRole, updateUserBudget } from "@/lib/api";
+import {
+  fetchOrgUser,
+  updateMemberRole,
+  updateUserBudget,
+  updateUserRole,
+  type OrgRole,
+} from "@/lib/api";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
 import { useAuth } from "@/components/providers";
@@ -59,6 +65,56 @@ function UserAvatar({ name, picture, size = 80 }: { name: string; picture: strin
     >
       {getInitials(name)}
     </div>
+  );
+}
+
+/**
+ * Role indicator + admin-only role select. Non-admin viewers see a
+ * read-only badge. Admins viewing other users see a Select that
+ * mutates `users.role`. Admins viewing THEMSELVES still see a badge —
+ * the BE blocks self-mutation (lockout prevention) so the FE doesn't
+ * offer the affordance either.
+ */
+function UserRoleControl({
+  user,
+  canEdit,
+  onChange,
+  pending,
+}: {
+  user: { role: "basic" | "advanced" | "admin" };
+  canEdit: boolean;
+  onChange: (role: OrgRole) => void;
+  pending: boolean;
+}) {
+  const badgeClass =
+    user.role === "admin"
+      ? "border-transparent bg-danger-1 text-danger-6 uppercase tracking-wide text-[10px] px-1.5 py-0"
+      : user.role === "advanced"
+        ? "border-transparent bg-primary-1 text-primary-7 uppercase tracking-wide text-[10px] px-1.5 py-0"
+        : "border-transparent bg-bg-3 text-text-2 uppercase tracking-wide text-[10px] px-1.5 py-0";
+
+  if (!canEdit) {
+    return <Badge className={badgeClass}>{user.role}</Badge>;
+  }
+
+  return (
+    <Select
+      value={user.role}
+      onValueChange={(v) => {
+        if (v === user.role) return;
+        onChange(v as OrgRole);
+      }}
+      disabled={pending}
+    >
+      <SelectTrigger className="h-7 w-[110px] rounded-full border-border-3 bg-bg-1 px-2.5 text-[11px] font-semibold uppercase tracking-wide text-text-2">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="basic">Basic</SelectItem>
+        <SelectItem value="advanced">Advanced</SelectItem>
+        <SelectItem value="admin">Admin</SelectItem>
+      </SelectContent>
+    </Select>
   );
 }
 
@@ -126,6 +182,20 @@ export default function UserDetailPage({
     },
   });
 
+  const orgRoleMutation = useMutation({
+    mutationFn: (role: OrgRole) => updateUserRole(id, role),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["users", id] });
+      // Refresh the org-users list so the role badge in Management →
+      // Users updates immediately without a hard reload.
+      queryClient.invalidateQueries({ queryKey: ["org-users"] });
+      toast.success(`Role updated to ${data.role}.`);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Couldn't update role.");
+    },
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -158,7 +228,10 @@ export default function UserDetailPage({
     if (budgetInput === null) return;
     const raw = budgetInput.replace(/\./g, "").replace(",", ".");
     const num = parseFloat(raw);
-    if (!isNaN(num) && num > 0 && num !== budget) {
+    // Allow 0 — that's the "suspend" gesture (admin blocks all spend
+    // for this user until they raise the budget again). BE enforces
+    // non-negative.
+    if (!isNaN(num) && num >= 0 && num !== budget) {
       budgetMutation.mutate(num);
     }
     setBudgetInput(null);
@@ -175,15 +248,14 @@ export default function UserDetailPage({
             <div className="space-y-3">
               <div className="flex items-center gap-2">
                 <p className="text-[18px] font-bold text-text-1">{displayName}</p>
-                <Badge
-                  className={
-                    user.tier === "advanced"
-                      ? "border-transparent bg-primary-1 text-primary-7 uppercase tracking-wide text-[10px] px-1.5 py-0"
-                      : "border-transparent bg-bg-3 text-text-2 uppercase tracking-wide text-[10px] px-1.5 py-0"
+                <UserRoleControl
+                  user={user}
+                  canEdit={
+                    currentUser?.role === "admin" && currentUser.id !== id
                   }
-                >
-                  {user.tier === "advanced" ? "Advanced" : "Basic"}
-                </Badge>
+                  onChange={(role) => orgRoleMutation.mutate(role)}
+                  pending={orgRoleMutation.isPending}
+                />
               </div>
               <p className="text-[16px] text-text-1">{user.email}</p>
             </div>

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
 import { fetchOrgUser, updateMemberRole, updateUserBudget } from "@/lib/api";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
+import { useAuth } from "@/components/providers";
 
 /* ─── Helper components ──────────────────────────────────────────────────── */
 
@@ -84,6 +85,12 @@ export default function UserDetailPage({
 }) {
   const { id } = use(params);
   const queryClient = useQueryClient();
+  const { user: currentUser } = useAuth();
+  // Mirrors the BE guard on PATCH /users/:id/budget — only admins may
+  // change a user's spend cap, since the cap is enforced upstream on
+  // OpenRouter and basic / advanced users letting each other lift it
+  // would defeat the whole point of the budget.
+  const canEditBudget = currentUser?.role === "admin";
 
   const { data: user, isLoading, error } = useQuery({
     queryKey: ["users", id],
@@ -95,6 +102,9 @@ export default function UserDetailPage({
   const budgetMutation = useMutation({
     mutationFn: (budgetUsd: number) => updateUserBudget(id, budgetUsd),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["users", id] }),
+    onError: (err: Error) => {
+      toast.error(err.message || "Couldn't update budget.");
+    },
   });
 
   const roleMutation = useMutation({
@@ -197,9 +207,21 @@ export default function UserDetailPage({
                 onChange={(e) => setBudgetInput(e.target.value)}
                 onBlur={handleBudgetBlur}
                 onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
-                className="w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-2 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
+                disabled={!canEditBudget}
+                title={
+                  canEditBudget
+                    ? undefined
+                    : "Only admins can change a user's monthly budget."
+                }
+                className="w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-2 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60"
               />
             </div>
+            {!canEditBudget && (
+              <p className="text-[12px] text-text-3">
+                Only admins can change this — ask an admin to adjust the
+                budget.
+              </p>
+            )}
           </div>
 
           {/* Spent / Remaining */}

--- a/apps/web/src/app/setup-profile/step-3/page.tsx
+++ b/apps/web/src/app/setup-profile/step-3/page.tsx
@@ -30,7 +30,7 @@ export default function SetupProfileStep3Page() {
               Set up your WorkenAI Identity
             </h1>
             <p className="text-[18px] font-normal leading-snug text-text-2 text-center">
-              Configure your organizational profile to customize your
+              Tell us a bit about yourself so we can personalize your
               enterprise AI experience.
             </p>
           </div>

--- a/apps/web/src/app/setup-profile/step-5/page.tsx
+++ b/apps/web/src/app/setup-profile/step-5/page.tsx
@@ -119,6 +119,13 @@ export default function SetupProfileStep5Page() {
                         onChange={(e) => setApiKey(id, e.target.value)}
                         className="h-11 text-base rounded-md border-border-3 placeholder:text-text-3 font-mono"
                       />
+                      {(id === "azure" || id === "private-vpc") && (
+                        <p className="text-[12px] text-text-3 leading-snug">
+                          {id === "azure"
+                            ? "Azure also needs a deployment URL — finish setup later in Management → Integration."
+                            : "Private VPC needs an endpoint URL — finish setup later in Management → Integration."}
+                        </p>
+                      )}
                     </div>
                   )}
                 </div>

--- a/apps/web/src/app/setup-profile/step-5/page.tsx
+++ b/apps/web/src/app/setup-profile/step-5/page.tsx
@@ -11,11 +11,40 @@ import { useOnboarding } from "../layout";
 
 type ProviderId = "openai" | "azure" | "anthropic" | "private-vpc";
 
-const PROVIDERS: Array<{ id: ProviderId; name: string; models: string }> = [
-  { id: "openai", name: "OpenAI", models: "GPT-4, GPT-3.5" },
-  { id: "azure", name: "Azure OpenAI", models: "Enterprise GPT-4" },
-  { id: "anthropic", name: "Anthropic", models: "Claude 3 Opus" },
-  { id: "private-vpc", name: "Private VPC", models: "Mistral, Llama" },
+// Per-provider placeholder mirrors the format the user sees in their
+// provider dashboard so they know they're pasting the right thing. We
+// avoid fully-formed valid-looking strings to discourage anyone copying
+// the placeholder itself by accident.
+const PROVIDERS: Array<{
+  id: ProviderId;
+  name: string;
+  models: string;
+  placeholder: string;
+}> = [
+  {
+    id: "openai",
+    name: "OpenAI",
+    models: "GPT-4, GPT-3.5",
+    placeholder: "sk-proj-…",
+  },
+  {
+    id: "azure",
+    name: "Azure OpenAI",
+    models: "Enterprise GPT-4",
+    placeholder: "Azure deployment key (32-char hex)",
+  },
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    models: "Claude 3 Opus",
+    placeholder: "sk-ant-api03-…",
+  },
+  {
+    id: "private-vpc",
+    name: "Private VPC",
+    models: "Mistral, Llama",
+    placeholder: "Endpoint URL or bearer token",
+  },
 ];
 
 export default function SetupProfileStep5Page() {
@@ -47,7 +76,7 @@ export default function SetupProfileStep5Page() {
           </div>
 
           <div className="flex flex-col gap-2">
-            {PROVIDERS.map(({ id, name, models }) => {
+            {PROVIDERS.map(({ id, name, models, placeholder }) => {
               const isExpanded = expanded === id;
               return (
                 <div
@@ -85,10 +114,10 @@ export default function SetupProfileStep5Page() {
                       </label>
                       <Input
                         type="password"
-                        placeholder={`Enter your ${name} API key`}
+                        placeholder={placeholder}
                         value={apiKeys[id] ?? ""}
                         onChange={(e) => setApiKey(id, e.target.value)}
-                        className="h-11 text-base rounded-md border-border-3 placeholder:text-text-3"
+                        className="h-11 text-base rounded-md border-border-3 placeholder:text-text-3 font-mono"
                       />
                     </div>
                   )}

--- a/apps/web/src/app/setup-profile/step-6/page.tsx
+++ b/apps/web/src/app/setup-profile/step-6/page.tsx
@@ -210,7 +210,8 @@ export default function SetupProfileStep6Page() {
           {/* Upload status / selected files */}
           {files.length === 0 ? (
             <div className="rounded border border-border-2 bg-bg-1 px-6 py-5 text-center text-[13px] text-text-3">
-              No files uploaded yet. Add documents to begin training your AI.
+              No files uploaded yet — this step is optional. You can finish
+              setup now and add documents later from Knowledge Core.
             </div>
           ) : (
             <ul className="flex flex-col gap-2">
@@ -251,11 +252,15 @@ export default function SetupProfileStep6Page() {
               Back
             </Button>
             <Button
-              className="h-12 w-[175px] rounded-lg bg-primary-6 hover:bg-primary-7 text-text-white"
+              className="h-12 w-[200px] rounded-lg bg-primary-6 hover:bg-primary-7 text-text-white"
               onClick={() => mutation.mutate()}
               disabled={mutation.isPending}
             >
-              {mutation.isPending ? "Saving..." : "Complete Setup"}
+              {mutation.isPending
+                ? "Saving..."
+                : files.length === 0
+                  ? "Skip & Finish Setup"
+                  : "Complete Setup"}
             </Button>
           </div>
         </div>

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -540,7 +540,19 @@ export function IntegrationTab() {
                     toggleMutation.mutate({ card, next })
                   }
                   onClick={(e) => e.stopPropagation()}
-                  disabled={toggleMutation.isPending}
+                  // Disabled when there's no key on a predefined provider —
+                  // a green toggle without a key wouldn't actually route
+                  // anything (BYOK falls through to OpenRouter). The user
+                  // adds a key first via Settings, which auto-enables.
+                  disabled={
+                    toggleMutation.isPending ||
+                    (!card.isCustom && !card.hasApiKey)
+                  }
+                  title={
+                    !card.isCustom && !card.hasApiKey
+                      ? "Add an API key in Settings before enabling — without one, this toggle has no effect."
+                      : undefined
+                  }
                 />
               </div>
 

--- a/apps/web/src/components/management/integration-tab.tsx
+++ b/apps/web/src/components/management/integration-tab.tsx
@@ -540,19 +540,7 @@ export function IntegrationTab() {
                     toggleMutation.mutate({ card, next })
                   }
                   onClick={(e) => e.stopPropagation()}
-                  // Disabled when there's no key on a predefined provider —
-                  // a green toggle without a key wouldn't actually route
-                  // anything (BYOK falls through to OpenRouter). The user
-                  // adds a key first via Settings, which auto-enables.
-                  disabled={
-                    toggleMutation.isPending ||
-                    (!card.isCustom && !card.hasApiKey)
-                  }
-                  title={
-                    !card.isCustom && !card.hasApiKey
-                      ? "Add an API key in Settings before enabling — without one, this toggle has no effect."
-                      : undefined
-                  }
+                  disabled={toggleMutation.isPending}
                 />
               </div>
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -728,6 +728,13 @@ export interface OrgUser {
   status: "pending" | "accepted";
   teams: string[];
   monthlyBudgetCents: number;
+  /**
+   * True when the user finished Managed-Cloud onboarding (has an
+   * OpenRouter key provisioned) but no admin has set a monthly budget
+   * yet — they cannot make AI calls until budget is bumped from 0.
+   * Drives the "N users awaiting approval" banner on Management → Users.
+   */
+  pendingBudgetApproval: boolean;
   spentCents: number;
   projectedCents: number;
   createdAt: string;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -782,7 +782,28 @@ export async function updateUserBudget(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ budgetUsd }),
   });
-  if (!res.ok) throw new Error("Failed to update user budget");
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to update user budget");
+  }
+  return res.json();
+}
+
+export type OrgRole = "basic" | "advanced" | "admin";
+
+export async function updateUserRole(
+  userId: string,
+  role: OrgRole,
+): Promise<{ id: string; role: OrgRole }> {
+  const res = await apiFetch(`/users/${userId}/role`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ role }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to update user role");
+  }
   return res.json();
 }
 

--- a/apps/web/src/lib/chat-errors.ts
+++ b/apps/web/src/lib/chat-errors.ts
@@ -25,7 +25,23 @@ export function humanizeChatError(err: unknown): string {
   const withModel = (tpl: (name: string) => string): string =>
     modelName ? tpl(modelName) : tpl("The selected model");
 
-  // 402 first — OpenRouter's body for budget-exhausted hits is full of
+  // Pending-approval check FIRST — this is a 402 too, but distinct from
+  // a budget that was set and then exhausted. The BE prefixes its error
+  // string with BUDGET_PENDING_APPROVAL when a Managed Cloud user has a
+  // provisioned key but no budget yet (admin hasn't approved). Keep this
+  // branch above the generic 402 so the user gets the actionable
+  // "ask your admin" message instead of "your budget is exhausted".
+  if (/BUDGET_PENDING_APPROVAL/.test(raw)) {
+    // BE crafts a specific, actionable sentence after the marker;
+    // strip the marker and pass the rest through verbatim.
+    const stripped = raw.replace(/^.*BUDGET_PENDING_APPROVAL:\s*/, "").trim();
+    return (
+      stripped ||
+      "Your account is pending budget approval. Ask your admin to set a monthly budget in Management → Users so you can start using AI."
+    );
+  }
+
+  // 402 — OpenRouter's body for budget-exhausted hits is full of
   // "max_tokens" and "total limit" wording that would otherwise false-
   // positive into the context-length branch below. The HTTP status code
   // is the most reliable signal, hence the \b402\b check here.

--- a/apps/web/src/lib/chat-errors.ts
+++ b/apps/web/src/lib/chat-errors.ts
@@ -27,16 +27,18 @@ export function humanizeChatError(err: unknown): string {
 
   // Pending-approval check FIRST — this is a 402 too, but distinct from
   // a budget that was set and then exhausted. The BE prefixes its error
-  // string with BUDGET_PENDING_APPROVAL when a Managed Cloud user has a
-  // provisioned key but no budget yet (admin hasn't approved). Keep this
-  // branch above the generic 402 so the user gets the actionable
-  // "ask your admin" message instead of "your budget is exhausted".
-  if (/BUDGET_PENDING_APPROVAL/.test(raw)) {
-    // BE crafts a specific, actionable sentence after the marker;
-    // strip the marker and pass the rest through verbatim.
-    const stripped = raw.replace(/^.*BUDGET_PENDING_APPROVAL:\s*/, "").trim();
+  // string with `BUDGET_PENDING_APPROVAL: <message>` when a Managed
+  // Cloud user has no admin-approved budget yet. Keep this branch above
+  // the generic 402 so the user gets the actionable "ask your admin"
+  // message instead of "your budget is exhausted".
+  //
+  // Anchored on the colon-then-message shape so any future error that
+  // mentions the constant by name (telemetry echo, log line surfaced to
+  // FE) won't accidentally trigger this branch.
+  const pendingMatch = raw.match(/BUDGET_PENDING_APPROVAL:\s*([^\r\n]+)/);
+  if (pendingMatch) {
     return (
-      stripped ||
+      pendingMatch[1].trim() ||
       "Your account is pending budget approval. Ask your admin to set a monthly budget in Management → Users so you can start using AI."
     );
   }

--- a/packages/database/backfill/backfill-legacy-onboarding-completed.sql
+++ b/packages/database/backfill/backfill-legacy-onboarding-completed.sql
@@ -1,0 +1,26 @@
+-- One-off backfill: mark legacy single-step profile-picker users as fully
+-- onboarded so the tightened OnboardingGuard does not bounce them into the
+-- new 6-step wizard.
+--
+-- Background: until this migration, auth.service.getUser computed
+--   onboardingCompleted := !!onboarding_completed_at || !!profile_type
+-- so users who only ever picked Company/Personal in the legacy flow were
+-- treated as onboarded even though they never entered infra/LLM/docs. We
+-- are tightening the BE to require onboarding_completed_at, which would
+-- otherwise re-onboard those legacy users. Pre-flight by stamping a
+-- timestamp for them here.
+--
+-- Idempotent: re-running is a no-op (WHERE clause excludes already-stamped
+-- rows). Safe to apply multiple times.
+--
+-- Verify before/after:
+--   SELECT COUNT(*) FILTER (WHERE profile_type IS NOT NULL AND onboarding_completed_at IS NULL) AS legacy_pending
+--   FROM users;
+--
+-- Run from repo root:
+--   docker exec -i worken-postgres psql -U worken -d worken < packages/database/backfill/backfill-legacy-onboarding-completed.sql
+
+UPDATE users
+SET onboarding_completed_at = COALESCE(updated_at, created_at, now())
+WHERE profile_type IS NOT NULL
+  AND onboarding_completed_at IS NULL;

--- a/packages/database/backfill/migrate-legacy-llm-credentials-to-integrations.sql
+++ b/packages/database/backfill/migrate-legacy-llm-credentials-to-integrations.sql
@@ -1,0 +1,50 @@
+-- One-off backfill: copy openai/anthropic API keys from the legacy
+-- `user_llm_credentials` table into the new `integrations` table so
+-- they show up enabled in Management → Integration.
+--
+-- Background: until commit 595f986, onboarding step 5 wrote keys to
+-- `user_llm_credentials`, which nothing in the live system reads from
+-- (chat-transport BYOK and the Integration tab both read from
+-- `integrations`). Users who onboarded before that fix (or before its
+-- API restart took effect) typed keys that landed in dead storage —
+-- their Integration tab shows every provider as "Not configured" even
+-- though the encrypted blobs are right there in the legacy table.
+--
+-- This migration walks every legacy row for openai/anthropic and
+-- inserts a matching `integrations` row with `is_enabled = true`,
+-- reusing the SAME encrypted blob (no re-encryption needed — both
+-- tables use the same EncryptionService key). Other legacy providers
+-- (azure, private-vpc) are skipped because they don't 1:1 map to a
+-- predefined provider and need additional fields (deployment URL,
+-- VPC endpoint) the wizard never collected.
+--
+-- Idempotent: the NOT EXISTS guard means re-running is a no-op for
+-- rows already migrated. Safe to apply multiple times. Doesn't touch
+-- the legacy rows — leave them in place until a separate cleanup PR
+-- drops the table once we've confirmed nothing else reads from it.
+--
+-- Verify before / after:
+--   SELECT
+--     (SELECT count(*) FROM user_llm_credentials WHERE provider IN ('openai','anthropic')) AS legacy,
+--     (SELECT count(*) FROM integrations WHERE provider_id IN ('openai','anthropic') AND api_url IS NULL) AS migrated;
+--
+-- Run from repo root:
+--   docker exec -i worken-postgres psql -U worken -d worken \
+--     < packages/database/backfill/migrate-legacy-llm-credentials-to-integrations.sql
+
+INSERT INTO integrations (owner_id, provider_id, api_url, api_key_encrypted, is_enabled, created_at)
+SELECT
+  ulc.user_id,
+  ulc.provider,
+  NULL,
+  ulc.api_key_encrypted,
+  TRUE,
+  ulc.created_at
+FROM user_llm_credentials ulc
+WHERE ulc.provider IN ('openai', 'anthropic')
+  AND NOT EXISTS (
+    SELECT 1 FROM integrations i
+    WHERE i.owner_id = ulc.user_id
+      AND i.provider_id = ulc.provider
+      AND i.api_url IS NULL
+  );


### PR DESCRIPTION
 ## Summary

  Audit of the onboarding flow against Figma turned up one critical bypass and a stack of smaller gaps. This PR closes the bypass, wires Managed Cloud to actually provision the OpenRouter key it implies, lets
  step-5 keys flow into the Integration tab the way the wizard implies, polishes copy / placeholders / email branding, and ships the pending-approval UX so admins know when a new user is waiting and users see
  an actionable message instead of a confusing 402.

  ## What's in here

  - **Tightened onboarding gate** (`9d8478f`). `auth.service.getUser` no longer admits users to `/` based on `profile_type` alone — it now requires `onboarding_completed_at`. A user who picked Company/Personal
  in step 3 and bailed used to be admitted to the dashboard with no infra, no LLM keys, no documents; that's closed. Backfill SQL stamps the timestamp for legacy single-step rows so production users aren't
  bounced back through the wizard.
  - **Managed Cloud OpenRouter provisioning** (`1c7a72b`). Step 5 with `infraChoice: 'managed'` now provisions a per-user OpenRouter sub-account with `limit: 0`. Best-effort post-transaction; `updateBudget`
  self-heals if OpenRouter is down at the moment. Limit stays at 0 by deliberate product choice — admin must explicitly approve a budget before any spend.
  - **Skip-aware step 6 + Personal subtitle** (`bab68ab`). The Knowledge Core CTA reads "Skip & Finish Setup" with no files, "Complete Setup" once a document is added, and the empty state explicitly calls out
  optionality. Personal-branch step 3 no longer says "Configure your organizational profile".
  - **Polish bundle** (`87bc8f6`). Per-provider mono placeholders on step 5 (`sk-proj-…`, `sk-ant-api03-…`, etc.). BE enum validation for `industry` / `teamSize` matching the FE dropdowns. Verification,
  password-reset, and org-invitation emails render the actual logo (106×29) plus a config-gated "Follow Us" footer (LinkedIn / Twitter via env vars).
  - **Pending-approval UX for Managed Cloud users** (`96c8590`). Distinct 402 from the BE prefixed with `BUDGET_PENDING_APPROVAL` plus actionable copy when a Managed Cloud user has `openrouterKeyId` set but
  `monthlyBudgetCents = 0`. FE chat-error humanizer renders the message verbatim instead of the generic "monthly budget exhausted". Same gate is wired into `/compare-models`. On the admin side, `GET /users`
  returns `pendingBudgetApproval` per row and Management → Users shows a yellow banner ("N users are awaiting budget approval — set a monthly budget for each to enable AI access.") with a "Show pending only"
  filter so the action is one click away.
  - **Step-5 keys flow into Integration tab** (`595f986`). Step 5 was writing to the legacy `user_llm_credentials` table, which nothing else in the system reads from — the user typed keys, completed onboarding,
   then opened Management → Integration and saw every provider as "Not configured". Switched the writes to `integrations` with `is_enabled: true`, so OpenAI and Anthropic cards show up enabled with the key set
  immediately. `getProfile` (My Account → Language Model Providers) also now reads from `integrations` so the My Account section reflects the same source of truth. Step-5 buttons that don't 1:1 match the
  predefined catalog (`azure`, `private-vpc`, since they need extra fields like deployment URL / endpoint) drop their keys and surface a hint under the input pointing the user to Management → Integration to
  finish setup — logged for telemetry.
