### PR TITLE
feat(billing): users.plan column + read-only My Account display  

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -516,6 +516,7 @@ export class AuthService {
       name: user.name,
       picture: user.picture,
       role: userRole,
+      plan: user.plan,
       inviteStatus: user.inviteStatus,
       emailVerified: !!user.emailVerifiedAt,
       profileType: user.profileType as 'company' | 'personal' | null,

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -357,6 +357,7 @@ export class OnboardingService {
       name: u.name,
       email: u.email,
       picture: u.picture,
+      plan: u.plan,
       profileType: u.profileType as 'company' | 'personal' | null,
       companyName: u.companyName,
       industry: u.industry,

--- a/apps/web/src/components/management/account-tab.tsx
+++ b/apps/web/src/components/management/account-tab.tsx
@@ -12,6 +12,7 @@ import {
   Check,
   X,
   Download,
+  Sparkles,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 
@@ -76,6 +77,37 @@ function Section({
       {children}
     </div>
   );
+}
+
+/**
+ * Static plan catalog. The BE column is loose-typed (any string) so
+ * unknown plan ids fall back to a capitalize-the-raw-string render
+ * rather than crashing — anyone can ship a new plan id without an
+ * FE deploy. Add an entry here when the new plan launches and the
+ * marketing copy is final.
+ */
+const PLAN_DETAILS: Record<
+  string,
+  { label: string; tagline: string; tone: "neutral" | "primary" | "premium" }
+> = {
+  free: {
+    label: "Free",
+    tagline:
+      "Default plan for every new account. Personal workspace and trial-tier usage.",
+    tone: "neutral",
+  },
+};
+
+function getPlanDetails(plan: string) {
+  if (PLAN_DETAILS[plan]) return PLAN_DETAILS[plan];
+  return {
+    label: plan
+      .split(/[-_\s]+/)
+      .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : ""))
+      .join(" "),
+    tagline: "Custom plan.",
+    tone: "neutral" as const,
+  };
 }
 
 function buildPermissions(role: "admin" | "advanced" | "basic") {
@@ -202,6 +234,29 @@ export function AccountTab() {
             </p>
           </Section>
         </div>
+
+        {/* Plan — full width row showing the user's subscription tier. */}
+        <Section title="Plan" icon={Sparkles}>
+          {(() => {
+            const planDetails = getPlanDetails(data.plan);
+            const badgeClass =
+              planDetails.tone === "premium"
+                ? "bg-warning-1 text-warning-7"
+                : planDetails.tone === "primary"
+                  ? "bg-primary-1 text-primary-7"
+                  : "bg-bg-3 text-text-2";
+            return (
+              <div className="flex items-center gap-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-3 py-1 text-[13px] font-semibold uppercase tracking-wide ${badgeClass}`}
+                >
+                  {planDetails.label}
+                </span>
+                <p className="text-[13px] text-text-3">{planDetails.tagline}</p>
+              </div>
+            );
+          })()}
+        </Section>
 
         {/* Permissions — full width list */}
         <Section title="Access tier & permissions" icon={ShieldCheck}>

--- a/apps/web/src/components/management/account-tab.tsx
+++ b/apps/web/src/components/management/account-tab.tsx
@@ -15,9 +15,11 @@ import {
   Sparkles,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/components/providers";
 import { fetchOnboardingProfile, type OnboardingProfile } from "@/lib/api";
 
@@ -92,8 +94,7 @@ const PLAN_DETAILS: Record<
 > = {
   free: {
     label: "Free",
-    tagline:
-      "Default plan for every new account. Personal workspace and trial-tier usage.",
+    tagline: "You're on the Free plan.",
     tone: "neutral",
   },
 };
@@ -235,7 +236,10 @@ export function AccountTab() {
           </Section>
         </div>
 
-        {/* Plan — full width row showing the user's subscription tier. */}
+        {/* Plan — full width row showing the user's subscription tier
+            plus an Upgrade CTA. The button currently fires a "Coming
+            soon" toast — paid plans aren't built yet. Wire it up to a
+            real upgrade flow once billing lands. */}
         <Section title="Plan" icon={Sparkles}>
           {(() => {
             const planDetails = getPlanDetails(data.plan);
@@ -246,13 +250,28 @@ export function AccountTab() {
                   ? "bg-primary-1 text-primary-7"
                   : "bg-bg-3 text-text-2";
             return (
-              <div className="flex items-center gap-3">
-                <span
-                  className={`inline-flex items-center rounded-full px-3 py-1 text-[13px] font-semibold uppercase tracking-wide ${badgeClass}`}
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <span
+                    className={`inline-flex shrink-0 items-center rounded-full px-3 py-1 text-[13px] font-semibold uppercase tracking-wide ${badgeClass}`}
+                  >
+                    {planDetails.label}
+                  </span>
+                  <p className="text-[13px] text-text-3">
+                    {planDetails.tagline}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  className="shrink-0"
+                  onClick={() =>
+                    toast.info(
+                      "Upgrade flow is coming soon — paid plans aren't live yet.",
+                    )
+                  }
                 >
-                  {planDetails.label}
-                </span>
-                <p className="text-[13px] text-text-3">{planDetails.tagline}</p>
+                  Upgrade account
+                </Button>
               </div>
             );
           })()}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -48,6 +48,10 @@ export interface User {
   id: string;
   email: string;
   role: "admin" | "advanced" | "basic";
+  // Subscription plan. Currently only "free" exists; the field is
+  // typed as a string union with `string` open-end so future plans
+  // ('pro', 'enterprise', …) don't require coordinated FE/BE deploy.
+  plan: "free" | (string & {});
   inviteStatus: "active" | "pending";
   name: string | null;
   picture: string | null;
@@ -1638,6 +1642,8 @@ export interface OnboardingProfile {
   name: string | null;
   email: string;
   picture: string | null;
+  /** Subscription plan — every user has at least 'free'. */
+  plan: "free" | (string & {});
   profileType: "company" | "personal" | null;
   companyName: string | null;
   industry: string | null;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -18,6 +18,12 @@ export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
   email: text("email").notNull().unique(),
   role: text("role").notNull().default("basic"),
+  // Subscription plan. New rows default to 'free'; existing rows get
+  // 'free' too on the first `db:push` thanks to the default. Future
+  // plans (e.g. 'pro', 'enterprise') will live on this column without
+  // a schema change. Kept loose-typed for now — once we know the full
+  // tier set we can lock it down with an enum.
+  plan: text("plan").notNull().default("free"),
   inviteStatus: text("invite_status").notNull().default("active"),
   name: text("name"),
   picture: text("picture"),


### PR DESCRIPTION
  ## Summary

  Scaffolding for billing. Adds a `plan` field to every user (default `'free'`) and surfaces it on Management → My Account with an Upgrade CTA stub. **Purely additive — does not gate, restrict, or filter any
  existing functionality.** Paid plans aren't built yet; the column exists so subsequent billing work can hang off it without a coordinated FE/BE deploy.

  ## What's in here

  - **Schema** (`ac3445e`): new `users.plan` column — `text NOT NULL DEFAULT 'free'`. Existing rows pick up `'free'` automatically when Postgres applies the default during the `db:push` (verified locally on 3
  existing users). New signups inherit it via the same default with no app-level work. Kept loose-typed for now — once the full tier set is final ('pro', 'enterprise', …) it can be locked down with an enum
  migration.
  - **Expose via API** (`c75554b`): `AuthService.getUser` (`GET /auth/me`) and `OnboardingService.getProfile` (`GET /onboarding/profile`) now include `plan` in their response. Read-only — nothing writes to the
  column from app code yet.
  - **FE types** (`c75554b`): `User` and `OnboardingProfile` gain a `plan: "free" | (string & {})` field. The open-ended union means shipping a new plan id from the BE doesn't crash an older FE — unknown values
   fall through to a capitalize-the-raw-string render.
  - **My Account → Plan section** (`c75554b` + `b707b67`): new card on `/teams?tab=my-account` between "AI Infrastructure" and "Access tier & permissions". Shows a tier badge ("FREE") + one-line tagline
  ("You're on the Free plan.") + an **Upgrade account** button on the right. The button fires a "Coming soon — paid plans aren't live yet" toast as a stub; wire to a real upgrade flow once billing lands.

  ## What this PR does NOT do

  Explicitly verified — no part of the codebase reads `plan` to make a decision:

  - No guard / route / endpoint gates on `plan`
  - No model / integration / project / team is filtered by `plan`
  - No budget, quota, or OpenRouter limit changes based on `plan`
  - No FE feature is hidden / disabled by `plan`

  `grep` confirms only 4 references to `plan` total: 2 read-only response fields on the BE, 1 PLAN_DETAILS lookup map on the FE, 1 display call in the JSX. Nothing conditional.

##   Test plan

  - After db:push on prod, every existing user has plan = 'free'
  - New signups land with plan = 'free' (no app-level write needed — schema default)
  - GET /auth/me returns plan in the response body
  - GET /onboarding/profile returns plan in the response body
  - /teams?tab=my-account renders a "Plan" section between "AI Infrastructure" and "Access tier & permissions"
  - Plan section shows a "FREE" badge + "You're on the Free plan." tagline
  - Clicking "Upgrade account" fires a toast saying paid plans are coming soon (no navigation, no error)
  - No regression — existing chat / arena / integration / budget flows behave identically (plan is not consulted)
  - FE typecheck clean (pnpm tsc --noEmit on both apps)

  ##  Already verified locally

  - ✅ All 3 existing users carry plan='free' after db:push
  - ✅ /auth/me and /onboarding/profile both return plan: 'free' for the test user
  - ✅ Plan section renders correctly with badge + tagline + Upgrade button
  - ✅ Both apps tsc --noEmit clean
  - ✅ Grep across apps/ confirms no conditional logic on plan

  ## Out of scope (next billing PRs)

  - Plan-tiered feature gates (e.g. "Free can only have N projects")
  - Per-plan budget caps / OpenRouter limits
  - Stripe / Paddle / payment integration
  - Real upgrade flow behind the CTA
  - Admin UI to manually change a user's plan
  - Per-team plans (currently the column is per-user only)
