### PR TITLE
feat(users-tab): clickable rows + admin edit-mode + activity log

### DIFF
--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -9,6 +9,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import { UsersService } from './users.service.js';
 import { TeamsService } from '../teams/teams.service.js';
@@ -18,6 +19,7 @@ import { eq } from 'drizzle-orm';
 import { users } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { MailService } from '../mail/mail.service.js';
+import { ObservabilityService } from '../observability/observability.service.js';
 
 @Controller('users')
 export class UsersController {
@@ -26,6 +28,7 @@ export class UsersController {
     private readonly usersService: UsersService,
     private readonly teamsService: TeamsService,
     private readonly mailService: MailService,
+    private readonly observabilityService: ObservabilityService,
   ) {}
 
   @Get()
@@ -39,6 +42,45 @@ export class UsersController {
     @CurrentUser() caller: AuthenticatedUser,
   ) {
     return this.usersService.findOne(id, caller.id);
+  }
+
+  /**
+   * User-scoped activity log: paginated observability events for the
+   * given user (chat / arena / evaluator calls, with model, cost,
+   * latency, success). Reuses ObservabilityService.listEvents under
+   * the hood with a from=epoch / to=now window so the result is the
+   * full lifetime of the user, not the dashboard's range filter.
+   *
+   * Auth: admin can see anyone's activity; non-admins can only see
+   * their own. Activity contains promptPreview snippets, so we don't
+   * leak it across users at non-admin level.
+   */
+  @Get(':id/activity')
+  async activity(
+    @Param('id') id: string,
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('page') pageRaw?: string,
+    @Query('pageSize') pageSizeRaw?: string,
+  ) {
+    const [callerUser] = await this.db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, caller.id));
+    const isAdmin = callerUser?.role === 'admin';
+    if (!isAdmin && caller.id !== id) {
+      throw new ForbiddenException(
+        'You can only view your own activity log.',
+      );
+    }
+    const page = Math.max(1, Number(pageRaw) || 1);
+    const pageSize = Math.max(1, Math.min(Number(pageSizeRaw) || 50, 200));
+    return this.observabilityService.listEvents({
+      from: new Date(0),
+      to: new Date(),
+      userId: id,
+      page,
+      pageSize,
+    });
   }
 
   @Post('invite')

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -7,6 +7,9 @@ import {
   Info,
   LayoutList,
   Loader2,
+  Pencil,
+  Check,
+  X,
 } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
