### PR TITLE
fix(team-detail): match user-detail edit/delete flow

### DIFF
--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -67,7 +67,7 @@ import {
 import { InviteMemberDialog } from "@/components/invite-member-dialog";
 import { TeamIntegrationsSection } from "@/components/team-integrations-section";
 import { TeamMemberCapDialog } from "@/components/team-member-cap-dialog";
-import { formatCurrency } from "@/lib/utils";
+import { formatBudgetInput, formatCurrency } from "@/lib/utils";
 
 /* ─── Helpers ────────────────────────────────────────────────────────────── */
 
@@ -353,7 +353,6 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     [rawGuardrails],
   );
 
-  const [budgetInput, setBudgetInput] = useState<string | null>(null);
   const budgetMutation = useMutation({
     mutationFn: (budgetUsd: number) => updateTeamBudget(id, budgetUsd),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams", id] }),
@@ -454,7 +453,6 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   const remaining = budget - spent;
   const projected = team.projectedCents / 100;
   const onTrack = projected <= budget;
-  const displayBudget = budgetInput ?? budget.toLocaleString("de-DE", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
   const myMembership = team.members.find(
     (m) =>
@@ -467,16 +465,6 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     (currentUser.id === team.ownerId || myMembership?.role === "owner" || myMembership?.role === "editor");
   // Back-compat alias used by the role Select.
   const canEditRoles = canManageTeam;
-
-  const handleBudgetBlur = () => {
-    if (budgetInput === null) return;
-    const raw = budgetInput.replace(/\./g, "").replace(",", ".");
-    const num = parseFloat(raw);
-    // 0 is allowed as a "suspend" gesture — blocks all spend until the
-    // owner raises the budget again. BE enforces non-negative.
-    if (!isNaN(num) && num >= 0 && num !== budget) budgetMutation.mutate(num);
-    setBudgetInput(null);
-  };
 
   // Render guard for the inline edit affordances. canManageTeam alone
   // isn't enough — non-managers could still flip isEditing via the
@@ -625,14 +613,18 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-3">
             <p className="text-[18px] font-bold text-text-1">Monthly Budget</p>
-            <div className="relative">
-              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[16px] text-text-2">$</span>
-              {editing ? (
+            {editing ? (
+              <div className="relative">
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[16px] text-text-2">
+                  $
+                </span>
                 <input
                   type="text"
                   inputMode="decimal"
                   value={editBudget}
-                  onChange={(e) => setEditBudget(e.target.value)}
+                  onChange={(e) =>
+                    setEditBudget(formatBudgetInput(e.target.value))
+                  }
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       e.preventDefault();
@@ -643,20 +635,25 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                     }
                   }}
                   disabled={isSavingTeam}
-                  className="w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-2 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:opacity-60"
+                  autoFocus
+                  className="w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60"
                 />
-              ) : (
-                <input
-                  type="text"
-                  value={displayBudget}
-                  onChange={(e) => setBudgetInput(e.target.value)}
-                  onBlur={handleBudgetBlur}
-                  onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
-                  readOnly={!canManageTeam}
-                  className={`w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-2 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 ${!canManageTeam ? "cursor-default" : ""}`}
-                />
-              )}
-            </div>
+              </div>
+            ) : (
+              <div className="flex h-[56px] items-center px-1 text-[16px] text-text-1">
+                {budget > 0 ? (
+                  <span>{formatCurrency(budget)}</span>
+                ) : (
+                  <span className="text-text-3">Not set</span>
+                )}
+              </div>
+            )}
+            {!editing && !canManageTeam && (
+              <p className="text-[12px] text-text-3">
+                Only team owners and editors can change this — ask one to
+                adjust the budget.
+              </p>
+            )}
           </div>
           <div className="space-y-3">
             <p className="text-[18px] font-bold text-text-1">Spent / Remaining</p>

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -52,76 +52,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { formatCurrency } from "@/lib/utils";
+import { formatBudgetInput, formatCurrency } from "@/lib/utils";
 import { useAuth } from "@/components/providers";
-
-/**
- * Live formatter for the de-DE budget input. Called on every
- * keystroke to keep the displayed value in `1.234,56` shape while the
- * user is typing. Also smart-parses pasted en-US values (`1234.56` →
- * `1.234,56`) so both keyboard layouts feel native.
- *
- * Pairs with the existing parser in confirmEdit, which strips dots
- * and converts the comma to a dot before parseFloat.
- */
-function formatBudgetInput(raw: string): string {
-  // Strip everything except digits, dots, commas.
-  let canonical = raw.replace(/[^\d.,]/g, "");
-
-  const hasComma = canonical.includes(",");
-  const dotCount = (canonical.match(/\./g) ?? []).length;
-
-  if (hasComma) {
-    // de-DE: comma is decimal, dots are thousand separators → drop dots.
-    canonical = canonical.replace(/\./g, "");
-  } else if (dotCount > 0) {
-    // No comma. Heuristic: a single dot followed by 1–2 digits is a
-    // decimal point (en-US paste like "1234.56"). Anything else is
-    // thousand-separator decoration ("1.234") and the dots get
-    // stripped.
-    const lastDot = canonical.lastIndexOf(".");
-    const trailingDigits = canonical.length - lastDot - 1;
-    if (dotCount === 1 && trailingDigits >= 1 && trailingDigits <= 2) {
-      canonical = canonical.replace(".", ",");
-    } else {
-      canonical = canonical.replace(/\./g, "");
-    }
-  }
-
-  // Collapse extra commas (keep first).
-  const firstComma = canonical.indexOf(",");
-  if (firstComma >= 0) {
-    canonical =
-      canonical.slice(0, firstComma + 1) +
-      canonical.slice(firstComma + 1).replace(/,/g, "");
-  }
-
-  if (canonical === "") return "";
-
-  let intPart: string;
-  let fracPart: string | null;
-  if (firstComma >= 0) {
-    const parts = canonical.split(",");
-    intPart = parts[0] ?? "";
-    fracPart = (parts[1] ?? "").slice(0, 2);
-  } else {
-    intPart = canonical;
-    fracPart = null;
-  }
-
-  // Strip leading zeros except keep the last digit; "00012" → "12",
-  // "0" → "0", "0001234" → "1234". Then handle the "0,5" case where
-  // the comma was typed but the int side ended up empty.
-  intPart = intPart.replace(/^0+(?=\d)/, "");
-  if (intPart === "" && fracPart !== null) {
-    intPart = "0";
-  }
-
-  // Insert thousand separators (dots) into the integer part.
-  const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-
-  return fracPart !== null ? `${intFormatted},${fracPart}` : intFormatted;
-}
 
 /* ─── Helper components ──────────────────────────────────────────────────── */
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -19,3 +19,70 @@ export function formatCurrency(value: number): string {
   });
   return value < 0 ? `-$${formatted}` : `$${formatted}`;
 }
