### PR TITLE
fix(users): clean up straggler FKs so DELETE /users/:id stops 500ing

### DIFF
--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -14,6 +14,7 @@ import {
   projects,
   conversations,
   guardrails,
+  messages,
   tenders,
   tenderTeamMembers,
   knowledgeFolders,
@@ -330,6 +331,11 @@ export class UsersService {
       await tx.delete(tenders).where(eq(tenders.ownerId, userId));
       await tx.delete(knowledgeFolders).where(eq(knowledgeFolders.ownerId, userId));
       await tx.delete(modelConfigs).where(eq(modelConfigs.ownerId, userId));
+      // Personal/global guardrails owned by the user (team_id NULL) AND
+      // any straggler guardrails the user owns on someone else's team —
+      // both have a NO ACTION FK to users.id, so without this they'd
+      // block the final users delete with a 23503 violation.
+      await tx.delete(guardrails).where(eq(guardrails.ownerId, userId));
       await tx.delete(conversations).where(eq(conversations.userId, userId));
       await tx.delete(projects).where(eq(projects.userId, userId));
 
@@ -337,6 +343,15 @@ export class UsersService {
         .update(knowledgeFiles)
         .set({ uploadedById: null })
         .where(eq(knowledgeFiles.uploadedById, userId));
+
+      // Messages the user posted in conversations owned by SOMEONE ELSE
+      // (e.g., team chats) survive the conversations delete above. The
+      // FK is NO ACTION, so we null out the author to preserve the
+      // thread for the remaining members rather than block the delete.
+      await tx
+        .update(messages)
+        .set({ userId: null })
+        .where(eq(messages.userId, userId));
 
       await tx.delete(users).where(eq(users.id, userId));
     });


### PR DESCRIPTION
Admin-initiated user deletion was failing with an Internal Server Error because UsersService.remove() didn't clean up two tables that have NO ACTION foreign keys to users.id:

- guardrails.owner_id — only handled when team_id was in the user's owned-team set, missing personal/global guardrails (team_id NULL) and the edge case where the user owns a guardrail on someone else's team. Postgres rejected the final users delete with a 23503 violation.
- messages.user_id — survives the conversations delete (which only cascades messages whose conversation_id was deleted). Messages the user posted in someone else's conversation (team chat, future shared threads) stay behind with a dangling user reference.

Add an explicit `delete from guardrails where owner_id = userId` to catch the strays, and `update messages set user_id = null where user_id = userId` to preserve threads in shared conversations rather than blocking the delete.

Verified locally: deleting a user with 4 personal guardrails (the case that triggered the 500) now returns 200 OK + the row is gone + no orphans remain.