### PR TITLE
Fix/onboarding improvements

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -89,6 +89,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/apps/api/src/api-keys/api-keys.controller.spec.ts
+++ b/apps/api/src/api-keys/api-keys.controller.spec.ts
@@ -1,0 +1,62 @@
+import { ForbiddenException } from '@nestjs/common';
+import type { Request } from 'express';
+import { ApiKeysController } from './api-keys.controller.js';
+import type { ApiKeysService } from './api-keys.service.js';
+import type {
+  AuthenticatedRequest,
+  AuthMethod,
+} from '../auth/jwt-or-api-key.guard.js';
+import type { AuthenticatedUser } from '../auth/types.js';
+
+const USER: AuthenticatedUser = {
+  id: 'user-id',
+  email: 'user@example.com',
+};
+
+function fakeReq(authMethod: AuthMethod): Request & AuthenticatedRequest {
+  return { authMethod, user: USER } as unknown as Request &
+    AuthenticatedRequest;
+}
+
+describe('ApiKeysController auth gates', () => {
+  let controller: ApiKeysController;
+  let apiKeysService: jest.Mocked<ApiKeysService>;
+
+  beforeEach(() => {
+    apiKeysService = {
+      list: jest.fn().mockResolvedValue([]),
+      mint: jest.fn().mockResolvedValue({
+        id: 'k1',
+        name: 'test',
+        prefix: 'abcd',
+        createdAt: new Date(),
+        lastUsedAt: null,
+        plaintext: 'sk-wai-ABCD…',
+      }),
+      revoke: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<ApiKeysService>;
+    controller = new ApiKeysController(apiKeysService);
+  });
+
+  describe('POST /api-keys (mint)', () => {
+    it('cookie-authenticated caller succeeds', async () => {
+      await expect(
+        controller.mint({ name: 'GitHub Actions' }, USER, fakeReq('cookie')),
+      ).resolves.toMatchObject({ name: 'test' });
+      expect(apiKeysService.mint).toHaveBeenCalledWith(
+        USER.id,
+        'GitHub Actions',
+      );
+    });
+
+    it('apikey-authenticated caller is blocked (privilege-escalation guard)', async () => {
+      // A leaked sk-wai-… token must not be usable to mint replacement
+      // tokens that survive the original being revoked. Mirrors the
+      // explicit 403 in api-keys.controller.ts.
+      expect(() =>
+        controller.mint({ name: 'leak' }, USER, fakeReq('apikey')),
+      ).toThrow(ForbiddenException);
+      expect(apiKeysService.mint).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -77,11 +77,19 @@ export class AuthController {
     const returnTo = cookies?.invite_return_to;
     res.clearCookie('invite_return_to', { path: '/' });
 
-    if (returnTo && typeof returnTo === 'string' && returnTo.startsWith('/')) {
-      res.redirect(`${frontendUrl}${returnTo}`);
-    } else {
-      res.redirect(frontendUrl);
-    }
+    // Direct-redirect to /setup-profile when the account hasn't
+    // finished onboarding. Without this, the FE landed on `/`,
+    // rendered the dashboard chrome for a few hundred ms while
+    // /auth/me resolved, and only then fired the
+    // OnboardingGuard.replace — a visible flash of unauthorized UI.
+    // The FE guard still does the same check as a safety net (cookie
+    // restore, manual /-typing, etc.).
+    const target = !user.onboardingCompletedAt
+      ? '/setup-profile'
+      : returnTo && typeof returnTo === 'string' && returnTo.startsWith('/')
+        ? returnTo
+        : '/';
+    res.redirect(`${frontendUrl}${target}`);
   }
 
   @Public()

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -74,21 +74,30 @@ export class AuthController {
 
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
     const cookies = req.cookies as Record<string, string> | undefined;
-    const returnTo = cookies?.invite_return_to;
+    const returnToRaw = cookies?.invite_return_to;
+    const returnTo =
+      typeof returnToRaw === 'string' && returnToRaw.startsWith('/')
+        ? returnToRaw
+        : null;
     res.clearCookie('invite_return_to', { path: '/' });
 
-    // Direct-redirect to /setup-profile when the account hasn't
-    // finished onboarding. Without this, the FE landed on `/`,
-    // rendered the dashboard chrome for a few hundred ms while
-    // /auth/me resolved, and only then fired the
-    // OnboardingGuard.replace — a visible flash of unauthorized UI.
-    // The FE guard still does the same check as a safety net (cookie
-    // restore, manual /-typing, etc.).
-    const target = !user.onboardingCompletedAt
-      ? '/setup-profile'
-      : returnTo && typeof returnTo === 'string' && returnTo.startsWith('/')
-        ? returnTo
-        : '/';
+    // Three cases:
+    //   1. Onboarding done, no returnTo → "/" (dashboard).
+    //   2. Onboarding done, returnTo set → returnTo (invite landed on
+    //      /invite/:token, the page handles acceptance there).
+    //   3. Onboarding NOT done → "/setup-profile". If a returnTo was
+    //      also set we forward it as `?next=<encoded>` so step-6's
+    //      success handler can finish the wizard AND land the user
+    //      on the original destination, instead of dropping the
+    //      invite link silently.
+    let target: string;
+    if (!user.onboardingCompletedAt) {
+      target = returnTo
+        ? `/setup-profile?next=${encodeURIComponent(returnTo)}`
+        : '/setup-profile';
+    } else {
+      target = returnTo ?? '/';
+    }
     res.redirect(`${frontendUrl}${target}`);
   }
 

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -174,15 +174,18 @@ export class MailService {
     const twitter = this.config.get<string>('TWITTER_URL');
     if (!linkedin && !twitter) return '';
 
+    // Anchor styles are margin-free so a single link centers cleanly
+    // (per-side margin shifted the lone link off-center). Multi-link
+    // cases get a middle-dot separator inserted between siblings.
     const link = (href: string, label: string) =>
-      `<a href="${href}" style="display: inline-block; margin: 0 8px; color: #4E5969; text-decoration: none; font-size: 14px;">${label}</a>`;
+      `<a href="${href}" style="display: inline-block; color: #4E5969; text-decoration: none; font-size: 14px;">${label}</a>`;
 
-    const links = [
-      linkedin ? link(linkedin, 'LinkedIn') : '',
-      twitter ? link(twitter, 'Twitter') : '',
-    ]
-      .filter(Boolean)
-      .join('');
+    const linkParts: string[] = [];
+    if (linkedin) linkParts.push(link(linkedin, 'LinkedIn'));
+    if (twitter) linkParts.push(link(twitter, 'Twitter'));
+    const separator =
+      '<span style="display: inline-block; padding: 0 10px; color: #C9CDD4;">·</span>';
+    const links = linkParts.join(separator);
 
     return `
       <div style="margin-top: 30px; text-align: center;">

--- a/apps/api/src/onboarding/onboarding.controller.ts
+++ b/apps/api/src/onboarding/onboarding.controller.ts
@@ -2,8 +2,11 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
+  HttpCode,
   Param,
+  Patch,
   Post,
   Res,
   UploadedFiles,
@@ -19,6 +22,7 @@ import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
 import {
   OnboardingService,
+  type OnboardingDraft,
   type OnboardingPayload,
 } from './onboarding.service.js';
 
@@ -42,6 +46,35 @@ export class OnboardingController {
   @Get('profile')
   getProfile(@CurrentUser() user: AuthenticatedUser) {
     return this.onboardingService.getProfile(user.id);
+  }
+
+  /**
+   * Resume-flow draft endpoints. The wizard PATCHes its scalar
+   * fields after each Continue so a user who closes the tab can
+   * pick up where they left off on next login. The row is per-user
+   * (PK = userId) and is dropped once `complete` succeeds.
+   */
+  @Get('draft')
+  getDraft(@CurrentUser() user: AuthenticatedUser) {
+    return this.onboardingService
+      .getDraft(user.id)
+      .then((draft) => ({ draft }));
+  }
+
+  @Patch('draft')
+  updateDraft(
+    @Body() body: OnboardingDraft,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.onboardingService
+      .updateDraft(user.id, body ?? {})
+      .then((draft) => ({ draft }));
+  }
+
+  @Delete('draft')
+  @HttpCode(204)
+  async deleteDraft(@CurrentUser() user: AuthenticatedUser) {
+    await this.onboardingService.deleteDraft(user.id);
   }
 
   @Get('documents/:id/download')

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -44,6 +44,14 @@ const VALID_PROVIDERS: Provider[] = [
   'private-vpc',
 ];
 
+// Subset of step-5 providers that 1:1 map to predefined providers in
+// the Integration tab catalog, and so can flow straight into the
+// `integrations` table on onboarding completion. Azure / private-vpc
+// need extra fields (deployment URL, VPC endpoint) the wizard never
+// collects, so their keys are deliberately dropped — see comment in
+// completeInner where this list is consulted.
+const SUPPORTED_FOR_INTEGRATION_TABLE: Provider[] = ['openai', 'anthropic'];
+
 // Whitelisted enum values for the company-branch dropdowns. Must stay in
 // sync with apps/web/src/app/setup-profile/step-2/page.tsx — the FE
 // dropdown values are the source of truth, and the BE enforces them so
@@ -221,7 +229,9 @@ export class OnboardingService {
         for (const [provider, key] of Object.entries(payload.apiKeys)) {
           if (!key || !key.trim()) continue;
           if (!VALID_PROVIDERS.includes(provider as Provider)) continue;
-          if (provider !== 'openai' && provider !== 'anthropic') {
+          if (
+            !SUPPORTED_FOR_INTEGRATION_TABLE.includes(provider as Provider)
+          ) {
             this.logger.warn(
               `Onboarding step-5: ${provider} key supplied but no matching predefined provider — skipping. User ${userId} can finish setup in Management → Integration.`,
             );
@@ -386,11 +396,12 @@ export class OnboardingService {
       }
       // industry/teamSize stay optional (Figma shows no asterisk), but
       // when supplied they must be one of the FE dropdown values.
+      // Cast the readonly tuple down to a plain string[] so `.includes`
+      // accepts an arbitrary string at the call site instead of forcing
+      // a tuple-narrowing cast on the input.
       if (
         p.industry &&
-        !VALID_INDUSTRIES.includes(
-          p.industry as (typeof VALID_INDUSTRIES)[number],
-        )
+        !(VALID_INDUSTRIES as readonly string[]).includes(p.industry)
       ) {
         throw new BadRequestException(
           `industry must be one of: ${VALID_INDUSTRIES.join(', ')}`,
@@ -398,9 +409,7 @@ export class OnboardingService {
       }
       if (
         p.teamSize &&
-        !VALID_TEAM_SIZES.includes(
-          p.teamSize as (typeof VALID_TEAM_SIZES)[number],
-        )
+        !(VALID_TEAM_SIZES as readonly string[]).includes(p.teamSize)
       ) {
         throw new BadRequestException(
           `teamSize must be one of: ${VALID_TEAM_SIZES.join(', ')}`,

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -426,15 +426,29 @@ export class OnboardingService {
   /**
    * Upsert the draft. Validates the partial against the same enum
    * lists `complete` uses so a malformed POST can't poison the row.
-   * Sanitises by dropping unknown keys — the user can't smuggle
-   * arbitrary jsonb in via this endpoint.
+   *
+   * Behaviour split: unknown top-level keys (anything outside the
+   * OnboardingDraft shape) are silently stripped — the FE always
+   * sends the canonical shape, and a future field added to the BE
+   * shouldn't break older FEs that don't know about it. But if a
+   * known field carries an invalid enum value
+   * (industry: 'lol', teamSize: '999', etc.) we 400 — the FE Selects
+   * are constrained, so an invalid enum from a programmatic caller
+   * is a real bug they want to know about, not silently dropped
+   * data.
    */
   async updateDraft(
     userId: string,
     input: OnboardingDraft,
   ): Promise<OnboardingDraft> {
     const sanitized: OnboardingDraft = {};
-    if (input.profileType === 'company' || input.profileType === 'personal') {
+
+    if (input.profileType !== undefined) {
+      if (input.profileType !== 'company' && input.profileType !== 'personal') {
+        throw new BadRequestException(
+          'profileType must be "company" or "personal"',
+        );
+      }
       sanitized.profileType = input.profileType;
     }
     if (typeof input.fullName === 'string') {
@@ -443,22 +457,37 @@ export class OnboardingService {
     if (typeof input.companyName === 'string') {
       sanitized.companyName = input.companyName.slice(0, 200);
     }
-    if (
-      typeof input.industry === 'string' &&
-      (VALID_INDUSTRIES as readonly string[]).includes(input.industry)
-    ) {
+    if (input.industry !== undefined) {
+      if (
+        typeof input.industry !== 'string' ||
+        !(VALID_INDUSTRIES as readonly string[]).includes(input.industry)
+      ) {
+        throw new BadRequestException(
+          `industry must be one of: ${VALID_INDUSTRIES.join(', ')}`,
+        );
+      }
       sanitized.industry = input.industry;
     }
-    if (
-      typeof input.teamSize === 'string' &&
-      (VALID_TEAM_SIZES as readonly string[]).includes(input.teamSize)
-    ) {
+    if (input.teamSize !== undefined) {
+      if (
+        typeof input.teamSize !== 'string' ||
+        !(VALID_TEAM_SIZES as readonly string[]).includes(input.teamSize)
+      ) {
+        throw new BadRequestException(
+          `teamSize must be one of: ${VALID_TEAM_SIZES.join(', ')}`,
+        );
+      }
       sanitized.teamSize = input.teamSize;
     }
-    if (
-      input.infraChoice === 'managed' ||
-      input.infraChoice === 'on-premise'
-    ) {
+    if (input.infraChoice !== undefined) {
+      if (
+        input.infraChoice !== 'managed' &&
+        input.infraChoice !== 'on-premise'
+      ) {
+        throw new BadRequestException(
+          'infraChoice must be "managed" or "on-premise"',
+        );
+      }
       sanitized.infraChoice = input.infraChoice;
     }
 

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -16,6 +16,7 @@ import {
   users,
   integrations,
   knowledgeDocuments,
+  onboardingDrafts,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
@@ -35,6 +36,25 @@ export interface OnboardingPayload {
   infraChoice: InfraChoice;
   // Step 5 — each key is optional; omitted/empty means "skipped"
   apiKeys?: Partial<Record<Provider, string>>;
+}
+
+/**
+ * Subset of the onboarding state safe to round-trip through the BE
+ * draft. Mirrors `OnboardingPayload` but with every field optional —
+ * a draft can be saved any time during the wizard.
+ *
+ * `apiKeys` is deliberately absent: keys are an XSS exfiltration
+ * vector if persisted server-side without strong scoping, and the
+ * wizard collects them only on the very last step before completion
+ * anyway. Files are also absent — they'd need multipart, not JSON.
+ */
+export interface OnboardingDraft {
+  profileType?: ProfileType;
+  fullName?: string;
+  companyName?: string;
+  industry?: string;
+  teamSize?: string;
+  infraChoice?: InfraChoice;
 }
 
 const VALID_PROVIDERS: Provider[] = [
@@ -287,6 +307,15 @@ export class OnboardingService {
     //      in `key-resolver.resolveUserKey` to make any chat attempt
     //      before approval fail with a 402 + BUDGET_PENDING_APPROVAL
     //      marker rather than silently creating a key.
+
+    // Drop the resume-draft now that the wizard is genuinely done.
+    // Kept outside the transaction because failure here is benign —
+    // the row would just orphan and can be reaped by cron later, no
+    // need to roll back a successful onboarding for it.
+    await this.db
+      .delete(onboardingDrafts)
+      .where(eq(onboardingDrafts.userId, userId))
+      .catch(() => undefined);
   }
 
   /**
@@ -377,6 +406,79 @@ export class OnboardingService {
       providers,
       documents,
     };
+  }
+
+  /**
+   * Read the user's draft if present. Returns null instead of
+   * throwing 404 because the FE always tries to hydrate; absence is
+   * the common case (fresh signup, or already-completed onboarding
+   * which deletes the row).
+   */
+  async getDraft(userId: string): Promise<OnboardingDraft | null> {
+    const [row] = await this.db
+      .select({ partial: onboardingDrafts.partial })
+      .from(onboardingDrafts)
+      .where(eq(onboardingDrafts.userId, userId))
+      .limit(1);
+    return (row?.partial as OnboardingDraft | undefined) ?? null;
+  }
+
+  /**
+   * Upsert the draft. Validates the partial against the same enum
+   * lists `complete` uses so a malformed POST can't poison the row.
+   * Sanitises by dropping unknown keys — the user can't smuggle
+   * arbitrary jsonb in via this endpoint.
+   */
+  async updateDraft(
+    userId: string,
+    input: OnboardingDraft,
+  ): Promise<OnboardingDraft> {
+    const sanitized: OnboardingDraft = {};
+    if (input.profileType === 'company' || input.profileType === 'personal') {
+      sanitized.profileType = input.profileType;
+    }
+    if (typeof input.fullName === 'string') {
+      sanitized.fullName = input.fullName.slice(0, 200);
+    }
+    if (typeof input.companyName === 'string') {
+      sanitized.companyName = input.companyName.slice(0, 200);
+    }
+    if (
+      typeof input.industry === 'string' &&
+      (VALID_INDUSTRIES as readonly string[]).includes(input.industry)
+    ) {
+      sanitized.industry = input.industry;
+    }
+    if (
+      typeof input.teamSize === 'string' &&
+      (VALID_TEAM_SIZES as readonly string[]).includes(input.teamSize)
+    ) {
+      sanitized.teamSize = input.teamSize;
+    }
+    if (
+      input.infraChoice === 'managed' ||
+      input.infraChoice === 'on-premise'
+    ) {
+      sanitized.infraChoice = input.infraChoice;
+    }
+
+    await this.db
+      .insert(onboardingDrafts)
+      .values({ userId, partial: sanitized })
+      .onConflictDoUpdate({
+        target: onboardingDrafts.userId,
+        set: { partial: sanitized, updatedAt: new Date() },
+      });
+
+    return sanitized;
+  }
+
+  /** Soft-delete the draft. Called both from the controller and from
+   *  `complete()` after a successful transaction. */
+  async deleteDraft(userId: string): Promise<void> {
+    await this.db
+      .delete(onboardingDrafts)
+      .where(eq(onboardingDrafts.userId, userId));
   }
 
   private validate(p: OnboardingPayload) {

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,0 +1,118 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import type { AuthenticatedUser } from '../auth/types.js';
+import { UsersController } from './users.controller.js';
+import type { UsersService } from './users.service.js';
+
+/**
+ * Build a fake `db` whose `db.select().from().where()` chain resolves
+ * to the preset rows. Drizzle's chain is what the controllers call to
+ * read the caller's role for the admin gates; mocking it directly is
+ * brittle but keeps the test fast (no Postgres) and lets us focus on
+ * the gate logic, not the SQL.
+ */
+function mockDb(rows: unknown[]) {
+  const where = jest.fn().mockResolvedValue(rows);
+  const from = jest.fn().mockReturnValue({ where });
+  const select = jest.fn().mockReturnValue({ from });
+  return { select } as unknown;
+}
+
+const ADMIN: AuthenticatedUser = {
+  id: 'admin-id',
+  email: 'admin@example.com',
+};
+const BASIC: AuthenticatedUser = {
+  id: 'basic-id',
+  email: 'basic@example.com',
+};
+
+describe('UsersController auth gates', () => {
+  let controller: UsersController;
+  let usersService: jest.Mocked<UsersService>;
+
+  function bootstrap(callerRows: unknown[]) {
+    const db = mockDb(callerRows);
+    usersService = {
+      updateBudget: jest
+        .fn()
+        .mockResolvedValue({ monthlyBudgetCents: 5000 }),
+      updateRole: jest
+        .fn()
+        .mockResolvedValue({ id: 'target-id', role: 'advanced' }),
+      remove: jest.fn().mockResolvedValue({ success: true }),
+    } as unknown as jest.Mocked<UsersService>;
+
+    controller = new UsersController(
+      db as never,
+      usersService,
+      {} as never, // teamsService — unused by the gated endpoints
+      {} as never, // mailService
+      {} as never, // observabilityService
+    );
+  }
+
+  describe('PATCH /users/:id/budget', () => {
+    it('admin succeeds and forwards to UsersService.updateBudget', async () => {
+      bootstrap([{ role: 'admin' }]);
+      await expect(
+        controller.updateBudget('target-id', { budgetUsd: 50 }, ADMIN),
+      ).resolves.toEqual({ monthlyBudgetCents: 5000 });
+      expect(usersService.updateBudget).toHaveBeenCalledWith('target-id', 50);
+    });
+
+    it('non-admin is rejected with ForbiddenException', async () => {
+      bootstrap([{ role: 'basic' }]);
+      await expect(
+        controller.updateBudget('target-id', { budgetUsd: 50 }, BASIC),
+      ).rejects.toThrow(ForbiddenException);
+      expect(usersService.updateBudget).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /users/:id/role', () => {
+    it('admin promoting another user succeeds', async () => {
+      bootstrap([{ role: 'admin' }]);
+      await expect(
+        controller.updateRole('target-id', { role: 'advanced' }, ADMIN),
+      ).resolves.toEqual({ id: 'target-id', role: 'advanced' });
+      expect(usersService.updateRole).toHaveBeenCalledWith(
+        'target-id',
+        'advanced',
+      );
+    });
+
+    it('non-admin is rejected with ForbiddenException', async () => {
+      bootstrap([{ role: 'advanced' }]);
+      await expect(
+        controller.updateRole('target-id', { role: 'admin' }, BASIC),
+      ).rejects.toThrow(ForbiddenException);
+      expect(usersService.updateRole).not.toHaveBeenCalled();
+    });
+
+    it('admin trying to mutate own role hits the self-lockout guard', async () => {
+      bootstrap([{ role: 'admin' }]);
+      await expect(
+        controller.updateRole(ADMIN.id, { role: 'basic' }, ADMIN),
+      ).rejects.toThrow(BadRequestException);
+      expect(usersService.updateRole).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE /users/:id', () => {
+    it('admin succeeds and forwards to UsersService.remove', async () => {
+      bootstrap([{ role: 'admin' }]);
+      await expect(
+        controller.remove('target-id', ADMIN),
+      ).resolves.toEqual({ success: true });
+      expect(usersService.remove).toHaveBeenCalledWith('target-id', ADMIN.id);
+    });
+
+    it('non-admin is rejected with ForbiddenException', async () => {
+      bootstrap([{ role: 'basic' }]);
+      await expect(controller.remove('target-id', BASIC)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(usersService.remove).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { Loader2 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { Sidebar, Appbar } from "@/components/layout";
 import { AuthProvider, useAuth } from "@/components/providers";
@@ -20,8 +21,20 @@ function OnboardingGuard({ children }: { children: React.ReactNode }) {
     }
   }, [isLoading, user, router]);
 
-  if (!isLoading && user && !user.onboardingCompleted) {
-    return null;
+  // Hold off rendering ANY of the dashboard chrome until auth has
+  // resolved AND onboardingCompleted is confirmed. The previous
+  // version returned children unconditionally while `isLoading`, so
+  // a Google-callback round-trip flashed the empty dashboard for a
+  // few hundred ms before the redirect to /setup-profile fired. Show
+  // a centered spinner during both the loading frame and the
+  // about-to-redirect frame so there's no flash of unauthorized
+  // content.
+  if (isLoading || (user && !user.onboardingCompleted)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-bg-1">
+        <Loader2 className="h-8 w-8 animate-spin text-text-3" />
+      </div>
+    );
   }
   return <>{children}</>;
 }

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -73,7 +73,7 @@ function UserAvatar({ name, picture, size = 24 }: { name: string; picture: strin
   if (picture) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
-      <img src={picture} alt={name} className="rounded-full object-cover border border-border-2" style={{ width: size, height: size }} />
+      <img src={picture} alt={name} referrerPolicy="no-referrer" className="rounded-full object-cover border border-border-2" style={{ width: size, height: size }} />
     );
   }
   return (
@@ -557,7 +557,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                               {sub.members.slice(0, 4).map((m, i) =>
                                 m.picture ? (
                                   // eslint-disable-next-line @next/next/no-img-element
-                                  <img key={i} src={m.picture} alt={m.name ?? ""} className="h-6 w-6 rounded-full border-2 border-bg-white object-cover" />
+                                  <img key={i} src={m.picture} alt={m.name ?? ""} referrerPolicy="no-referrer" className="h-6 w-6 rounded-full border-2 border-bg-white object-cover" />
                                 ) : (
                                   <div key={i} className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-bg-white bg-bg-3 text-[9px] font-semibold text-text-3">
                                     {(m.name ?? "?").charAt(0)}

--- a/apps/web/src/app/(app)/tender-ai/create/page.tsx
+++ b/apps/web/src/app/(app)/tender-ai/create/page.tsx
@@ -570,6 +570,7 @@ function TeamStep({
                   <img
                     src={m.picture}
                     alt={m.name ?? ""}
+                    referrerPolicy="no-referrer"
                     className="h-9 w-9 shrink-0 rounded-full object-cover"
                   />
                 ) : (

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -31,6 +31,7 @@ import {
   fetchOrgUser,
   fetchUserActivity,
   removeOrgUser,
+  removeTeamMember,
   updateMemberRole,
   updateUserBudget,
   updateUserRole,
@@ -322,6 +323,14 @@ export default function UserDetailPage({
   const [editRole, setEditRole] = useState<OrgRole>("basic");
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [activityOpen, setActivityOpen] = useState(false);
+  // Pending team-removal target. Triggered by the "Remove from team"
+  // dropdown item in the Teams table; surfaces a confirm dialog
+  // before actually firing the mutation.
+  const [pendingTeamRemoval, setPendingTeamRemoval] = useState<{
+    teamId: string;
+    memberId: string;
+    teamName: string;
+  } | null>(null);
 
   // Lazy-load: only fetch when the dialog is opened. 50 most recent
   // events is enough for a glance; if the user wants the full history
@@ -373,6 +382,26 @@ export default function UserDetailPage({
     },
     onError: (err: Error) => {
       toast.error(err.message || "Couldn't remove user.");
+    },
+  });
+
+  const removeTeamMemberMutation = useMutation({
+    mutationFn: ({
+      teamId,
+      memberId,
+    }: {
+      teamId: string;
+      memberId: string;
+    }) => removeTeamMember(teamId, memberId),
+    onSuccess: () => {
+      toast.success("Removed from team.");
+      queryClient.invalidateQueries({ queryKey: ["users", id] });
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+      setPendingTeamRemoval(null);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Couldn't remove from team.");
+      setPendingTeamRemoval(null);
     },
   });
 
@@ -711,19 +740,43 @@ export default function UserDetailPage({
                     </td>
                     <td className="bg-bg-white px-4 align-middle w-[93px]">
                       <div className="flex justify-center">
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button variant="ghost" size="icon" className="h-7 w-7 text-text-2 hover:text-text-1">
-                              <MoreVertical className="h-5 w-5" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem className="gap-2 text-danger-6 focus:text-danger-6">
-                              <Trash2 className="h-4 w-4" />
-                              Remove from team
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                        {/* Kebab only renders for the caller-can-manage
+                            AND not-self path. The BE rejects
+                            self-removal explicitly ("Cannot remove
+                            yourself from the team"), so the row owner
+                            viewing their own page never sees this
+                            action. Admin viewing another user's
+                            membership: shown when `t.canManage` is
+                            true (admin is owner or accepted editor of
+                            the team). */}
+                        {!isSelf && t.canManage && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7 text-text-2 hover:text-text-1"
+                              >
+                                <MoreVertical className="h-5 w-5" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                className="gap-2 text-danger-6 focus:text-danger-6"
+                                onClick={() =>
+                                  setPendingTeamRemoval({
+                                    teamId: t.id,
+                                    memberId: t.memberId,
+                                    teamName: t.name,
+                                  })
+                                }
+                              >
+                                <Trash2 className="h-4 w-4" />
+                                Remove from team
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
                       </div>
                     </td>
                   </tr>
@@ -801,6 +854,50 @@ export default function UserDetailPage({
               onClick={() => setActivityOpen(false)}
             >
               Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove-from-team confirm — opened by the per-row dropdown
+          in the Teams table. Stays separate from the org-level
+          "Remove user" dialog below because the action and target
+          are different (team membership vs whole user account). */}
+      <Dialog
+        open={!!pendingTeamRemoval}
+        onOpenChange={(open) => !open && setPendingTeamRemoval(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove from team</DialogTitle>
+            <DialogDescription>
+              Remove <strong>{displayName}</strong> from{" "}
+              <strong>{pendingTeamRemoval?.teamName}</strong>? They&apos;ll
+              lose access to that team&apos;s projects and budget. Their
+              account stays intact.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setPendingTeamRemoval(null)}
+              disabled={removeTeamMemberMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (pendingTeamRemoval) {
+                  removeTeamMemberMutation.mutate({
+                    teamId: pendingTeamRemoval.teamId,
+                    memberId: pendingTeamRemoval.memberId,
+                  });
+                }
+              }}
+              disabled={removeTeamMemberMutation.isPending}
+            >
+              {removeTeamMemberMutation.isPending ? "Removing..." : "Remove"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -135,6 +135,7 @@ function UserAvatar({ name, picture, size = 80 }: { name: string; picture: strin
       <img
         src={picture}
         alt={name}
+        referrerPolicy="no-referrer"
         className="rounded-full object-cover border border-border-2"
         style={{ width: size, height: size }}
       />

--- a/apps/web/src/app/setup-profile/layout.tsx
+++ b/apps/web/src/app/setup-profile/layout.tsx
@@ -9,6 +9,11 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  fetchOnboardingDraft,
+  updateOnboardingDraft,
+  type OnboardingDraft,
+} from "@/lib/api";
 
 type ProfileType = "company" | "personal";
 type InfraChoice = "managed" | "on-premise";
@@ -34,12 +39,29 @@ interface OnboardingContextValue {
   files: File[];
   setFiles: (files: File[]) => void;
   reset: () => void;
+  /**
+   * Fire-and-forget BE persist of the wizard's scalar state. Steps
+   * call this after each Continue so the draft survives session
+   * loss. Pass the same patch you'd give to `update` so the snapshot
+   * sent to the BE includes the just-typed value, not the
+   * one-render-stale ref. Calling without a patch persists the
+   * current state as-is (useful when individual onChanges already
+   * pushed the values into context).
+   */
+  saveDraft: (patch?: Partial<OnboardingScalarState>) => void;
 }
 
 const STORAGE_KEY = "workenai:onboarding:v1";
 const emptyState: OnboardingScalarState = { apiKeys: {} };
 
 const OnboardingContext = createContext<OnboardingContextValue | null>(null);
+
+/** Strip apiKeys before sending to either storage layer. */
+function persistableScalars(state: OnboardingScalarState): OnboardingDraft {
+  const { apiKeys: _apiKeys, ...rest } = state;
+  void _apiKeys;
+  return rest;
+}
 
 export default function SetupProfileLayout({
   children,
@@ -50,25 +72,51 @@ export default function SetupProfileLayout({
   const [files, setFiles] = useState<File[]>([]);
   const hydrated = useRef(false);
 
-  // Hydrate from sessionStorage once on mount.
+  // Hydrate on mount: prefer the BE draft (durable across sessions /
+  // device switches) and fall back to sessionStorage if the BE has
+  // nothing (or 401-ed). sessionStorage stays in play as a fast local
+  // cache between Continue clicks within a single session.
   useEffect(() => {
     if (hydrated.current) return;
     hydrated.current = true;
-    try {
-      const raw = sessionStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as Omit<
-          OnboardingScalarState,
-          "apiKeys"
-        >;
-        // API keys intentionally never round-trip through storage; always
-        // restart them as empty on reload.
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setState({ ...emptyState, ...parsed, apiKeys: {} });
+
+    let cancelled = false;
+    const hydrateFromSessionStorage = (): boolean => {
+      try {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as Omit<
+            OnboardingScalarState,
+            "apiKeys"
+          >;
+          // API keys intentionally never round-trip through storage;
+          // always restart them as empty on reload.
+          setState({ ...emptyState, ...parsed, apiKeys: {} });
+          return true;
+        }
+      } catch {
+        // Corrupt storage — ignore and start fresh.
       }
-    } catch {
-      // Corrupt storage — ignore and start fresh.
-    }
+      return false;
+    };
+
+    fetchOnboardingDraft()
+      .then((draft) => {
+        if (cancelled) return;
+        if (draft && Object.keys(draft).length > 0) {
+          setState({ ...emptyState, ...draft, apiKeys: {} });
+        } else {
+          hydrateFromSessionStorage();
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        hydrateFromSessionStorage();
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Persist scalars on every change. API keys are held in memory only so
@@ -77,10 +125,10 @@ export default function SetupProfileLayout({
   useEffect(() => {
     if (!hydrated.current) return;
     try {
-      // Strip apiKeys before writing.
-      const { apiKeys: _apiKeys, ...persistable } = state;
-      void _apiKeys;
-      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(persistable));
+      sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(persistableScalars(state)),
+      );
     } catch {
       // Quota exceeded or disabled — not fatal.
     }
@@ -107,9 +155,45 @@ export default function SetupProfileLayout({
     }
   }, []);
 
+  // Snapshot current state at call time, fire PATCH async. We don't
+  // await — Continue should feel instant; if the network is slow the
+  // sessionStorage cache + the next Continue's PATCH cover us. A
+  // genuine BE failure would surface on the next /onboarding/complete
+  // call where it actually matters.
+  //
+  // The optional `patch` argument matters: when a Continue handler
+  // calls `update({ x })` and then `saveDraft({ x })` in the same
+  // event, the `state` here is still the pre-update value (setState
+  // hasn't flushed). Merging the patch into the snapshot guarantees
+  // the BE sees the freshly-typed field.
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const saveDraft = useCallback(
+    (patch?: Partial<OnboardingScalarState>) => {
+      const merged = { ...stateRef.current, ...(patch ?? {}) };
+      const snapshot = persistableScalars(merged);
+      if (Object.keys(snapshot).length === 0) return;
+      void updateOnboardingDraft(snapshot).catch(() => {
+        // Swallow — sessionStorage is the fallback.
+      });
+    },
+    [],
+  );
+
   const value = useMemo<OnboardingContextValue>(
-    () => ({ state, update, setApiKey, files, setFiles, reset }),
-    [state, update, setApiKey, files, reset],
+    () => ({
+      state,
+      update,
+      setApiKey,
+      files,
+      setFiles,
+      reset,
+      saveDraft,
+    }),
+    [state, update, setApiKey, files, reset, saveDraft],
   );
 
   return (

--- a/apps/web/src/app/setup-profile/page.tsx
+++ b/apps/web/src/app/setup-profile/page.tsx
@@ -72,7 +72,7 @@ export default function SetupProfilePage() {
                 key={type}
                 type="button"
                 onClick={() => pick(type)}
-                className="flex items-start gap-4 rounded border border-border-2 bg-bg-white p-6 text-left transition-colors hover:border-primary-6"
+                className="flex items-start gap-4 rounded border border-border-2 bg-bg-white p-6 text-left cursor-pointer transition-colors hover:border-primary-6"
               >
                 <div className="h-10 w-10 shrink-0 rounded bg-bg-1 flex items-center justify-center">
                   <Icon className="h-5 w-5 text-primary-7" strokeWidth={2} />

--- a/apps/web/src/app/setup-profile/page.tsx
+++ b/apps/web/src/app/setup-profile/page.tsx
@@ -32,10 +32,13 @@ const OPTIONS: Array<{
 
 export default function SetupProfilePage() {
   const router = useRouter();
-  const { update } = useOnboarding();
+  const { update, saveDraft } = useOnboarding();
 
   const pick = (type: ProfileType) => {
     update({ profileType: type });
+    // Pass the patch so the BE snapshot picks up the just-set value
+    // even though `update`'s setState hasn't flushed yet.
+    saveDraft({ profileType: type });
     router.push(
       type === "company" ? "/setup-profile/step-2" : "/setup-profile/step-3",
     );

--- a/apps/web/src/app/setup-profile/step-2/page.tsx
+++ b/apps/web/src/app/setup-profile/step-2/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Building2, User as UserIcon } from "lucide-react";
@@ -39,6 +40,27 @@ export default function SetupProfileStep2Page() {
   const companyName = state.companyName ?? "";
   const industry = state.industry ?? "";
   const teamSize = state.teamSize ?? "";
+
+  // Show inline errors only after the user tries to advance — avoids
+  // yelling at them the moment they land on the page. After the first
+  // failed Continue, subsequent renders re-evaluate per-field so
+  // filling a field clears its error live.
+  const [attempted, setAttempted] = useState(false);
+  const errors = {
+    companyName: !companyName.trim(),
+    industry: !industry,
+    teamSize: !teamSize,
+  };
+  const hasError =
+    errors.companyName || errors.industry || errors.teamSize;
+
+  const handleContinue = () => {
+    if (hasError) {
+      setAttempted(true);
+      return;
+    }
+    router.push("/setup-profile/step-4");
+  };
 
   return (
     <div className="flex min-h-screen w-full items-center justify-center bg-bg-1 bg-[url('/login-bg.png')] bg-cover bg-center bg-no-repeat px-4 py-8">
@@ -80,39 +102,75 @@ export default function SetupProfileStep2Page() {
 
           {/* Form */}
           <div className="flex flex-col gap-4">
-            <div className="relative">
-              <UserIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 h-5 w-5 text-text-3" />
-              <Input
-                placeholder="Company Name"
-                value={companyName}
-                onChange={(e) => update({ companyName: e.target.value })}
-                className="h-11 pl-10 text-base rounded-md border-border-3 placeholder:text-text-3"
-              />
+            <div className="flex flex-col gap-1">
+              <div className="relative">
+                <UserIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 h-5 w-5 text-text-3" />
+                <Input
+                  placeholder="Company Name"
+                  value={companyName}
+                  onChange={(e) => update({ companyName: e.target.value })}
+                  aria-invalid={attempted && errors.companyName}
+                  className="h-11 pl-10 text-base rounded-md border-border-3 placeholder:text-text-3"
+                />
+              </div>
+              {attempted && errors.companyName && (
+                <p className="text-[12px] text-danger-6">
+                  Company name is required.
+                </p>
+              )}
             </div>
-            <Select value={industry} onValueChange={(v) => update({ industry: v })}>
-              <SelectTrigger className="h-11 w-full rounded-md border-border-2 text-base">
-                <SelectValue placeholder="Industry" />
-              </SelectTrigger>
-              <SelectContent>
-                {INDUSTRIES.map((i) => (
-                  <SelectItem key={i.value} value={i.value}>
-                    {i.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={teamSize} onValueChange={(v) => update({ teamSize: v })}>
-              <SelectTrigger className="h-11 w-full rounded-md border-border-2 text-base">
-                <SelectValue placeholder="Team Size" />
-              </SelectTrigger>
-              <SelectContent>
-                {TEAM_SIZES.map((t) => (
-                  <SelectItem key={t.value} value={t.value}>
-                    {t.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+
+            <div className="flex flex-col gap-1">
+              <Select
+                value={industry}
+                onValueChange={(v) => update({ industry: v })}
+              >
+                <SelectTrigger
+                  aria-invalid={attempted && errors.industry}
+                  className="h-11 w-full rounded-md border-border-2 text-base"
+                >
+                  <SelectValue placeholder="Industry" />
+                </SelectTrigger>
+                <SelectContent>
+                  {INDUSTRIES.map((i) => (
+                    <SelectItem key={i.value} value={i.value}>
+                      {i.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {attempted && errors.industry && (
+                <p className="text-[12px] text-danger-6">
+                  Pick an industry.
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Select
+                value={teamSize}
+                onValueChange={(v) => update({ teamSize: v })}
+              >
+                <SelectTrigger
+                  aria-invalid={attempted && errors.teamSize}
+                  className="h-11 w-full rounded-md border-border-2 text-base"
+                >
+                  <SelectValue placeholder="Team Size" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TEAM_SIZES.map((t) => (
+                    <SelectItem key={t.value} value={t.value}>
+                      {t.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {attempted && errors.teamSize && (
+                <p className="text-[12px] text-danger-6">
+                  Pick a team size.
+                </p>
+              )}
+            </div>
 
             <div className="flex justify-between pt-2">
               <Button
@@ -124,7 +182,7 @@ export default function SetupProfileStep2Page() {
               </Button>
               <Button
                 className="h-12 w-[127px] rounded-lg bg-primary-6 hover:bg-primary-7 text-text-white"
-                onClick={() => router.push("/setup-profile/step-4")}
+                onClick={handleContinue}
               >
                 Continue
               </Button>

--- a/apps/web/src/app/setup-profile/step-2/page.tsx
+++ b/apps/web/src/app/setup-profile/step-2/page.tsx
@@ -36,7 +36,7 @@ const TEAM_SIZES = [
 
 export default function SetupProfileStep2Page() {
   const router = useRouter();
-  const { state, update } = useOnboarding();
+  const { state, update, saveDraft } = useOnboarding();
   const companyName = state.companyName ?? "";
   const industry = state.industry ?? "";
   const teamSize = state.teamSize ?? "";
@@ -59,6 +59,9 @@ export default function SetupProfileStep2Page() {
       setAttempted(true);
       return;
     }
+    // All fields already in context via individual onChanges, so a
+    // patchless saveDraft persists exactly what the user sees.
+    saveDraft();
     router.push("/setup-profile/step-4");
   };
 

--- a/apps/web/src/app/setup-profile/step-3/page.tsx
+++ b/apps/web/src/app/setup-profile/step-3/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { UserRound, User as UserIcon } from "lucide-react";
@@ -12,6 +13,20 @@ export default function SetupProfileStep3Page() {
   const router = useRouter();
   const { state, update } = useOnboarding();
   const fullName = state.fullName ?? "";
+
+  // Show inline error only after the first failed Continue — same
+  // pattern as step-2 so the form doesn't yell at users the moment
+  // they land. Filling the field clears the error live.
+  const [attempted, setAttempted] = useState(false);
+  const fullNameError = !fullName.trim();
+
+  const handleContinue = () => {
+    if (fullNameError) {
+      setAttempted(true);
+      return;
+    }
+    router.push("/setup-profile/step-4");
+  };
 
   return (
     <div className="flex min-h-screen w-full items-center justify-center bg-bg-1 bg-[url('/login-bg.png')] bg-cover bg-center bg-no-repeat px-4 py-8">
@@ -52,14 +67,22 @@ export default function SetupProfileStep3Page() {
 
           {/* Form */}
           <div className="flex flex-col gap-4">
-            <div className="relative">
-              <UserIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 h-5 w-5 text-text-3" />
-              <Input
-                placeholder="Full name"
-                value={fullName}
-                onChange={(e) => update({ fullName: e.target.value })}
-                className="h-11 pl-10 text-base rounded-md border-border-3 placeholder:text-text-3"
-              />
+            <div className="flex flex-col gap-1">
+              <div className="relative">
+                <UserIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 h-5 w-5 text-text-3" />
+                <Input
+                  placeholder="Full name"
+                  value={fullName}
+                  onChange={(e) => update({ fullName: e.target.value })}
+                  aria-invalid={attempted && fullNameError}
+                  className="h-11 pl-10 text-base rounded-md border-border-3 placeholder:text-text-3"
+                />
+              </div>
+              {attempted && fullNameError && (
+                <p className="text-[12px] text-danger-6">
+                  Full name is required.
+                </p>
+              )}
             </div>
 
             <div className="flex justify-between pt-2">
@@ -72,7 +95,7 @@ export default function SetupProfileStep3Page() {
               </Button>
               <Button
                 className="h-12 w-[127px] rounded-lg bg-primary-6 hover:bg-primary-7 text-text-white"
-                onClick={() => router.push("/setup-profile/step-4")}
+                onClick={handleContinue}
               >
                 Continue
               </Button>

--- a/apps/web/src/app/setup-profile/step-3/page.tsx
+++ b/apps/web/src/app/setup-profile/step-3/page.tsx
@@ -11,7 +11,7 @@ import { useOnboarding } from "../layout";
 
 export default function SetupProfileStep3Page() {
   const router = useRouter();
-  const { state, update } = useOnboarding();
+  const { state, update, saveDraft } = useOnboarding();
   const fullName = state.fullName ?? "";
 
   // Show inline error only after the first failed Continue — same
@@ -25,6 +25,7 @@ export default function SetupProfileStep3Page() {
       setAttempted(true);
       return;
     }
+    saveDraft();
     router.push("/setup-profile/step-4");
   };
 

--- a/apps/web/src/app/setup-profile/step-4/page.tsx
+++ b/apps/web/src/app/setup-profile/step-4/page.tsx
@@ -47,7 +47,7 @@ const INFRA_OPTIONS: Array<{
 
 export default function SetupProfileStep4Page() {
   const router = useRouter();
-  const { state, update } = useOnboarding();
+  const { state, update, saveDraft } = useOnboarding();
   const selected: Infra = state.infraChoice ?? "managed";
 
   return (
@@ -133,6 +133,7 @@ export default function SetupProfileStep4Page() {
                 // cards — otherwise step 6 would see infraChoice undefined
                 // and reject the submit.
                 if (!state.infraChoice) update({ infraChoice: selected });
+                saveDraft({ infraChoice: selected });
                 router.push("/setup-profile/step-5");
               }}
             >

--- a/apps/web/src/app/setup-profile/step-4/page.tsx
+++ b/apps/web/src/app/setup-profile/step-4/page.tsx
@@ -80,7 +80,7 @@ export default function SetupProfileStep4Page() {
                   key={type}
                   type="button"
                   onClick={() => update({ infraChoice: type })}
-                  className={`flex-1 flex flex-col gap-4 rounded bg-bg-white p-6 text-left transition-colors ${
+                  className={`flex-1 flex flex-col gap-4 rounded bg-bg-white p-6 text-left cursor-pointer transition-colors ${
                     isSelected
                       ? "border-[1.5px] border-primary-6"
                       : "border border-border-2 hover:border-primary-6"

--- a/apps/web/src/app/setup-profile/step-5/page.tsx
+++ b/apps/web/src/app/setup-profile/step-5/page.tsx
@@ -11,39 +11,48 @@ import { useOnboarding } from "../layout";
 
 type ProviderId = "openai" | "azure" | "anthropic" | "private-vpc";
 
-// Per-provider placeholder mirrors the format the user sees in their
-// provider dashboard so they know they're pasting the right thing. We
-// avoid fully-formed valid-looking strings to discourage anyone copying
-// the placeholder itself by accident.
+// `available: true` means the provider flows end-to-end through
+// onboarding → integrations table → chat-transport BYOK. Marked
+// providers persist the typed key, the others render with a
+// "Coming soon" pill and a disabled input — they need extra fields
+// (Azure deployment URL, VPC endpoint) the wizard doesn't collect
+// yet, so the typed key would be dropped on the BE. Showing the
+// state honestly avoids the "I configured Azure but chat doesn't
+// route through it" confusion.
 const PROVIDERS: Array<{
   id: ProviderId;
   name: string;
   models: string;
   placeholder: string;
+  available: boolean;
 }> = [
   {
     id: "openai",
     name: "OpenAI",
     models: "GPT-4, GPT-3.5",
     placeholder: "sk-proj-…",
+    available: true,
   },
   {
     id: "azure",
     name: "Azure OpenAI",
     models: "Enterprise GPT-4",
     placeholder: "Azure deployment key (32-char hex)",
+    available: false,
   },
   {
     id: "anthropic",
     name: "Anthropic",
     models: "Claude 3 Opus",
     placeholder: "sk-ant-api03-…",
+    available: true,
   },
   {
     id: "private-vpc",
     name: "Private VPC",
     models: "Mistral, Llama",
     placeholder: "Endpoint URL or bearer token",
+    available: false,
   },
 ];
 
@@ -76,7 +85,7 @@ export default function SetupProfileStep5Page() {
           </div>
 
           <div className="flex flex-col gap-2">
-            {PROVIDERS.map(({ id, name, models, placeholder }) => {
+            {PROVIDERS.map(({ id, name, models, placeholder, available }) => {
               const isExpanded = expanded === id;
               return (
                 <div
@@ -85,7 +94,7 @@ export default function SetupProfileStep5Page() {
                     isExpanded
                       ? "border-[1.5px] border-primary-6"
                       : "border border-border-2"
-                  }`}
+                  } ${available ? "" : "opacity-70"}`}
                 >
                   <button
                     type="button"
@@ -93,9 +102,16 @@ export default function SetupProfileStep5Page() {
                     className="flex w-full items-center justify-between"
                   >
                     <div className="flex flex-col gap-0.5 text-left">
-                      <h3 className="text-[18px] font-bold text-text-1 leading-tight">
-                        {name}
-                      </h3>
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-[18px] font-bold text-text-1 leading-tight">
+                          {name}
+                        </h3>
+                        {!available && (
+                          <span className="rounded-full bg-warning-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-warning-7">
+                            Coming soon
+                          </span>
+                        )}
+                      </div>
                       <p className="text-[13px] text-text-3 leading-snug">
                         {models}
                       </p>
@@ -114,16 +130,20 @@ export default function SetupProfileStep5Page() {
                       </label>
                       <Input
                         type="password"
-                        placeholder={placeholder}
+                        placeholder={
+                          available ? placeholder : "Coming soon — not active yet"
+                        }
                         value={apiKeys[id] ?? ""}
                         onChange={(e) => setApiKey(id, e.target.value)}
-                        className="h-11 text-base rounded-md border-border-3 placeholder:text-text-3 font-mono"
+                        disabled={!available}
+                        className="h-11 text-base rounded-md border-border-3 placeholder:text-text-3 font-mono disabled:cursor-not-allowed disabled:bg-bg-1"
                       />
-                      {(id === "azure" || id === "private-vpc") && (
+                      {!available && (
                         <p className="text-[12px] text-text-3 leading-snug">
-                          {id === "azure"
-                            ? "Azure also needs a deployment URL — finish setup later in Management → Integration."
-                            : "Private VPC needs an endpoint URL — finish setup later in Management → Integration."}
+                          {name} support is on the roadmap — we&apos;ll
+                          enable it here once the rest of the integration
+                          ships. In the meantime, finish setup in
+                          Management → Integration after onboarding.
                         </p>
                       )}
                     </div>

--- a/apps/web/src/app/setup-profile/step-5/page.tsx
+++ b/apps/web/src/app/setup-profile/step-5/page.tsx
@@ -130,9 +130,13 @@ export default function SetupProfileStep5Page() {
                       </label>
                       <Input
                         type="password"
-                        placeholder={
-                          available ? placeholder : "Coming soon — not active yet"
-                        }
+                        // Format-specific placeholder stays visible even
+                        // for the coming-soon providers — the
+                        // disabled input + the yellow pill on the
+                        // header + the help text below already convey
+                        // the not-active-yet state, so we can keep the
+                        // format hint front and centre.
+                        placeholder={placeholder}
                         value={apiKeys[id] ?? ""}
                         onChange={(e) => setApiKey(id, e.target.value)}
                         disabled={!available}

--- a/apps/web/src/app/setup-profile/step-6/page.tsx
+++ b/apps/web/src/app/setup-profile/step-6/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { UploadCloud, FolderClosed, Users, Server, Award, FileText, X } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -31,6 +31,7 @@ function hasAllowedExtension(name: string) {
 
 export default function SetupProfileStep6Page() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { state, files, setFiles, reset } = useOnboarding();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -113,7 +114,13 @@ export default function SetupProfileStep6Page() {
     onSuccess: () => {
       reset();
       queryClient.invalidateQueries({ queryKey: ["auth", "me"] });
-      window.location.href = "/";
+      // Honour ?next= when present — set by the BE Google callback
+      // when the user signed in to accept an invite mid-flow. Has to
+      // be a same-origin path; reject anything else as a redirect
+      // hardening guard.
+      const next = searchParams.get("next");
+      const target = next && next.startsWith("/") ? next : "/";
+      window.location.href = target;
     },
     onError: (err: Error) => {
       toast.error(err.message || "Couldn't save your setup. Please try again.");

--- a/apps/web/src/components/management/team-row.tsx
+++ b/apps/web/src/components/management/team-row.tsx
@@ -86,6 +86,7 @@ function MemberAvatars({
               key={i}
               src={m.picture}
               alt={m.name ?? ""}
+              referrerPolicy="no-referrer"
               className="h-6 w-6 rounded-full border-2 border-bg-white object-cover"
             />
           ) : (

--- a/apps/web/src/components/management/user-row.tsx
+++ b/apps/web/src/components/management/user-row.tsx
@@ -88,6 +88,7 @@ export function UserRow({ user }: { user: OrgUser }) {
             <img
               src={user.picture}
               alt={user.name ?? user.email}
+              referrerPolicy="no-referrer"
               className="h-7 w-7 shrink-0 rounded-full object-cover"
             />
           ) : (

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -27,11 +27,19 @@ function Avatar({
 
 function AvatarImage({
   className,
+  referrerPolicy = "no-referrer",
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  // Default `no-referrer` so Google profile pictures
+  // (lh3.googleusercontent.com), the most common avatar source we
+  // get from Google OAuth, actually load. Google blocks image
+  // requests whose Referer header points at non-allowed origins
+  // (e.g. localhost during dev), and a stripped referrer is the
+  // standard escape hatch. Callers can still override.
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
+      referrerPolicy={referrerPolicy}
       className={cn("aspect-square size-full", className)}
       {...props}
     />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1705,6 +1705,45 @@ export async function fetchOnboardingProfile(): Promise<OnboardingProfile> {
   return res.json();
 }
 
+/**
+ * Resume-flow draft. Mirrors the BE `OnboardingDraft` — every field
+ * optional, no API keys, no files. Persisted server-side per user
+ * (PK = userId) and dropped once onboarding completes.
+ */
+export interface OnboardingDraft {
+  profileType?: "company" | "personal";
+  fullName?: string;
+  companyName?: string;
+  industry?: string;
+  teamSize?: string;
+  infraChoice?: "managed" | "on-premise";
+}
+
+export async function fetchOnboardingDraft(): Promise<OnboardingDraft | null> {
+  const res = await apiFetch("/onboarding/draft", { skipAuthRedirect: true });
+  if (res.status === 401) return null;
+  if (!res.ok) return null;
+  const body = (await res.json()) as { draft: OnboardingDraft | null };
+  return body.draft ?? null;
+}
+
+export async function updateOnboardingDraft(
+  draft: OnboardingDraft,
+): Promise<OnboardingDraft> {
+  const res = await apiFetch("/onboarding/draft", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(draft),
+  });
+  if (!res.ok) throw new Error("Failed to save onboarding draft");
+  const body = (await res.json()) as { draft: OnboardingDraft };
+  return body.draft;
+}
+
+export async function deleteOnboardingDraft(): Promise<void> {
+  await apiFetch("/onboarding/draft", { method: "DELETE" });
+}
+
 export interface CompleteOnboardingPayload {
   profileType: "company" | "personal";
   fullName?: string;

--- a/packages/database/backfill/backfill-legacy-onboarding-completed.sql
+++ b/packages/database/backfill/backfill-legacy-onboarding-completed.sql
@@ -20,7 +20,11 @@
 -- Run from repo root:
 --   docker exec -i worken-postgres psql -U worken -d worken < packages/database/backfill/backfill-legacy-onboarding-completed.sql
 
+BEGIN;
+
 UPDATE users
 SET onboarding_completed_at = COALESCE(updated_at, created_at, now())
 WHERE profile_type IS NOT NULL
   AND onboarding_completed_at IS NULL;
+
+COMMIT;

--- a/packages/database/backfill/drop-legacy-user-llm-credentials.sql
+++ b/packages/database/backfill/drop-legacy-user-llm-credentials.sql
@@ -1,0 +1,42 @@
+-- One-shot drop of the legacy `user_llm_credentials` table.
+--
+-- Background: until commit 595f986, onboarding step 5 wrote API keys
+-- to `user_llm_credentials`. Nothing in the live system has read from
+-- it since — the chat-transport BYOK path and the Integration tab
+-- both read from `integrations`, and the legacy `getProfile` reader
+-- was switched over in the same commit. The remaining rows were
+-- copied across by `migrate-legacy-llm-credentials-to-integrations.sql`.
+--
+-- This is the cleanup. Drops the table so future devs don't see a
+-- dead schema definition and start writing to it again.
+--
+-- Pre-flight check (read-only — does NOT modify anything):
+--   SELECT
+--     (SELECT count(*) FROM user_llm_credentials WHERE provider IN ('openai','anthropic')) AS legacy_total,
+--     (
+--       SELECT count(*) FROM user_llm_credentials ulc
+--       WHERE ulc.provider IN ('openai','anthropic')
+--         AND NOT EXISTS (
+--           SELECT 1 FROM integrations i
+--           WHERE i.owner_id = ulc.user_id
+--             AND i.provider_id = ulc.provider
+--             AND i.api_url IS NULL
+--         )
+--     ) AS unmigrated;
+--
+-- The `unmigrated` count MUST be 0 before running this. If it's not,
+-- run `migrate-legacy-llm-credentials-to-integrations.sql` first.
+--
+-- Idempotent: `DROP TABLE IF EXISTS` so re-running is a no-op once
+-- the table is gone. The FK constraint to `users.id` (ON DELETE
+-- CASCADE) is dropped automatically with the table.
+--
+-- Run from repo root:
+--   docker exec -i worken-postgres psql -U worken -d worken \
+--     < packages/database/backfill/drop-legacy-user-llm-credentials.sql
+
+BEGIN;
+
+DROP TABLE IF EXISTS user_llm_credentials;
+
+COMMIT;

--- a/packages/database/backfill/migrate-legacy-llm-credentials-to-integrations.sql
+++ b/packages/database/backfill/migrate-legacy-llm-credentials-to-integrations.sql
@@ -32,6 +32,8 @@
 --   docker exec -i worken-postgres psql -U worken -d worken \
 --     < packages/database/backfill/migrate-legacy-llm-credentials-to-integrations.sql
 
+BEGIN;
+
 INSERT INTO integrations (owner_id, provider_id, api_url, api_key_encrypted, is_enabled, created_at)
 SELECT
   ulc.user_id,
@@ -48,3 +50,5 @@ WHERE ulc.provider IN ('openai', 'anthropic')
       AND i.provider_id = ulc.provider
       AND i.api_url IS NULL
   );
+
+COMMIT;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -216,6 +216,31 @@ export const guardrails = pgTable("guardrails", {
 // Onboarding step-5 keys now flow into the `integrations` table from
 // commit 595f986 onwards.
 
+/**
+ * Per-user staged onboarding state. Survives sessionStorage loss
+ * (browser crash, cookie clear, device switch) so a user who closed
+ * the tab on step 4 can pick up where they left off on next login.
+ *
+ * Lives only until the user completes onboarding —
+ * `OnboardingService.complete` deletes the row after the atomic
+ * users/credentials/documents transaction commits. ON DELETE CASCADE
+ * to users.id covers GDPR delete + admin user-removal as well.
+ *
+ * Stores the *non-sensitive* scalar fields gathered across steps 2–4:
+ * profile type, company info (name / industry / team size), infra
+ * choice. Step-5 API keys and step-6 file uploads stay out of the
+ * draft on purpose — the keys are an XSS exfiltration vector if
+ * persisted, and the files are large multipart uploads that don't
+ * round-trip cleanly through a JSON column.
+ */
+export const onboardingDrafts = pgTable("onboarding_drafts", {
+  userId: uuid("user_id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade" }),
+  partial: jsonb("partial").notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
 export const knowledgeDocuments = pgTable("knowledge_documents", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id")

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -211,15 +211,10 @@ export const guardrails = pgTable("guardrails", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
-export const userLlmCredentials = pgTable("user_llm_credentials", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  userId: uuid("user_id")
-    .references(() => users.id, { onDelete: "cascade" })
-    .notNull(),
-  provider: text("provider").notNull(), // 'openai' | 'azure' | 'anthropic' | 'private-vpc'
-  apiKeyEncrypted: text("api_key_encrypted").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+// Legacy `user_llm_credentials` table dropped — see
+// `packages/database/backfill/drop-legacy-user-llm-credentials.sql`.
+// Onboarding step-5 keys now flow into the `integrations` table from
+// commit 595f986 onwards.
 
 export const knowledgeDocuments = pgTable("knowledge_documents", {
   id: uuid("id").primaryKey().defaultRandom(),


### PR DESCRIPTION
  ## Summary

  Bundles seven follow-up TODOs from the post-`fix/onboarding` cleanup list, two new UX features, and the final pre-merge review fixes. Net result: the wizard survives session loss, the Google → /setup-profile
  transition no longer flashes the dashboard, step 2/3 validate before the final submit, the legacy `user_llm_credentials` table is gone, and admin auth gates are now locked down by tests.

  ## What's in here (in commit order)

  ### Cleanups + drops

  - **`f8720e9` polish — TODO-9, TODO-10, TODO-11, TODO-12.** Wrap the multi-statement backfill SQLs in explicit `BEGIN; ... COMMIT;` (the `DO $$ … $$;` arena-runs backfill is already atomic, left alone).
  Refactor onboarding step-5 validation to use a `SUPPORTED_FOR_INTEGRATION_TABLE = ['openai', 'anthropic']` constant instead of inline string compares. Fix the lone-link "Follow Us" footer rendering 8px
  off-center — anchor margin removed, multi-link cases get a `·` separator span between siblings. Drop the verbose `as (typeof VALID_INDUSTRIES)[number]` casts in favour of `(VALID as readonly
  string[]).includes(p.industry)`.

  - **`2b866c6` drop legacy `user_llm_credentials` — TODO-6.** Table has been dead code since 595f986. New idempotent `drop-legacy-user-llm-credentials.sql` (with pre-flight check macro in the comments) +
  schema definition removed in favour of a one-line breadcrumb. Plus TODO-8 audit (JOINs against `messages.user_id` after the cc51fe9 NULL-out fix): no fixes needed — `conversations.findByProject` INNER JOIN
  intentionally excludes NULL author rows, `findOne` is already LEFT JOIN, `teams.ownerId` is safe because owned teams are deleted before the user.

  ### Tests

  - **`6546b47` NestJS spec scaffolding — TODO-7.** Wires `moduleNameMapper: {"^(\\.{1,2}/.*)\\.js$": "$1"}` into the existing jest config so production-side `.js` ESM imports resolve under ts-jest. New specs
  cover UsersController (admin gates on PATCH budget / PATCH role / DELETE; self-mutation lockout) and ApiKeysController (POST /api-keys blocked when `authMethod === 'apikey'` — the persistence-after-revoke
  escalation guard). 10 tests, ~2s, all green.

  ### UX fixes

  - **`223e89a` no dashboard flash on Google → /setup-profile.** Two-pronged. BE Google callback redirects directly to `/setup-profile` when `onboardingCompletedAt` is null. FE `OnboardingGuard` renders a
  centered Loader2 spinner during both `isLoading` and the about-to-redirect state, instead of leaking the dashboard chrome through.

  - **`41ca2cb` mark Azure / Private VPC as Coming soon.** Step 5 now shows a yellow "COMING SOON" pill on the disabled provider cards, dimmed background, disabled input, and inline help text saying support is
  on the roadmap and to finish setup in Management → Integration. The BE was already dropping these keys with a warn log; this surfaces that state honestly to the user instead of letting them think Azure / VPC
  was configured.

  - **`7076fd3` inline validation on step 2 / step 3 Continue.** Step 2 (Company) requires `companyName + industry + teamSize`. Step 3 (Personal) requires `fullName`. Click Continue with empty fields → inline
  red helper text appears under the offending input, `aria-invalid` flips on so the existing styles draw a red ring. Errors clear live as the user fills fields. `attempted` flag avoids yelling on initial
  render.

  - **`18d8a48` per-step BE draft.** New per-user `onboarding_drafts` table (PK = userId, partial jsonb, ON DELETE CASCADE on user_id). Endpoints: `GET /onboarding/draft`, `PATCH /onboarding/draft`, `DELETE
  /onboarding/draft`. `OnboardingService.complete()` deletes the row after success. FE `SetupProfileLayout` hydrates from BE first, falls back to sessionStorage. Each step's Continue handler calls
  `saveDraft(patch?)` — patch optional and merged into the snapshot to handle the "setState hasn't flushed yet" race in the same event handler. API keys + files explicitly excluded (XSS exfiltration vector +
  multipart not JSON-friendly).

  - **`222fe41` keep format-specific placeholders on Coming-soon rows.** The `Coming soon — not active yet` placeholder string was overwriting the per-provider format hint on Azure / Private VPC. Restored — the
   not-active-yet state is already conveyed by three other affordances (yellow pill, disabled input, help text).

  ### Pre-merge review fixes

  - **`03f6822` review fixes (#2 + #5 from the gap review).** Draft sanitiser now 400s on invalid enum values for known fields (industry / teamSize / profileType / infraChoice) instead of silently dropping —
  programmatic callers get an explicit error. Unknown top-level keys still strip silently for forward-compat. Plus Google callback now forwards `invite_return_to` through onboarding via
  `?next=<encoded-invite>`; step 6's success handler honours it (with a same-origin path guard) so an invited user finishing onboarding lands on the invite page instead of losing the link.

  ## Migration step

  Two backfill SQLs to run on prod, both idempotent and BEGIN/COMMIT-framed:


  # 1. Migrate any straggler legacy keys (run first, every time before drop)
  docker exec -i worken-postgres psql -U worken -d worken \
    < packages/database/backfill/migrate-legacy-llm-credentials-to-integrations.sql

  # 2. Drop the legacy table
  docker exec -i worken-postgres psql -U worken -d worken \
    < packages/database/backfill/drop-legacy-user-llm-credentials.sql

  db:push will pick up the new onboarding_drafts table automatically — no separate migration needed for that one.

  Test plan

 ____

- [x]  - Sign in with Google as a fresh user → land directly on /setup-profile with no dashboard flash
- [x]   - Sign in with Google as an already-onboarded user → land on / (regression)
- [ ]   - Sign in via invite-flow + incomplete onboarding → URL after Google callback is /setup-profile?next=... → after completing step 6 you land on the invite page (not /)
- [ ]   - Step 2: click Continue with empty fields → inline red errors appear under each missing field, no navigation
- [ ]   - Step 2: fill the field → its error clears live without re-clicking Continue
- [ ]   - Step 3: same as step 2 for fullName
- [ ]   - Step 5: Azure + Private VPC cards show yellow "Coming soon" pill, disabled input, help text. Format-specific placeholder still visible in the disabled field
- [ ]   - Step 5: type into OpenAI / Anthropic, click Continue, refresh → state persists (sessionStorage)
- [ ]   - Step 5: type into OpenAI, complete onboarding, log out, log back in, start fresh wizard → no leftover keys (deleted on complete)
- [ ]   - Mid-onboarding: clear cookies + sessionStorage + log back in → wizard resumes from BE draft (companyName / industry / teamSize / infraChoice intact, API keys re-prompted)
- [ ]   - PATCH /onboarding/draft {industry: "lol"} → 400 with whitelist message
- [ ]   - PATCH /onboarding/draft {unknownKey: "x", companyName: "Acme"} → 200, unknown key dropped
- [ ]   - DELETE /onboarding/draft → 204; subsequent GET → { draft: null }
- [ ]   - Apply drop-legacy-user-llm-credentials.sql on a clean DB → table is gone, dependent schema lookups still pass
- [ ]   - Run cd apps/api && pnpm test → 3 suites, 10 tests, all green
- [ ]   - Both apps pnpm tsc --noEmit clean

____

  Already verified locally

  - ✅ All 9 commits' typecheck clean on both apps
  - ✅ 10 jest tests pass in ~2s
  - ✅ /onboarding/draft GET / PATCH / DELETE round-trip end-to-end
  - ✅ PATCH draft with invalid enum returns 400 (verified for industry, teamSize)
  - ✅ PATCH draft with unknown top-level keys silently strips them (forward-compat)
  - ✅ Drop SQL applied on local DB, table is gone, no orphan references in apps/
  - ✅ users.controller.spec.ts exercises admin gates + self-mutation lockout
  - ✅ api-keys.controller.spec.ts blocks mint via api-key auth (persistence-after-revoke guard)

  Out of scope (acknowledged in the review)

  - Step 4 implicit-default infraChoice still saves 'managed' on Continue without an explicit click. Inconsistent with steps 2/3, but kept to match Figma's pre-selected card behaviour. Worth a doc-clarity
  follow-up.
  - OnboardingGuard doesn't gate on isFetching (only isLoading), so a successful onboarding completion that triggers a stale-revalidation could briefly re-show the spinner. Acceptable cost.
  - mockDb test scaffolding only mocks select().from().where(). Future controllers calling other Drizzle chains would silently bypass the mock. Worth a test-coverage TODO.
  - Body-parser size limit not explicitly tightened — Express default of 100KB is plenty for the draft payload (~1KB) and not a meaningful DoS vector.