@@ -69,42 +72,37 @@ function UserAvatar({ name, picture, size = 80 }: { name: string; picture: strin
 }
 
 /**
- * Role indicator + admin-only role select. Non-admin viewers see a
- * read-only badge. Admins viewing other users see a Select that
- * mutates `users.role`. Admins viewing THEMSELVES still see a badge —
- * the BE blocks self-mutation (lockout prevention) so the FE doesn't
- * offer the affordance either.
+ * Role indicator. In view mode (or for non-editable callers) shows a
+ * read-only Badge. In edit mode shows a controlled Select; the parent
+ * owns the staged value and decides when to commit on Confirm.
  */
 function UserRoleControl({
-  user,
-  canEdit,
+  role,
+  mode,
   onChange,
-  pending,
+  disabled,
 }: {
-  user: { role: "basic" | "advanced" | "admin" };
-  canEdit: boolean;
-  onChange: (role: OrgRole) => void;
-  pending: boolean;
+  role: OrgRole;
+  mode: "view" | "edit";
+  onChange?: (role: OrgRole) => void;
+  disabled?: boolean;
 }) {
   const badgeClass =
-    user.role === "admin"
+    role === "admin"
       ? "border-transparent bg-danger-1 text-danger-6 uppercase tracking-wide text-[10px] px-1.5 py-0"
-      : user.role === "advanced"
+      : role === "advanced"
         ? "border-transparent bg-primary-1 text-primary-7 uppercase tracking-wide text-[10px] px-1.5 py-0"
         : "border-transparent bg-bg-3 text-text-2 uppercase tracking-wide text-[10px] px-1.5 py-0";
 
-  if (!canEdit) {
-    return <Badge className={badgeClass}>{user.role}</Badge>;
+  if (mode === "view") {
+    return <Badge className={badgeClass}>{role}</Badge>;
   }
 
   return (
     <Select
-      value={user.role}
-      onValueChange={(v) => {
-        if (v === user.role) return;
-        onChange(v as OrgRole);
-      }}
-      disabled={pending}
+      value={role}
+      onValueChange={(v) => onChange?.(v as OrgRole)}
+      disabled={disabled}
     >
       <SelectTrigger className="h-7 w-[110px] rounded-full border-border-3 bg-bg-1 px-2.5 text-[11px] font-semibold uppercase tracking-wide text-text-2">
         <SelectValue />
@@ -142,28 +140,34 @@ export default function UserDetailPage({
   const { id } = use(params);
   const queryClient = useQueryClient();
   const { user: currentUser } = useAuth();
-  // Mirrors the BE guard on PATCH /users/:id/budget — only admins may
-  // change a user's spend cap, since the cap is enforced upstream on
-  // OpenRouter and basic / advanced users letting each other lift it
-  // would defeat the whole point of the budget.
-  const canEditBudget = currentUser?.role === "admin";
+  const isAdmin = currentUser?.role === "admin";
+  const isSelf = currentUser?.id === id;
 
   const { data: user, isLoading, error } = useQuery({
     queryKey: ["users", id],
     queryFn: () => fetchOrgUser(id),
   });
 
-  // Budget editing
-  const [budgetInput, setBudgetInput] = useState<string | null>(null);
+  // Edit mode — the page is read-only by default. Admins flip into
+  // edit mode via the green pencil; both Monthly Budget and the
+  // organization role are staged locally and committed atomically
+  // on Confirm. Cancel discards the staged values.
+  const [isEditing, setIsEditing] = useState(false);
+  const [editBudget, setEditBudget] = useState("");
+  const [editRole, setEditRole] = useState<OrgRole>("basic");
+
   const budgetMutation = useMutation({
     mutationFn: (budgetUsd: number) => updateUserBudget(id, budgetUsd),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["users", id] }),
-    onError: (err: Error) => {
-      toast.error(err.message || "Couldn't update budget.");
-    },
   });
 
-  const roleMutation = useMutation({
+  const orgRoleMutation = useMutation({
+    mutationFn: (role: OrgRole) => updateUserRole(id, role),
+  });
+
+  // Team-member role mutation kept separate — that table has its own
+  // inline Select per row (Editor / Viewer) and doesn't go through the
+  // edit-mode flow.
+  const teamRoleMutation = useMutation({
     mutationFn: ({
       teamId,
       memberId,
@@ -176,20 +180,6 @@ export default function UserDetailPage({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users", id] });
       toast.success("Role updated.");
-    },
-    onError: (err: Error) => {
-      toast.error(err.message || "Couldn't update role.");
-    },
-  });
-
-  const orgRoleMutation = useMutation({
-    mutationFn: (role: OrgRole) => updateUserRole(id, role),
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["users", id] });
-      // Refresh the org-users list so the role badge in Management →
-      // Users updates immediately without a hard reload.
-      queryClient.invalidateQueries({ queryKey: ["org-users"] });
-      toast.success(`Role updated to ${data.role}.`);
     },
     onError: (err: Error) => {
       toast.error(err.message || "Couldn't update role.");
@@ -219,22 +209,84 @@ export default function UserDetailPage({
   const projected = user.projectedCents / 100;
   const onTrack = projected <= budget;
 
-  const displayBudget = budgetInput ?? budget.toLocaleString("de-DE", {
+  const formattedBudget = budget.toLocaleString("de-DE", {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
 
-  const handleBudgetBlur = () => {
-    if (budgetInput === null) return;
-    const raw = budgetInput.replace(/\./g, "").replace(",", ".");
-    const num = parseFloat(raw);
-    // Allow 0 — that's the "suspend" gesture (admin blocks all spend
-    // for this user until they raise the budget again). BE enforces
-    // non-negative.
-    if (!isNaN(num) && num >= 0 && num !== budget) {
-      budgetMutation.mutate(num);
+  const isSubmitting = budgetMutation.isPending || orgRoleMutation.isPending;
+  // Block editing your own role — BE rejects self-mutation to avoid
+  // admin lockout, FE matches that.
+  const canEditSelfRole = !isSelf;
+
+  const enterEditMode = () => {
+    setEditBudget(formattedBudget);
+    setEditRole(user.role);
+    setIsEditing(true);
+  };
+
+  const cancelEdit = () => {
+    setIsEditing(false);
+    setEditBudget("");
+  };
+
+  const confirmEdit = async () => {
+    // Parse budget — accept "1.234,56" (de-DE), "1234.56", "0".
+    const raw = editBudget.replace(/\./g, "").replace(",", ".");
+    const parsed = parseFloat(raw);
+    if (isNaN(parsed) || parsed < 0) {
+      toast.error("Budget must be a non-negative number.");
+      return;
     }
-    setBudgetInput(null);
+
+    const budgetChanged = parsed !== budget;
+    const roleChanged = editRole !== user.role;
+    if (!budgetChanged && !roleChanged) {
+      setIsEditing(false);
+      return;
+    }
+
+    // Fire the changed mutations in parallel; surface a per-mutation
+    // toast so a partial failure (e.g. budget OK but role rejected) is
+    // visible. React Query refetches the user on success; the staged
+    // values are cleared regardless so the next edit starts fresh.
+    const tasks: Array<Promise<unknown>> = [];
+    if (budgetChanged) {
+      tasks.push(
+        budgetMutation
+          .mutateAsync(parsed)
+          .then(() => toast.success("Budget updated."))
+          .catch((err: Error) => {
+            toast.error(err.message || "Couldn't update budget.");
+            throw err;
+          }),
+      );
+    }
+    if (roleChanged) {
+      tasks.push(
+        orgRoleMutation
+          .mutateAsync(editRole)
+          .then((data) =>
+            toast.success(`Role updated to ${data.role}.`),
+          )
+          .catch((err: Error) => {
+            toast.error(err.message || "Couldn't update role.");
+            throw err;
+          }),
+      );
+    }
+
+    const results = await Promise.allSettled(tasks);
+    queryClient.invalidateQueries({ queryKey: ["users", id] });
+    queryClient.invalidateQueries({ queryKey: ["org-users"] });
+
+    // Stay in edit mode if anything failed so the user can retry / see
+    // their staged values; exit only on a fully clean run.
+    const allOk = results.every((r) => r.status === "fulfilled");
+    if (allOk) {
+      setIsEditing(false);
+      setEditBudget("");
+    }
   };
 
   return (
@@ -247,48 +299,116 @@ export default function UserDetailPage({
             <UserAvatar name={displayName} picture={user.picture} size={80} />
             <div className="space-y-3">
               <div className="flex items-center gap-2">
-                <p className="text-[18px] font-bold text-text-1">{displayName}</p>
+                <p className="text-[18px] font-bold text-text-1">
+                  {displayName}
+                </p>
                 <UserRoleControl
-                  user={user}
-                  canEdit={
-                    currentUser?.role === "admin" && currentUser.id !== id
+                  role={isEditing ? editRole : user.role}
+                  mode={
+                    isEditing && canEditSelfRole ? "edit" : "view"
                   }
-                  onChange={(role) => orgRoleMutation.mutate(role)}
-                  pending={orgRoleMutation.isPending}
+                  onChange={(r) => setEditRole(r)}
+                  disabled={isSubmitting}
                 />
+                {isEditing && !canEditSelfRole && (
+                  <span className="text-[11px] text-text-3">
+                    (you can&apos;t change your own role)
+                  </span>
+                )}
               </div>
               <p className="text-[16px] text-text-1">{user.email}</p>
             </div>
           </div>
-          <Button variant="outline" className="h-10 gap-2 border-border-2 text-[14px] text-text-1 shrink-0">
-            <LayoutList className="h-4 w-4" />
-            Activity Log
-          </Button>
+          <div className="flex items-center gap-2 shrink-0">
+            <Button
+              variant="outline"
+              className="h-10 gap-2 border-border-2 text-[14px] text-text-1"
+            >
+              <LayoutList className="h-4 w-4" />
+              Activity Log
+            </Button>
+
+            {/* Admin-only edit toggle. View mode shows a green Pencil
+                icon; clicking it stages the current values and reveals
+                the inputs. Edit mode swaps the icon for a Confirm /
+                Cancel pair. Non-admins never see any of these. */}
+            {isAdmin && !isEditing && (
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-10 w-10 border-success-7/40 text-success-7 hover:bg-success-7/10 hover:text-success-7"
+                onClick={enterEditMode}
+                title="Edit Monthly Budget and role"
+              >
+                <Pencil className="h-4 w-4" strokeWidth={2.5} />
+              </Button>
+            )}
+            {isAdmin && isEditing && (
+              <>
+                <Button
+                  variant="outline"
+                  className="h-10 gap-2 border-border-2"
+                  onClick={cancelEdit}
+                  disabled={isSubmitting}
+                >
+                  <X className="h-4 w-4" />
+                  Cancel
+                </Button>
+                <Button
+                  className="h-10 gap-2 bg-success-7 text-white hover:bg-success-7/90"
+                  onClick={confirmEdit}
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Check className="h-4 w-4" strokeWidth={2.5} />
+                  )}
+                  Confirm
+                </Button>
+              </>
+            )}
+          </div>
         </div>
 
         {/* Budget row */}
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {/* Monthly Budget */}
+          {/* Monthly Budget — text in view mode, input in edit mode. */}
           <div className="space-y-3">
             <p className="text-[18px] font-bold text-text-1">Monthly Budget</p>
-            <div className="relative">
-              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[16px] text-text-2">$</span>
-              <input
-                type="text"
-                value={displayBudget}
-                onChange={(e) => setBudgetInput(e.target.value)}
-                onBlur={handleBudgetBlur}
-                onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
-                disabled={!canEditBudget}
-                title={
-                  canEditBudget
-                    ? undefined
-                    : "Only admins can change a user's monthly budget."
-                }
-                className="w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-2 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60"
-              />
-            </div>
-            {!canEditBudget && (
+            {isEditing ? (
+              <div className="relative">
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[16px] text-text-2">
+                  $
+                </span>
+                <input
+                  type="text"
+                  value={editBudget}
+                  onChange={(e) => setEditBudget(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      void confirmEdit();
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      cancelEdit();
+                    }
+                  }}
+                  disabled={isSubmitting}
+                  autoFocus
+                  className="w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+            ) : (
+              <div className="flex h-[56px] items-center px-1 text-[16px] text-text-1">
+                {budget > 0 ? (
+                  <span>{formatCurrency(budget)}</span>
+                ) : (
+                  <span className="text-text-3">Not set</span>
+                )}
+              </div>
+            )}
+            {!isEditing && !isAdmin && (
               <p className="text-[12px] text-text-3">
                 Only admins can change this — ask an admin to adjust the
                 budget.
@@ -359,7 +479,7 @@ export default function UserDetailPage({
                           value={t.role}
                           disabled={!t.canManage}
                           onValueChange={(value) =>
-                            roleMutation.mutate({
+                            teamRoleMutation.mutate({
                               teamId: t.id,
                               memberId: t.memberId,
                               role: value as "editor" | "viewer",

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   MoreVertical,
   Trash2,
   Info,
   LayoutList,
   Loader2,
-  Pencil,
   Check,
   X,
 } from "lucide-react";
@@ -29,11 +29,20 @@ import {
 } from "@/components/ui/select";
 import {
   fetchOrgUser,
+  removeOrgUser,
   updateMemberRole,
   updateUserBudget,
   updateUserRole,
   type OrgRole,
 } from "@/lib/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
 import { useAuth } from "@/components/providers";
@@ -138,6 +147,7 @@ export default function UserDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = use(params);
+  const router = useRouter();
   const queryClient = useQueryClient();
   const { user: currentUser } = useAuth();
   const isAdmin = currentUser?.role === "admin";
@@ -149,12 +159,14 @@ export default function UserDetailPage({
   });
 
   // Edit mode — the page is read-only by default. Admins flip into
-  // edit mode via the green pencil; both Monthly Budget and the
-  // organization role are staged locally and committed atomically
-  // on Confirm. Cancel discards the staged values.
+  // edit mode via the appbar pencil (which dispatches user-detail:edit
+  // on the window); both Monthly Budget and the organization role are
+  // staged locally and committed atomically on Confirm. Cancel
+  // discards the staged values.
   const [isEditing, setIsEditing] = useState(false);
   const [editBudget, setEditBudget] = useState("");
   const [editRole, setEditRole] = useState<OrgRole>("basic");
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const budgetMutation = useMutation({
     mutationFn: (budgetUsd: number) => updateUserBudget(id, budgetUsd),
@@ -186,6 +198,19 @@ export default function UserDetailPage({
     },
   });
 
+  const removeMutation = useMutation({
+    mutationFn: () => removeOrgUser(id),
+    onSuccess: () => {
+      toast.success("User removed.");
+      queryClient.invalidateQueries({ queryKey: ["org-users"] });
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+      router.push("/teams?tab=users");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Couldn't remove user.");
+    },
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -209,21 +234,10 @@ export default function UserDetailPage({
   const projected = user.projectedCents / 100;
   const onTrack = projected <= budget;
 
-  const formattedBudget = budget.toLocaleString("de-DE", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-
   const isSubmitting = budgetMutation.isPending || orgRoleMutation.isPending;
   // Block editing your own role — BE rejects self-mutation to avoid
   // admin lockout, FE matches that.
   const canEditSelfRole = !isSelf;
-
-  const enterEditMode = () => {
-    setEditBudget(formattedBudget);
-    setEditRole(user.role);
-    setIsEditing(true);
-  };
 
   const cancelEdit = () => {
     setIsEditing(false);
@@ -289,6 +303,35 @@ export default function UserDetailPage({
     }
   };
 
+  // The appbar's Pencil / Trash2 buttons fire `user-detail:edit` and
+  // `user-detail:delete` window events (see appbar.tsx — same pattern
+  // as the other appbar actions). Wire them here so the chrome
+  // controls drive page state without prop-drilling through the
+  // layout. Admin gating lives on the appbar side; if a non-admin
+  // somehow dispatches the event, the BE would reject anyway.
+  useEffect(() => {
+    const onEdit = () => {
+      if (!user) return;
+      setEditBudget(
+        (user.monthlyBudgetCents / 100).toLocaleString("de-DE", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        }),
+      );
+      setEditRole(user.role);
+      setIsEditing(true);
+    };
+    const onDelete = () => {
+      setConfirmDeleteOpen(true);
+    };
+    window.addEventListener("user-detail:edit", onEdit);
+    window.addEventListener("user-detail:delete", onDelete);
+    return () => {
+      window.removeEventListener("user-detail:edit", onEdit);
+      window.removeEventListener("user-detail:delete", onDelete);
+    };
+  }, [user]);
+
   return (
     <div className="space-y-6">
       {/* ── User info + Budget card ──────────────────────────────── */}
@@ -328,21 +371,11 @@ export default function UserDetailPage({
               Activity Log
             </Button>
 
-            {/* Admin-only edit toggle. View mode shows a green Pencil
-                icon; clicking it stages the current values and reveals
-                the inputs. Edit mode swaps the icon for a Confirm /
-                Cancel pair. Non-admins never see any of these. */}
-            {isAdmin && !isEditing && (
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-10 w-10 border-success-7/40 text-success-7 hover:bg-success-7/10 hover:text-success-7"
-                onClick={enterEditMode}
-                title="Edit Monthly Budget and role"
-              >
-                <Pencil className="h-4 w-4" strokeWidth={2.5} />
-              </Button>
-            )}
+            {/* Edit-mode controls. The "enter edit mode" pencil lives
+                up in the appbar (see appbar.tsx — userDetail variant);
+                clicking it dispatches a window event the page listens
+                for. Confirm / Cancel are inline because they're
+                contextual to the form state, not chrome. */}
             {isAdmin && isEditing && (
               <>
                 <Button
@@ -527,6 +560,41 @@ export default function UserDetailPage({
           </div>
         </div>
       </div>
+
+      {/* Remove user confirm — opened by the appbar Trash2 dispatch.
+          Mirrors the dialog UserRow uses on /teams?tab=users; on
+          success we route back to the Users tab. */}
+      <Dialog
+        open={confirmDeleteOpen}
+        onOpenChange={(open) => !open && setConfirmDeleteOpen(false)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove user</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to remove{" "}
+              <strong>{displayName}</strong> from the organization? This
+              action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={removeMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => removeMutation.mutate()}
+              disabled={removeMutation.isPending}
+            >
+              {removeMutation.isPending ? "Removing..." : "Remove"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -211,6 +211,40 @@ export default function UserDetailPage({
     },
   });
 
+  // The appbar's Pencil / Trash2 buttons fire `user-detail:edit` and
+  // `user-detail:delete` window events (see appbar.tsx — same pattern
+  // as the other appbar actions). Wire them here so the chrome
+  // controls drive page state without prop-drilling through the
+  // layout. Admin gating lives on the appbar side; if a non-admin
+  // somehow dispatches the event, the BE would reject anyway.
+  //
+  // MUST stay above the early-return guards below — React's rules of
+  // hooks require the hook count to match across every render, so
+  // placing this after `if (isLoading) return ...` would crash the
+  // page on the first load → loaded transition.
+  useEffect(() => {
+    const onEdit = () => {
+      if (!user) return;
+      setEditBudget(
+        (user.monthlyBudgetCents / 100).toLocaleString("de-DE", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        }),
+      );
+      setEditRole(user.role);
+      setIsEditing(true);
+    };
+    const onDelete = () => {
+      setConfirmDeleteOpen(true);
+    };
+    window.addEventListener("user-detail:edit", onEdit);
+    window.addEventListener("user-detail:delete", onDelete);
+    return () => {
+      window.removeEventListener("user-detail:edit", onEdit);
+      window.removeEventListener("user-detail:delete", onDelete);
+    };
+  }, [user]);
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -302,35 +336,6 @@ export default function UserDetailPage({
       setEditBudget("");
     }
   };
-
-  // The appbar's Pencil / Trash2 buttons fire `user-detail:edit` and
-  // `user-detail:delete` window events (see appbar.tsx — same pattern
-  // as the other appbar actions). Wire them here so the chrome
-  // controls drive page state without prop-drilling through the
-  // layout. Admin gating lives on the appbar side; if a non-admin
-  // somehow dispatches the event, the BE would reject anyway.
-  useEffect(() => {
-    const onEdit = () => {
-      if (!user) return;
-      setEditBudget(
-        (user.monthlyBudgetCents / 100).toLocaleString("de-DE", {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        }),
-      );
-      setEditRole(user.role);
-      setIsEditing(true);
-    };
-    const onDelete = () => {
-      setConfirmDeleteOpen(true);
-    };
-    window.addEventListener("user-detail:edit", onEdit);
-    window.addEventListener("user-detail:delete", onDelete);
-    return () => {
-      window.removeEventListener("user-detail:edit", onEdit);
-      window.removeEventListener("user-detail:delete", onDelete);
-    };
-  }, [user]);
 
   return (
     <div className="space-y-6">

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -49,6 +49,74 @@ import { toast } from "sonner";
 import { formatCurrency } from "@/lib/utils";
 import { useAuth } from "@/components/providers";
 
+/**
+ * Live formatter for the de-DE budget input. Called on every
+ * keystroke to keep the displayed value in `1.234,56` shape while the
+ * user is typing. Also smart-parses pasted en-US values (`1234.56` →
+ * `1.234,56`) so both keyboard layouts feel native.
+ *
+ * Pairs with the existing parser in confirmEdit, which strips dots
+ * and converts the comma to a dot before parseFloat.
+ */
+function formatBudgetInput(raw: string): string {
+  // Strip everything except digits, dots, commas.
+  let canonical = raw.replace(/[^\d.,]/g, "");
+
+  const hasComma = canonical.includes(",");
+  const dotCount = (canonical.match(/\./g) ?? []).length;
+
+  if (hasComma) {
+    // de-DE: comma is decimal, dots are thousand separators → drop dots.
+    canonical = canonical.replace(/\./g, "");
+  } else if (dotCount > 0) {
+    // No comma. Heuristic: a single dot followed by 1–2 digits is a
+    // decimal point (en-US paste like "1234.56"). Anything else is
+    // thousand-separator decoration ("1.234") and the dots get
+    // stripped.
+    const lastDot = canonical.lastIndexOf(".");
+    const trailingDigits = canonical.length - lastDot - 1;
+    if (dotCount === 1 && trailingDigits >= 1 && trailingDigits <= 2) {
+      canonical = canonical.replace(".", ",");
+    } else {
+      canonical = canonical.replace(/\./g, "");
+    }
+  }
+
+  // Collapse extra commas (keep first).
+  const firstComma = canonical.indexOf(",");
+  if (firstComma >= 0) {
+    canonical =
+      canonical.slice(0, firstComma + 1) +
+      canonical.slice(firstComma + 1).replace(/,/g, "");
+  }
+
+  if (canonical === "") return "";
+
+  let intPart: string;
+  let fracPart: string | null;
+  if (firstComma >= 0) {
+    const parts = canonical.split(",");
+    intPart = parts[0] ?? "";
+    fracPart = (parts[1] ?? "").slice(0, 2);
+  } else {
+    intPart = canonical;
+    fracPart = null;
+  }
+
+  // Strip leading zeros except keep the last digit; "00012" → "12",
+  // "0" → "0", "0001234" → "1234". Then handle the "0,5" case where
+  // the comma was typed but the int side ended up empty.
+  intPart = intPart.replace(/^0+(?=\d)/, "");
+  if (intPart === "" && fracPart !== null) {
+    intPart = "0";
+  }
+
+  // Insert thousand separators (dots) into the integer part.
+  const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+
+  return fracPart !== null ? `${intFormatted},${fracPart}` : intFormatted;
+}
+
 /* ─── Helper components ──────────────────────────────────────────────────── */
 
 function getInitials(name: string): string {
@@ -518,8 +586,11 @@ export default function UserDetailPage({
                 </span>
                 <input
                   type="text"
+                  inputMode="decimal"
                   value={editBudget}
-                  onChange={(e) => setEditBudget(e.target.value)}
+                  onChange={(e) =>
+                    setEditBudget(formatBudgetInput(e.target.value))
+                  }
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       e.preventDefault();

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -436,6 +436,14 @@ export default function UserDetailPage({
   // Block editing your own role — BE rejects self-mutation to avoid
   // admin lockout, FE matches that.
   const canEditSelfRole = !isSelf;
+  // The edit affordances should only ever render when an admin asks
+  // for them. `isEditing` can be flipped to true by anyone who knows
+  // to dispatch `user-detail:edit` from devtools (the appbar icon
+  // hides for non-admins, but the event is global). Gating the
+  // rendered controls on isAdmin closes that loophole — non-admins
+  // can't end up looking at editable inputs they have no way to
+  // submit, even if they trip the state.
+  const editing = isAdmin && isEditing;
 
   const cancelEdit = () => {
     setIsEditing(false);
@@ -515,14 +523,12 @@ export default function UserDetailPage({
                   {displayName}
                 </p>
                 <UserRoleControl
-                  role={isEditing ? editRole : user.role}
-                  mode={
-                    isEditing && canEditSelfRole ? "edit" : "view"
-                  }
+                  role={editing ? editRole : user.role}
+                  mode={editing && canEditSelfRole ? "edit" : "view"}
                   onChange={(r) => setEditRole(r)}
                   disabled={isSubmitting}
                 />
-                {isEditing && !canEditSelfRole && (
+                {editing && !canEditSelfRole && (
                   <span className="text-[11px] text-text-3">
                     (you can&apos;t change your own role)
                   </span>
@@ -546,7 +552,7 @@ export default function UserDetailPage({
                 clicking it dispatches a window event the page listens
                 for. Confirm / Cancel are inline because they're
                 contextual to the form state, not chrome. */}
-            {isAdmin && isEditing && (
+            {editing && (
               <>
                 <Button
                   variant="outline"
@@ -579,7 +585,7 @@ export default function UserDetailPage({
           {/* Monthly Budget — text in view mode, input in edit mode. */}
           <div className="space-y-3">
             <p className="text-[18px] font-bold text-text-1">Monthly Budget</p>
-            {isEditing ? (
+            {editing ? (
               <div className="relative">
                 <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[16px] text-text-2">
                   $
@@ -614,7 +620,7 @@ export default function UserDetailPage({
                 )}
               </div>
             )}
-            {!isEditing && !isAdmin && (
+            {!editing && !isAdmin && (
               <p className="text-[12px] text-text-3">
                 Only admins can change this — ask an admin to adjust the
                 budget.

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -29,11 +29,13 @@ import {
 } from "@/components/ui/select";
 import {
   fetchOrgUser,
+  fetchUserActivity,
   removeOrgUser,
   updateMemberRole,
   updateUserBudget,
   updateUserRole,
   type OrgRole,
+  type UserActivityEvent,
 } from "@/lib/api";
 import {
   Dialog,
@@ -125,6 +127,89 @@ function UserRoleControl({
   );
 }
 
+/**
+ * Activity-log row. One per observability event for this user. Compact
+ * grid: time + type pill / model + provider / tokens + cost + latency
+ * + status. Failed events get the danger-tinted dot and surface the
+ * error message; successful ones show only the metrics.
+ */
+function ActivityRow({ event }: { event: UserActivityEvent }) {
+  const when = new Date(event.createdAt);
+  const time = when.toLocaleString(undefined, {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+  const eventLabel = (() => {
+    switch (event.eventType) {
+      case "chat_call":
+        return "Chat";
+      case "arena_call":
+        return "Arena";
+      case "evaluator_call":
+        return "Evaluator";
+      case "guardrail_trigger":
+        return "Guardrail";
+      default:
+        return event.eventType;
+    }
+  })();
+  const cost =
+    event.costUsd != null
+      ? `$${event.costUsd.toFixed(event.costUsd < 1 ? 4 : 2)}`
+      : null;
+
+  return (
+    <li className="flex flex-col gap-1.5 border-b border-bg-1 px-4 py-3 last:border-0">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className={`inline-flex h-2 w-2 shrink-0 rounded-full ${
+              event.success ? "bg-success-7" : "bg-danger-6"
+            }`}
+            aria-label={event.success ? "Success" : "Failed"}
+          />
+          <span className="rounded bg-bg-1 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-text-2">
+            {eventLabel}
+          </span>
+          {event.model && (
+            <span className="truncate text-[13px] text-text-1">
+              {event.model}
+            </span>
+          )}
+        </div>
+        <span className="shrink-0 text-[12px] text-text-3 whitespace-nowrap">
+          {time}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] text-text-3 pl-4">
+        {event.provider && <span>{event.provider}</span>}
+        {event.totalTokens != null && (
+          <span>{event.totalTokens.toLocaleString()} tokens</span>
+        )}
+        {cost && <span>{cost}</span>}
+        {event.latencyMs != null && (
+          <span>
+            {event.latencyMs >= 1000
+              ? `${(event.latencyMs / 1000).toFixed(1)}s`
+              : `${event.latencyMs}ms`}
+          </span>
+        )}
+        {event.teamName && <span>· {event.teamName}</span>}
+      </div>
+      {!event.success && event.errorMessage && (
+        <p className="pl-4 text-[12px] text-danger-6 line-clamp-2">
+          {event.errorMessage}
+        </p>
+      )}
+      {event.promptPreview && (
+        <p className="pl-4 text-[12px] text-text-2 line-clamp-2 italic">
+          “{event.promptPreview}”
+        </p>
+      )}
+    </li>
+  );
+}
+
 function SpentBar({ spent, budget }: { spent: number; budget: number }) {
   const pct = budget > 0 ? Math.min((spent / budget) * 100, 100) : 0;
   const exceeded = spent > budget;
@@ -167,6 +252,17 @@ export default function UserDetailPage({
   const [editBudget, setEditBudget] = useState("");
   const [editRole, setEditRole] = useState<OrgRole>("basic");
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [activityOpen, setActivityOpen] = useState(false);
+
+  // Lazy-load: only fetch when the dialog is opened. 50 most recent
+  // events is enough for a glance; if the user wants the full history
+  // they can drill into the Observability dashboard with a userId
+  // filter (separate page, supports search + range).
+  const activityQuery = useQuery({
+    queryKey: ["user-activity", id],
+    queryFn: () => fetchUserActivity(id, { page: 1, pageSize: 50 }),
+    enabled: activityOpen,
+  });
 
   const budgetMutation = useMutation({
     mutationFn: (budgetUsd: number) => updateUserBudget(id, budgetUsd),
@@ -371,6 +467,7 @@ export default function UserDetailPage({
             <Button
               variant="outline"
               className="h-10 gap-2 border-border-2 text-[14px] text-text-1"
+              onClick={() => setActivityOpen(true)}
             >
               <LayoutList className="h-4 w-4" />
               Activity Log
@@ -565,6 +662,71 @@ export default function UserDetailPage({
           </div>
         </div>
       </div>
+
+      {/* Activity Log — opened by the page-level Activity Log button.
+          Lazy-fetches the last 50 observability events for this user
+          (chat / arena / evaluator calls, guardrail triggers). Admin
+          can see anyone's activity; non-admins only their own (gated
+          on the BE). */}
+      <Dialog
+        open={activityOpen}
+        onOpenChange={(open) => !open && setActivityOpen(false)}
+      >
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Activity log — {displayName}</DialogTitle>
+            <DialogDescription>
+              Recent AI calls and platform events for this user.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-[60vh] overflow-y-auto rounded-md border border-bg-1 bg-bg-white">
+            {activityQuery.isLoading && (
+              <div className="flex items-center justify-center py-10">
+                <Loader2 className="h-6 w-6 animate-spin text-text-3" />
+              </div>
+            )}
+            {activityQuery.isError && (
+              <div className="px-4 py-10 text-center text-sm text-danger-6">
+                {activityQuery.error instanceof Error
+                  ? activityQuery.error.message
+                  : "Failed to load activity log."}
+              </div>
+            )}
+            {activityQuery.data &&
+              !activityQuery.isLoading &&
+              activityQuery.data.events.length === 0 && (
+                <div className="px-4 py-10 text-center text-sm text-text-3">
+                  No activity recorded for this user yet.
+                </div>
+              )}
+            {activityQuery.data &&
+              activityQuery.data.events.length > 0 && (
+                <ul className="flex flex-col">
+                  {activityQuery.data.events.map((e) => (
+                    <ActivityRow key={e.id} event={e} />
+                  ))}
+                </ul>
+              )}
+          </div>
+          {activityQuery.data &&
+            activityQuery.data.total > activityQuery.data.events.length && (
+              <p className="text-[12px] text-text-3">
+                Showing {activityQuery.data.events.length} of{" "}
+                {activityQuery.data.total.toLocaleString()} most recent
+                events. Older events are available in the Observability
+                dashboard.
+              </p>
+            )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setActivityOpen(false)}
+            >
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Remove user confirm — opened by the appbar Trash2 dispatch.
           Mirrors the dialog UserRow uses on /teams?tab=users; on

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -269,7 +269,7 @@ export const Appbar = () => {
             </SheetContent>
           </Sheet>
 
-          <Link href="/teams">
+          <Link href="/teams?tab=users">
             <Button
               variant="ghost"
               size="icon"

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -241,6 +241,12 @@ export const Appbar = () => {
   /* ── User detail appbar ──────────────────────────────────────────────── */
   if (config.appbarType === "userDetail") {
     const userName = breadcrumbs[breadcrumbs.length - 1]?.label ?? "";
+    // Edit / delete are admin-only — same gates as the underlying
+    // endpoints (PATCH /users/:id/budget, PATCH /users/:id/role,
+    // DELETE /users/:id). Hide the icons entirely for non-admins
+    // rather than rendering them disabled; the user-detail page
+    // surfaces the "ask an admin" hint inline.
+    const canManage = currentUser?.role === "admin";
 
     return (
       <header
@@ -274,22 +280,32 @@ export const Appbar = () => {
           </Link>
           <h4 className="text-[26px] font-bold text-text-1">{userName}</h4>
         </div>
-        <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-success-7 hover:text-success-7/80"
-          >
-            <Pencil className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-success-7 hover:text-success-7/80"
-          >
-            <Trash2 className="h-4 w-4" />
-          </Button>
-        </div>
+        {canManage && (
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-success-7 hover:text-success-7/80"
+              onClick={() =>
+                window.dispatchEvent(new CustomEvent("user-detail:edit"))
+              }
+              title="Edit user"
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-success-7 hover:text-success-7/80"
+              onClick={() =>
+                window.dispatchEvent(new CustomEvent("user-detail:delete"))
+              }
+              title="Remove user"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
       </header>
     );
   }

--- a/apps/web/src/components/management/user-row.tsx
+++ b/apps/web/src/components/management/user-row.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { MoreVertical, UserX, Eye } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -39,10 +40,12 @@ function SpentBar({ spent, budget }: { spent: number; budget: number }) {
 }
 
 export function UserRow({ user }: { user: OrgUser }) {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const { user: currentUser } = useAuth();
   const canRemove = currentUser?.role === "admin";
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const detailHref = `/users/${user.id}`;
 
   const removeMutation = useMutation({
     mutationFn: () => removeOrgUser(user.id),
@@ -64,7 +67,19 @@ export function UserRow({ user }: { user: OrgUser }) {
   const overBudget = projected > budget;
 
   return (
-    <tr className="h-14 border-b border-bg-1 transition-colors hover:bg-bg-1/50">
+    <tr
+      role="link"
+      tabIndex={0}
+      aria-label={`Open ${user.name ?? user.email}`}
+      className="h-14 cursor-pointer border-b border-bg-1 transition-colors hover:bg-bg-1/50 focus:outline-none focus-visible:bg-bg-1/60 focus-visible:ring-1 focus-visible:ring-primary-6"
+      onClick={() => router.push(detailHref)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          router.push(detailHref);
+        }
+      }}
+    >
       {/* Name */}
       <td className="px-4 align-middle text-base font-normal text-text-1 whitespace-nowrap">
         <div className="flex items-center gap-2">
@@ -165,8 +180,12 @@ export function UserRow({ user }: { user: OrgUser }) {
           ) : null}
         </div>
       </td>
-      {/* Actions */}
-      <td className="px-4 align-middle text-right">
+      {/* Actions — stopPropagation so clicking the kebab / Remove
+          button doesn't also fire the row's navigate-to-detail click. */}
+      <td
+        className="px-4 align-middle text-right"
+        onClick={(e) => e.stopPropagation()}
+      >
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -179,7 +198,7 @@ export function UserRow({ user }: { user: OrgUser }) {
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem asChild className="gap-2">
-              <Link href={`/users/${user.id}`}>
+              <Link href={detailHref}>
                 <Eye className="h-4 w-4" />
                 View user
               </Link>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -793,6 +793,45 @@ export async function updateUserBudget(
   return res.json();
 }
 
+export interface UserActivityEvent {
+  id: string;
+  createdAt: string;
+  eventType: string;
+  model: string | null;
+  provider: string | null;
+  totalTokens: number | null;
+  costUsd: number | null;
+  latencyMs: number | null;
+  success: boolean;
+  errorMessage: string | null;
+  promptPreview: string | null;
+  teamId: string | null;
+  teamName: string | null;
+}
+
+export interface UserActivityResponse {
+  total: number;
+  page: number;
+  pageSize: number;
+  events: UserActivityEvent[];
+}
+
+export async function fetchUserActivity(
+  userId: string,
+  params: { page?: number; pageSize?: number } = {},
+): Promise<UserActivityResponse> {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.pageSize) qs.set("pageSize", String(params.pageSize));
+  const url = `/users/${userId}/activity${qs.toString() ? `?${qs}` : ""}`;
+  const res = await apiFetch(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to load activity log");
+  }
+  return res.json();
+}
+
 export type OrgRole = "basic" | "advanced" | "admin";
 
 export async function updateUserRole(


### PR DESCRIPTION
  ## Summary

  Reshapes the Users area on `/teams?tab=users` and the user detail page at `/users/[id]` so they match the parity already set by the Teams tab and finally use the appbar buttons that have been sitting idle on
  the user-detail route. Six commits, three landing themes:

  1. **Row click navigates to detail** — drop-in parity with the Teams tab.
  2. **Read-only by default + admin edit mode with Confirm/Cancel** — replaces the inline-edit-on-blur Monthly Budget and inline role Select with an explicit edit flow driven by the appbar's existing Pencil +
  Trash2 icons. Live de-DE formatting on the budget input.
  3. **Activity Log dialog wired to a real BE endpoint** — the button on the detail page used to be inert.

  ## What's in here

  - **`8d12175` clickable user rows.** UserRow on `/teams?tab=users` now mirrors TeamRow: clicking anywhere on the row navigates to `/users/<id>`. Enter / Space on the focused row triggers the same navigation,
  `role="link"` + `aria-label` so screen readers announce it as a link, kebab menu and Remove confirm dialog stay separate via `stopPropagation` on the Actions cell.

  - **`08fb74d` read-only by default + edit-mode flow.** The user detail page renders Monthly Budget as plain text (`$X.YY`) and role as a Badge. Edit mode (initially gated behind a green pencil) stages both
  fields locally; Confirm fires only the changed mutations in parallel, Cancel discards. Self-mutation of role still blocked at the BE; FE matches by locking the Select with an inline explanation.

  - **`60b0084` use the existing appbar buttons.** Removes the redundant page-level pencil — the appbar's userDetail variant already had Pencil + Trash2 stubs, so wire those instead of keeping a second copy.
  Both icons are admin-only at the appbar level; clicking dispatches `user-detail:edit` / `user-detail:delete` window events the page listens for. Same pattern the rest of the appbar already uses (observability
   range change, observability export, generic appbarAction). Adds a delete confirm dialog on the page; on success routes back to `/teams?tab=users`.

  - **`7882b36` rules-of-hooks fix.** `60b0084` placed the appbar-event `useEffect` after the `if (isLoading)` and `if (error || !user)` early returns, which flipped the hook count between the loading and
  loaded renders and crashed the page. Moved the `useEffect` above the early returns; internal `if (!user) return` guard inside the listener handles the still-loading case.

  - **`3d56083` Activity Log dialog.** New `GET /users/:id/activity` endpoint that delegates to `ObservabilityService.listEvents` with a from=epoch / to=now window — so the result is the user's full lifetime,
  not the dashboard's range filter. Auth: admin can see anyone's activity; non-admins only their own. Same shape as the existing admin-only `/observability/events` but scoped per-user and gated self-or-admin.
  FE Dialog opens lazily on click (React Query `enabled` flag), fetches the 50 most recent events, renders them as a compact list — status dot, type pill, model, provider, tokens, cost, latency, prompt preview
  (BE already truncates to 200 chars), error message on failures. When the user has more than 50 events, the footer hints that older history is in the Observability dashboard.

  - **`390296e` live de-DE format on budget input.** Budget input now formats on every keystroke: `1234` → `1.234`, `1234,5` → `1.234,5`, paste `1234.56` → `1.234,56`. Includes a smart-paste heuristic — a
  single dot with 1–2 trailing digits (en-US style) is treated as a decimal; multiple dots or a "1.234" shape stay as thousand separators. Empty / leading zeros / `0,5` / fractional cap at 2 digits all behave
  sensibly (verified against a table of 13 inputs).

  ## Test plan

  - [x] On `/teams?tab=users`, clicking any user row navigates to `/users/<id>`. Pressing Enter on a focused row does the same. Clicking the kebab menu does NOT navigate.
  - [x] On `/users/<id>` as a non-admin: Monthly Budget shown as text with the "ask an admin" hint, role shown as a Badge, no Pencil / Trash2 icons in the appbar.
  - [x] On `/users/<id>` as an admin: appbar shows green Pencil + Trash2 icons.
  - [x] Clicking the appbar Pencil enters edit mode — budget input pre-filled in `1.234,56` shape, role Select populated, Confirm + Cancel buttons appear inline next to Activity Log.
  - [x] In edit mode, typing in the budget input formats live as you type. Pasting `1234.56` becomes `1.234,56`. Pasting `1.234,56` stays `1.234,56`.
  - [x] Confirm with no changes is a no-op (just exits edit mode). Confirm with both fields changed fires both mutations and shows two success toasts. Confirm with only one changed fires only that mutation.
  Partial failure (one mutation rejected) keeps the user in edit mode.
  - [x] Setting budget to `0` is allowed and persists (suspend semantic). Setting it to `-5` or non-numeric is rejected with a toast.
  - [x] Admin viewing themselves: role Select is locked with the "you can't change your own role" hint; budget can still be edited.
  - [x] Clicking the appbar Trash2 opens a Remove user confirm dialog. Clicking Remove → user is deleted, redirect to `/teams?tab=users`.
  - [x] Activity Log button on the detail page opens a Dialog. Loading spinner shows briefly, then the list renders. Each row has a status dot, type pill, model, provider, tokens, cost, latency, time. Failed
  events show the error message in red. Prompt previews render in italic.
  - [x] Activity Log respects auth: `GET /users/<other-id>/activity` as a non-admin returns 403; as that user themselves, returns 200.
  - [x] If the user has more than 50 events, the footer hint about Observability dashboard appears.
  - [x] No "rules of hooks" warning in the console on the user detail page.
  - [x] FE typecheck clean (`pnpm tsc --noEmit` on both apps).

  ## Already verified locally

  - ✅ All six commits, both apps `tsc --noEmit` clean
  - ✅ Live BE auth: admin-self / admin-other / basic-self / basic-other on `/users/:id/activity` (200 / 200 / 200 / 403)
  - ✅ 314 events returned with correct shape for an admin viewing themselves
  - ✅ Live BE: `PATCH /users/:id/budget` with `0` succeeds, with `-5` returns 400
  - ✅ `formatBudgetInput` table of 13 inputs (empty, leading zeros, dots, commas, en-US paste, multiple dots, fractional cap) — all correct

  ## Out of scope

  - Audit log of admin actions (budget change, role change, delete) — only LLM-call observability events surface today
  - Pagination beyond first 50 events in the Activity Log dialog (older history available in the Observability dashboard)
  - Activity Log filtering by event type / model — same workaround
  - The appbar's Trash2 button on this PR fires a confirm; future PRs may add an inline tooltip for "Remove user"