+
+/**
+ * Live formatter for the de-DE budget input. Called on every keystroke
+ * to keep the displayed value in `1.234,56` shape while the user is
+ * typing. Also smart-parses pasted en-US values (`1234.56` → `1.234,56`)
+ * so both keyboard layouts feel native.
+ *
+ * Pairs with the parser used on confirm: strip dots, swap comma for
+ * dot, then `parseFloat`.
+ */
+export function formatBudgetInput(raw: string): string {
+  // Strip everything except digits, dots, commas.
+  let canonical = raw.replace(/[^\d.,]/g, "");
+
+  const hasComma = canonical.includes(",");
+  const dotCount = (canonical.match(/\./g) ?? []).length;
+
+  if (hasComma) {
+    // de-DE: comma is decimal, dots are thousand separators → drop dots.
+    canonical = canonical.replace(/\./g, "");
+  } else if (dotCount > 0) {
+    // No comma. Heuristic: a single dot followed by 1–2 digits is a
+    // decimal point (en-US paste like "1234.56"). Anything else is
+    // thousand-separator decoration ("1.234") and the dots get stripped.
+    const lastDot = canonical.lastIndexOf(".");
+    const trailingDigits = canonical.length - lastDot - 1;
+    if (dotCount === 1 && trailingDigits >= 1 && trailingDigits <= 2) {
+      canonical = canonical.replace(".", ",");
+    } else {
+      canonical = canonical.replace(/\./g, "");
+    }
+  }
+
+  // Collapse extra commas (keep first).
+  const firstComma = canonical.indexOf(",");
+  if (firstComma >= 0) {
+    canonical =
+      canonical.slice(0, firstComma + 1) +
+      canonical.slice(firstComma + 1).replace(/,/g, "");
+  }
+
+  if (canonical === "") return "";
+
+  let intPart: string;
+  let fracPart: string | null;
+  if (firstComma >= 0) {
+    const parts = canonical.split(",");
+    intPart = parts[0] ?? "";
+    fracPart = (parts[1] ?? "").slice(0, 2);
+  } else {
+    intPart = canonical;
+    fracPart = null;
+  }
+
+  // Strip leading zeros except keep the last digit; "00012" → "12",
+  // "0" → "0", "0001234" → "1234". Then handle the "0,5" case where
+  // the comma was typed but the int side ended up empty.
+  intPart = intPart.replace(/^0+(?=\d)/, "");
+  if (intPart === "" && fracPart !== null) {
+    intPart = "0";
+  }
+
+  // Insert thousand separators (dots) into the integer part.
+  const intFormatted = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+
+  return fracPart !== null ? `${intFormatted},${fracPart}` : intFormatted;
+}


### PR DESCRIPTION
Team detail's budget had two ways to edit (inline-on-blur + the appbar Pencil edit-mode), which made the appbar Edit button feel redundant. Drop the inline-editable input: in view mode the budget now reads as plain currency (or "Not set" / a non-manager hint), exactly like /users/[id]. Edit mode picks up the shared formatBudgetInput live formatter and autoFocus too.

formatBudgetInput is now shared in lib/utils.ts so both pages stay in sync.