### PR TITLE
Feat/company budget

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { RedisModule } from './redis/redis.module';
 import { ModelsModule } from './models/models.module';
 import { ObservabilityModule } from './observability/observability.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
+import { OrgSettingsModule } from './org-settings/org-settings.module';
 import { PromptsModule } from './prompts/prompts.module';
 import { ShortcutsModule } from './shortcuts/shortcuts.module';
 import { TeamsModule } from './teams/teams.module';
@@ -42,6 +43,7 @@ import { UsersModule } from './users/users.module';
     ModelsModule,
     ObservabilityModule,
     OnboardingModule,
+    OrgSettingsModule,
     ProjectsModule,
     PromptsModule,
     ShortcutsModule,

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -62,11 +62,9 @@ export class ChatController {
     // managed-cloud with monthlyBudgetCents = 0 — awaiting admin
     // approval. Project-scoped chats gate on the team budget; personal
     // chats gate on the user's budget.
-    await this.chatTransport.assertManagedBudgetApproved(
-      transport,
-      user.id,
-      { projectId: conversation.projectId },
-    );
+    await this.chatTransport.assertManagedBudgetApproved(transport, user.id, {
+      projectId: conversation.projectId,
+    });
 
     // Per-member team cap. Independent from the team-wide budget gate
     // above: a team can have $1000/mo total but each member capped at
@@ -91,6 +89,12 @@ export class ChatController {
       estimatedCostUsd != null ? Math.ceil(estimatedCostUsd * 100) : 0;
     await this.chatTransport.assertTeamMemberCapNotExceeded(user.id, {
       projectId: conversation.projectId,
+      estimatedCostCents,
+    });
+    // Org-wide budget gate fires last so per-team / per-member caps
+    // surface their actionable wording first (those are easier for an
+    // admin to fix than the company-level target).
+    await this.chatTransport.assertOrgBudgetNotExceeded({
       estimatedCostCents,
     });
 
@@ -219,8 +223,7 @@ export class ChatController {
           message?: string;
           error?: { message?: string };
         };
-        const upstreamMessage =
-          apiErr.error?.message ?? apiErr.message ?? '';
+        const upstreamMessage = apiErr.error?.message ?? apiErr.message ?? '';
 
         // 401 + no-auth placeholder = user registered a Custom LLM
         // without an API key but the endpoint requires one. Surface a

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -91,6 +91,13 @@ export class ChatController {
       projectId: conversation.projectId,
       estimatedCostCents,
     });
+    // Team budget covers BYOK + Custom routes too (OpenRouter sub-
+    // account limit can't see those). Sits between per-member and org
+    // so the most actionable error fires first.
+    await this.chatTransport.assertTeamBudgetNotExceeded({
+      projectId: conversation.projectId,
+      estimatedCostCents,
+    });
     // Org-wide budget gate fires last so per-team / per-member caps
     // surface their actionable wording first (those are easier for an
     // admin to fix than the company-level target).

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -243,6 +243,10 @@ export class CompareModelsController {
             teamId,
             estimatedCostCents,
           });
+          await this.chatTransport.assertTeamBudgetNotExceeded({
+            teamId,
+            estimatedCostCents,
+          });
           await this.chatTransport.assertOrgBudgetNotExceeded({
             estimatedCostCents,
           });

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -160,8 +160,13 @@ export class CompareModelsController {
       throw new BadRequestException('`question` is required.');
     }
 
-    if (body.expectedOutput !== undefined && typeof body.expectedOutput !== 'string') {
-      throw new BadRequestException('`expectedOutput` must be a string when provided.');
+    if (
+      body.expectedOutput !== undefined &&
+      typeof body.expectedOutput !== 'string'
+    ) {
+      throw new BadRequestException(
+        '`expectedOutput` must be a string when provided.',
+      );
     }
     body.expectedOutput = body.expectedOutput ?? '';
 
@@ -174,7 +179,9 @@ export class CompareModelsController {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.error(`Key resolution failed for user ${user.id}: ${msg}`);
-      throw new ServiceUnavailableException(`AI gateway key unavailable: ${msg}`);
+      throw new ServiceUnavailableException(
+        `AI gateway key unavailable: ${msg}`,
+      );
     }
 
     // Personal-by-default scoping. If the body carries an explicit
@@ -231,11 +238,12 @@ export class CompareModelsController {
             4096,
           );
           const estimatedCostCents =
-            estimatedCostUsd != null
-              ? Math.ceil(estimatedCostUsd * 100)
-              : 0;
+            estimatedCostUsd != null ? Math.ceil(estimatedCostUsd * 100) : 0;
           await this.chatTransport.assertTeamMemberCapNotExceeded(user.id, {
             teamId,
+            estimatedCostCents,
+          });
+          await this.chatTransport.assertOrgBudgetNotExceeded({
             estimatedCostCents,
           });
           const start = Date.now();
@@ -425,7 +433,9 @@ export class CompareModelsController {
       runId = row?.id;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Failed to persist arena run for user ${user.id}: ${msg}`);
+      this.logger.error(
+        `Failed to persist arena run for user ${user.id}: ${msg}`,
+      );
     }
 
     return { runId, comparison: comparisonWithMetrics, responses };
@@ -594,7 +604,10 @@ export class CompareModelsController {
           content = file.buffer.toString('utf8');
         } else {
           const dot = lowerName.lastIndexOf('.');
-          const ext = dot !== -1 && dot < lowerName.length - 1 ? lowerName.slice(dot) : '';
+          const ext =
+            dot !== -1 && dot < lowerName.length - 1
+              ? lowerName.slice(dot)
+              : '';
           const detail = ext
             ? `"${ext}" (${mimetype || 'no MIME type'})`
             : `"${mimetype || 'unknown type'}"`;

--- a/apps/api/src/integrations/chat-transport.service.spec.ts
+++ b/apps/api/src/integrations/chat-transport.service.spec.ts
@@ -3,6 +3,7 @@ import {
   ChatTransportService,
   MEMBER_CAP_REACHED_MARKER,
   MEMBER_SUSPENDED_MARKER,
+  ORG_BUDGET_EXCEEDED_MARKER,
   decideCapAction,
 } from './chat-transport.service.js';
 
@@ -167,11 +168,10 @@ describe('ChatTransportService.assertTeamMemberCapNotExceeded', () => {
     // The ctor needs encryption + key-resolver too; we only exercise
     // the cap gate so stubs are sufficient.
     return new ChatTransportService(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       db as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       {} as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       {} as any,
     );
   }
@@ -290,5 +290,62 @@ describe('ChatTransportService.assertTeamMemberCapNotExceeded', () => {
         teamId: TEAM_ID,
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+/* ─── assertOrgBudgetNotExceeded (with mocked db) ─────────────────── */
+
+describe('ChatTransportService.assertOrgBudgetNotExceeded', () => {
+  function makeService(rowSets: unknown[][]) {
+    const db = makeChainableDb(rowSets);
+    return new ChatTransportService(
+      db as any,
+
+      {} as any,
+
+      {} as any,
+    );
+  }
+
+  it('passes when org_settings row is missing (fresh deployment)', async () => {
+    const svc = makeService([
+      [], // org_settings — no row yet
+    ]);
+    await expect(svc.assertOrgBudgetNotExceeded()).resolves.toBeUndefined();
+  });
+
+  it('passes when monthlyBudgetCents = 0 ("no target set")', async () => {
+    const svc = makeService([[{ monthlyBudgetCents: 0 }]]);
+    await expect(svc.assertOrgBudgetNotExceeded()).resolves.toBeUndefined();
+  });
+
+  it('passes when projected (spent + estimate) stays under the target', async () => {
+    const svc = makeService([
+      [{ monthlyBudgetCents: 50000 }], // $500 target
+      [{ total: '100.00' }], // $100 spent so far
+    ]);
+    await expect(
+      svc.assertOrgBudgetNotExceeded({ estimatedCostCents: 100 }), // +$1
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws ORG_BUDGET_EXCEEDED post-flight when spend already crosses target', async () => {
+    const svc = makeService([
+      [{ monthlyBudgetCents: 50000 }], // $500
+      [{ total: '512.00' }], // $512 — over
+    ]);
+    await expect(svc.assertOrgBudgetNotExceeded()).rejects.toThrow(
+      ORG_BUDGET_EXCEEDED_MARKER,
+    );
+  });
+
+  it('throws ORG_BUDGET_EXCEEDED pre-flight when the estimate would push over', async () => {
+    const svc = makeService([
+      [{ monthlyBudgetCents: 50000 }], // $500
+      [{ total: '498.00' }], // $498
+    ]);
+    await expect(
+      svc.assertOrgBudgetNotExceeded({ estimatedCostCents: 500 }), // +$5 → $503
+    ).rejects.toThrow(/would push the company past/);
   });
 });

--- a/apps/api/src/integrations/chat-transport.service.spec.ts
+++ b/apps/api/src/integrations/chat-transport.service.spec.ts
@@ -4,6 +4,7 @@ import {
   MEMBER_CAP_REACHED_MARKER,
   MEMBER_SUSPENDED_MARKER,
   ORG_BUDGET_EXCEEDED_MARKER,
+  ORG_SUSPENDED_MARKER,
   TEAM_BUDGET_EXCEEDED_MARKER,
   TEAM_SUSPENDED_MARKER,
   decideCapAction,
@@ -316,9 +317,16 @@ describe('ChatTransportService.assertOrgBudgetNotExceeded', () => {
     await expect(svc.assertOrgBudgetNotExceeded()).resolves.toBeUndefined();
   });
 
-  it('passes when monthlyBudgetCents = 0 ("no target set")', async () => {
-    const svc = makeService([[{ monthlyBudgetCents: 0 }]]);
+  it('passes when monthlyBudgetCents is null ("no target set")', async () => {
+    const svc = makeService([[{ monthlyBudgetCents: null }]]);
     await expect(svc.assertOrgBudgetNotExceeded()).resolves.toBeUndefined();
+  });
+
+  it('throws ORG_SUSPENDED when monthlyBudgetCents = 0 (kill switch)', async () => {
+    const svc = makeService([[{ monthlyBudgetCents: 0 }]]);
+    await expect(svc.assertOrgBudgetNotExceeded()).rejects.toThrow(
+      ORG_SUSPENDED_MARKER,
+    );
   });
 
   it('passes when projected (spent + estimate) stays under the target', async () => {

--- a/apps/api/src/integrations/chat-transport.service.spec.ts
+++ b/apps/api/src/integrations/chat-transport.service.spec.ts
@@ -4,6 +4,8 @@ import {
   MEMBER_CAP_REACHED_MARKER,
   MEMBER_SUSPENDED_MARKER,
   ORG_BUDGET_EXCEEDED_MARKER,
+  TEAM_BUDGET_EXCEEDED_MARKER,
+  TEAM_SUSPENDED_MARKER,
   decideCapAction,
 } from './chat-transport.service.js';
 
@@ -347,5 +349,73 @@ describe('ChatTransportService.assertOrgBudgetNotExceeded', () => {
     await expect(
       svc.assertOrgBudgetNotExceeded({ estimatedCostCents: 500 }), // +$5 → $503
     ).rejects.toThrow(/would push the company past/);
+  });
+});
+
+/* ─── assertTeamBudgetNotExceeded (with mocked db) ────────────────── */
+
+describe('ChatTransportService.assertTeamBudgetNotExceeded', () => {
+  const TEAM_ID = 'team-id';
+
+  function makeService(rowSets: unknown[][]) {
+    const db = makeChainableDb(rowSets);
+    return new ChatTransportService(db as never, {} as never, {} as never);
+  }
+
+  it('skips when no team is in scope (personal chat)', async () => {
+    const svc = makeService([]);
+    await expect(svc.assertTeamBudgetNotExceeded()).resolves.toBeUndefined();
+  });
+
+  it('passes when team row is gone (race with deletion)', async () => {
+    const svc = makeService([
+      [], // teams — no row
+    ]);
+    await expect(
+      svc.assertTeamBudgetNotExceeded({ teamId: TEAM_ID }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws TEAM_SUSPENDED when budget is 0', async () => {
+    const svc = makeService([[{ budget: 0, name: 'Engineering' }]]);
+    await expect(
+      svc.assertTeamBudgetNotExceeded({ teamId: TEAM_ID }),
+    ).rejects.toThrow(TEAM_SUSPENDED_MARKER);
+  });
+
+  it('passes when projected stays under the budget', async () => {
+    const svc = makeService([
+      [{ budget: 50000, name: 'Engineering' }], // $500
+      [{ total: '100.00' }], // $100 spent
+    ]);
+    await expect(
+      svc.assertTeamBudgetNotExceeded({
+        teamId: TEAM_ID,
+        estimatedCostCents: 100, // +$1
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws TEAM_BUDGET_EXCEEDED post-flight when spend already crosses budget', async () => {
+    const svc = makeService([
+      [{ budget: 50000, name: 'Engineering' }], // $500
+      [{ total: '512.00' }], // $512 — over
+    ]);
+    await expect(
+      svc.assertTeamBudgetNotExceeded({ teamId: TEAM_ID }),
+    ).rejects.toThrow(TEAM_BUDGET_EXCEEDED_MARKER);
+  });
+
+  it('throws TEAM_BUDGET_EXCEEDED pre-flight when the estimate would push over', async () => {
+    const svc = makeService([
+      [{ budget: 50000, name: 'Engineering' }], // $500
+      [{ total: '498.00' }], // $498
+    ]);
+    await expect(
+      svc.assertTeamBudgetNotExceeded({
+        teamId: TEAM_ID,
+        estimatedCostCents: 500, // +$5 → $503
+      }),
+    ).rejects.toThrow(/would push the team past/);
   });
 });

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -1,9 +1,10 @@
 import { HttpException, Inject, Injectable, Logger } from '@nestjs/common';
-import { and, eq, gte, isNull, sql } from 'drizzle-orm';
+import { and, asc, eq, gte, isNull, sql } from 'drizzle-orm';
 import {
   integrations,
   modelConfigs,
   observabilityEvents,
+  orgSettings,
   projects,
   teamMembers,
   teams,
@@ -31,6 +32,15 @@ export const MEMBER_CAP_REACHED_MARKER = 'TEAM_MEMBER_CAP_REACHED';
 export const MEMBER_SUSPENDED_MARKER = 'TEAM_MEMBER_SUSPENDED';
 
 /**
+ * Marker for the org-wide monthly budget gate. Distinct from the
+ * team-wide budget exhausted hit (raised by OpenRouter against a team's
+ * sub-account) and from the per-member cap above. Lets the FE
+ * humanizer route the user to "ask an admin to raise the company
+ * budget" instead of "raise your personal cap".
+ */
+export const ORG_BUDGET_EXCEEDED_MARKER = 'ORG_BUDGET_EXCEEDED';
+
+/**
  * Pure decision function for the per-member cap gate. Returns either
  * `{ pass: true }` or `{ pass: false, message }` so the IO-bound caller
  * can throw uniformly while the policy stays unit-testable without a
@@ -49,9 +59,7 @@ export function decideCapAction(input: {
   capCents: number | null;
   spentCents: number;
   estimatedCostCents: number;
-}):
-  | { pass: true }
-  | { pass: false; marker: string; message: string } {
+}): { pass: true } | { pass: false; marker: string; message: string } {
   const { capCents, spentCents } = input;
   const estimateCents = Math.max(input.estimatedCostCents, 0);
 
@@ -236,9 +244,7 @@ export class ChatTransportService {
     //    of "admin sets up Anthropic for TEAM X, members just use it".
     const provider = providerOfModel(modelIdentifier);
     if (provider) {
-      let byokRow:
-        | typeof integrations.$inferSelect
-        | undefined;
+      let byokRow: typeof integrations.$inferSelect | undefined;
 
       if (teamScopeId) {
         // Predefined providers only — apiUrl IS NULL filter mirrors
@@ -406,10 +412,7 @@ export class ChatTransportService {
       .where(eq(users.id, userId))
       .limit(1);
 
-    if (
-      u?.infraChoice === 'managed' &&
-      u.budgetCents === 0
-    ) {
+    if (u?.infraChoice === 'managed' && u.budgetCents === 0) {
       throw new HttpException(
         `${PENDING_APPROVAL_MARKER}: Your account is pending budget approval. Ask your admin to set a monthly budget in Management → Users so you can start using AI.`,
         402,
@@ -493,10 +496,7 @@ export class ChatTransportService {
       .select({ cap: teamMembers.monthlyCapCents })
       .from(teamMembers)
       .where(
-        and(
-          eq(teamMembers.teamId, teamId),
-          eq(teamMembers.userId, userId),
-        ),
+        and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)),
       )
       .limit(1);
     if (!membership) return;
@@ -539,6 +539,74 @@ export class ChatTransportService {
     if (!decision.pass) {
       throw new HttpException(decision.message, 402);
     }
+  }
+
+  /**
+   * Org-wide monthly budget gate. Pulls the singleton target from
+   * `org_settings` and compares against aggregate org spend for the
+   * current calendar month, optionally including a pre-flight cost
+   * estimate.
+   *
+   * Rules:
+   *   - target === 0 → "no target set", always pass. Existing
+   *     deployments that never opened the Company tab Pencil keep
+   *     working unchanged.
+   *   - target > 0 → block when (spent + estimate) >= target. Same
+   *     pre-flight vs post-flight wording split as decideCapAction
+   *     so the user sees actionable copy.
+   *
+   * Runs on every chat path (WorkenAI default, BYOK, Custom). Custom
+   * routes have cost=null in observability so they don't *consume*
+   * the cap, but they're still blocked once the target is exhausted
+   * by other routes — same shape as the per-member gate.
+   */
+  async assertOrgBudgetNotExceeded(
+    options: {
+      /**
+       * Upper-bound cost estimate (cents) for the call about to happen.
+       * Same semantics as the per-member gate — pass 0 (or omit) to
+       * skip the pre-flight branch.
+       */
+      estimatedCostCents?: number;
+    } = {},
+  ): Promise<void> {
+    const [settings] = await this.db
+      .select({ monthlyBudgetCents: orgSettings.monthlyBudgetCents })
+      .from(orgSettings)
+      .orderBy(asc(orgSettings.createdAt))
+      .limit(1);
+    const targetCents = settings?.monthlyBudgetCents ?? 0;
+    if (targetCents <= 0) return; // no target set
+
+    const startOfMonth = sql`date_trunc('month', now())`;
+    const [agg] = await this.db
+      .select({
+        total: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          eq(observabilityEvents.success, true),
+          gte(observabilityEvents.createdAt, startOfMonth),
+        ),
+      );
+    const spentUsd = agg ? parseFloat(agg.total) : 0;
+    const spentCents = Math.round(spentUsd * 100);
+
+    const estimateCents = Math.max(options.estimatedCostCents ?? 0, 0);
+    const projectedCents = spentCents + estimateCents;
+    if (projectedCents < targetCents) return;
+
+    const targetUsd = (targetCents / 100).toFixed(2);
+    const spentUsdStr = (spentCents / 100).toFixed(2);
+    const isPreflight = estimateCents > 0 && spentCents < targetCents;
+    const detail = isPreflight
+      ? `would push the company past ~$${(projectedCents / 100).toFixed(2)} (target $${targetUsd}, currently $${spentUsdStr}). Try a smaller prompt or wait for next month.`
+      : `is reached (spent $${spentUsdStr}). Resets on the 1st of next month, or ask an admin to raise the target in Management → Company.`;
+    throw new HttpException(
+      `${ORG_BUDGET_EXCEEDED_MARKER}: Your company's monthly AI budget of $${targetUsd} ${detail}`,
+      402,
+    );
   }
 
   private safeDecrypt(encrypted: string, context: string): string {

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -43,13 +43,14 @@ export const TEAM_BUDGET_EXCEEDED_MARKER = 'TEAM_BUDGET_EXCEEDED';
 export const TEAM_SUSPENDED_MARKER = 'TEAM_SUSPENDED';
 
 /**
- * Marker for the org-wide monthly budget gate. Distinct from the
- * team-wide budget exhausted hit (raised by our own assertTeam… or
- * by OpenRouter against a team's sub-account) and from the per-member
- * cap above. Lets the FE humanizer route the user to "ask an admin to
- * raise the company budget" instead of "raise your personal cap".
+ * Markers for the org-wide monthly budget gate. Two of them, mirror-
+ * shape with TEAM_BUDGET_EXCEEDED / TEAM_SUSPENDED above:
+ *   - ORG_BUDGET_EXCEEDED → cap > 0 and (spent + estimate) >= cap
+ *   - ORG_SUSPENDED       → cap === 0 (admin kill switch)
+ * cap === null is "no target set" → silent pass, no marker.
  */
 export const ORG_BUDGET_EXCEEDED_MARKER = 'ORG_BUDGET_EXCEEDED';
+export const ORG_SUSPENDED_MARKER = 'ORG_SUSPENDED';
 
 /**
  * Pure decision function for the per-member cap gate. Returns either
@@ -643,13 +644,15 @@ export class ChatTransportService {
    * current calendar month, optionally including a pre-flight cost
    * estimate.
    *
-   * Rules:
-   *   - target === 0 → "no target set", always pass. Existing
-   *     deployments that never opened the Company tab Pencil keep
-   *     working unchanged.
-   *   - target > 0 → block when (spent + estimate) >= target. Same
-   *     pre-flight vs post-flight wording split as decideCapAction
-   *     so the user sees actionable copy.
+   * Tri-state, mirrors `team_members.monthlyCapCents`:
+   *   - target === null → "no target set", always pass. Default for
+   *     fresh deployments / lazy-seeded rows so installs that never
+   *     opened the Company tab keep working unchanged.
+   *   - target === 0   → org-wide chat suspended (admin kill switch).
+   *     Throws ORG_SUSPENDED regardless of spend / estimate.
+   *   - target > 0     → block when (spent + estimate) >= target with
+   *     ORG_BUDGET_EXCEEDED. Same pre-flight vs post-flight wording
+   *     split as decideCapAction.
    *
    * Runs on every chat path (WorkenAI default, BYOK, Custom). Custom
    * routes have cost=null in observability so they don't *consume*
@@ -671,8 +674,17 @@ export class ChatTransportService {
       .from(orgSettings)
       .orderBy(asc(orgSettings.createdAt))
       .limit(1);
-    const targetCents = settings?.monthlyBudgetCents ?? 0;
-    if (targetCents <= 0) return; // no target set
+    const targetCents = settings?.monthlyBudgetCents ?? null;
+    // null (or missing row) → no target set, gate is a silent pass.
+    // 0 → admin flipped the org-wide kill switch.
+    // >0 → enforced below.
+    if (targetCents === null) return;
+    if (targetCents === 0) {
+      throw new HttpException(
+        `${ORG_SUSPENDED_MARKER}: Org-wide chat is paused (Company Monthly Budget set to $0). Ask an admin to raise it in Management → Company.`,
+        402,
+      );
+    }
 
     const startOfMonth = sql`date_trunc('month', now())`;
     const [agg] = await this.db

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -32,11 +32,22 @@ export const MEMBER_CAP_REACHED_MARKER = 'TEAM_MEMBER_CAP_REACHED';
 export const MEMBER_SUSPENDED_MARKER = 'TEAM_MEMBER_SUSPENDED';
 
 /**
+ * Marker for the team-wide budget cap, fired by our own gate (not
+ * OpenRouter). The OpenRouter sub-account limit only sees calls that
+ * actually flow through OpenRouter — BYOK / Custom routes bypass it.
+ * This marker covers the "I'm over the team budget *across all
+ * routes*" case so admins can't accidentally exceed their team budget
+ * just by routing through their own Anthropic key.
+ */
+export const TEAM_BUDGET_EXCEEDED_MARKER = 'TEAM_BUDGET_EXCEEDED';
+export const TEAM_SUSPENDED_MARKER = 'TEAM_SUSPENDED';
+
+/**
  * Marker for the org-wide monthly budget gate. Distinct from the
- * team-wide budget exhausted hit (raised by OpenRouter against a team's
- * sub-account) and from the per-member cap above. Lets the FE
- * humanizer route the user to "ask an admin to raise the company
- * budget" instead of "raise your personal cap".
+ * team-wide budget exhausted hit (raised by our own assertTeam… or
+ * by OpenRouter against a team's sub-account) and from the per-member
+ * cap above. Lets the FE humanizer route the user to "ask an admin to
+ * raise the company budget" instead of "raise your personal cap".
  */
 export const ORG_BUDGET_EXCEEDED_MARKER = 'ORG_BUDGET_EXCEEDED';
 
@@ -539,6 +550,91 @@ export class ChatTransportService {
     if (!decision.pass) {
       throw new HttpException(decision.message, 402);
     }
+  }
+
+  /**
+   * Team-wide monthly budget gate. Mirrors the per-member shape but
+   * scoped to the whole team — sums every observability event tagged
+   * with this team's id for the current calendar month and compares
+   * against `teams.monthlyBudgetCents`.
+   *
+   * Why we duplicate logic OpenRouter already does on its sub-account
+   * side: BYOK and Custom routes bypass OpenRouter entirely, so the
+   * sub-account limit only sees a fraction of the team's traffic. An
+   * admin who flips on a team-shared Anthropic key would otherwise
+   * watch the team blow past its monthly budget without anything
+   * stopping them. This gate plugs that hole — every team-routed call
+   * (regardless of source) is subject to the same cap.
+   *
+   * Custom LLM cost rows are null in observability, so they don't
+   * *consume* the budget, but `monthlyBudgetCents=0` (admin set the
+   * team to suspended) still blocks them just like the member gate
+   * does.
+   */
+  async assertTeamBudgetNotExceeded(
+    options: {
+      projectId?: string | null;
+      teamId?: string | null;
+      /** Pre-flight cost estimate (cents). Same semantics as the per-
+       *  member gate; pass 0 / omit to skip the pre-flight branch. */
+      estimatedCostCents?: number;
+    } = {},
+  ): Promise<void> {
+    let teamId = options.teamId ?? null;
+    if (!teamId && options.projectId) {
+      const [proj] = await this.db
+        .select({ teamId: projects.teamId })
+        .from(projects)
+        .where(eq(projects.id, options.projectId))
+        .limit(1);
+      teamId = proj?.teamId ?? null;
+    }
+    if (!teamId) return; // personal-scope chat — nothing to enforce here
+
+    const [team] = await this.db
+      .select({ budget: teams.monthlyBudgetCents, name: teams.name })
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+    if (!team) return; // race with team deletion — let the call proceed
+
+    if (team.budget === 0) {
+      throw new HttpException(
+        `${TEAM_SUSPENDED_MARKER}: Team "${team.name}" is suspended (budget set to $0). Ask an admin to raise the team's Monthly Budget in /teams/${teamId}.`,
+        402,
+      );
+    }
+
+    const startOfMonth = sql`date_trunc('month', now())`;
+    const [agg] = await this.db
+      .select({
+        total: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          eq(observabilityEvents.teamId, teamId),
+          eq(observabilityEvents.success, true),
+          gte(observabilityEvents.createdAt, startOfMonth),
+        ),
+      );
+    const spentUsd = agg ? parseFloat(agg.total) : 0;
+    const spentCents = Math.round(spentUsd * 100);
+
+    const estimateCents = Math.max(options.estimatedCostCents ?? 0, 0);
+    const projectedCents = spentCents + estimateCents;
+    if (projectedCents < team.budget) return;
+
+    const capUsd = (team.budget / 100).toFixed(2);
+    const spentUsdStr = (spentCents / 100).toFixed(2);
+    const isPreflight = estimateCents > 0 && spentCents < team.budget;
+    const detail = isPreflight
+      ? `would push the team past ~$${(projectedCents / 100).toFixed(2)} (budget $${capUsd}, currently $${spentUsdStr}). Try a smaller prompt or wait for next month.`
+      : `is reached (spent $${spentUsdStr}). Resets on the 1st of next month, or ask an admin to raise it in /teams/${teamId}.`;
+    throw new HttpException(
+      `${TEAM_BUDGET_EXCEEDED_MARKER}: Team "${team.name}"'s monthly budget of $${capUsd} ${detail}`,
+      402,
+    );
   }
 
   /**

--- a/apps/api/src/org-settings/org-settings.controller.ts
+++ b/apps/api/src/org-settings/org-settings.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Inject,
+  Patch,
+} from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { users } from '@worken/database/schema';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthenticatedUser } from '../auth/types.js';
+import { DATABASE, type Database } from '../database/database.module.js';
+import { OrgSettingsService } from './org-settings.service.js';
+
+@Controller('org-settings')
+export class OrgSettingsController {
+  constructor(
+    @Inject(DATABASE) private readonly db: Database,
+    private readonly orgSettings: OrgSettingsService,
+  ) {}
+
+  /**
+   * Read access is open to any authenticated user — the Company tab
+   * needs the budget target to render its primary card and the value
+   * isn't sensitive.
+   */
+  @Get()
+  getCurrent() {
+    return this.orgSettings.getCurrent();
+  }
+
+  @Patch()
+  async update(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Body() body: { monthlyBudgetCents?: number },
+  ) {
+    const [callerUser] = await this.db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, caller.id));
+    if (!callerUser || callerUser.role !== 'admin') {
+      throw new ForbiddenException(
+        'Only admins can change the company monthly budget.',
+      );
+    }
+    return this.orgSettings.update(body);
+  }
+}

--- a/apps/api/src/org-settings/org-settings.module.ts
+++ b/apps/api/src/org-settings/org-settings.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { OrgSettingsController } from './org-settings.controller.js';
+import { OrgSettingsService } from './org-settings.service.js';
+
+@Module({
+  controllers: [OrgSettingsController],
+  providers: [OrgSettingsService],
+  exports: [OrgSettingsService],
+})
+export class OrgSettingsModule {}

--- a/apps/api/src/org-settings/org-settings.service.spec.ts
+++ b/apps/api/src/org-settings/org-settings.service.spec.ts
@@ -1,0 +1,45 @@
+import { BadRequestException } from '@nestjs/common';
+import { OrgSettingsService } from './org-settings.service.js';
+
+/**
+ * Validation in `update` runs before any DB call, so the spec
+ * exercises BadRequest paths against a service whose DB stub
+ * explodes the moment it's touched. If validation regresses, the
+ * test fails on the unexpected DB access instead of silently saving
+ * a bad value.
+ */
+function svc() {
+  const exploder = (): never => {
+    throw new Error(
+      'unexpected DB call — validation should have rejected first',
+    );
+  };
+
+  const db: unknown = new Proxy(
+    {},
+    {
+      get: () => exploder,
+    },
+  );
+  return new OrgSettingsService(db as never);
+}
+
+describe('OrgSettingsService.update validation', () => {
+  it('rejects negative monthly budget', async () => {
+    await expect(
+      svc().update({ monthlyBudgetCents: -1 }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects non-integer monthly budget', async () => {
+    await expect(
+      svc().update({ monthlyBudgetCents: 12.5 }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects NaN', async () => {
+    await expect(
+      svc().update({ monthlyBudgetCents: NaN }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/api/src/org-settings/org-settings.service.ts
+++ b/apps/api/src/org-settings/org-settings.service.ts
@@ -1,7 +1,14 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
-import { asc, eq } from 'drizzle-orm';
+import { asc, eq, sql } from 'drizzle-orm';
 import { orgSettings } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
+
+// Postgres advisory lock key for the singleton seed. Constant on
+// purpose — every fetchOrSeed call grabs the same key, so concurrent
+// first-time-GETs serialize through the lock and only the first
+// transaction inserts the row. Held xact_lock so it auto-releases on
+// commit / rollback.
+const ORG_SETTINGS_SEED_LOCK = 974_184_372;
 
 export interface OrgSettingsView {
   id: string;
@@ -60,6 +67,8 @@ export class OrgSettingsService {
   }
 
   private async fetchOrSeed() {
+    // Fast path: row already exists, common case after the first
+    // call ever. No transaction overhead.
     const [existing] = await this.db
       .select()
       .from(orgSettings)
@@ -67,8 +76,27 @@ export class OrgSettingsService {
       .limit(1);
     if (existing) return existing;
 
-    const [created] = await this.db.insert(orgSettings).values({}).returning();
-    return created;
+    // Race-safe seed: two concurrent first-time GETs would otherwise
+    // both see "no rows", both insert, and leave the table with
+    // duplicates that getCurrent would then read inconsistently.
+    // Wrap the seed in a transaction-scoped advisory lock so only
+    // the first call inserts; the second blocks on the lock, then
+    // re-reads the now-existing row. Schema is left lean (no
+    // singleton constraint) — the lock is the cheaper guard since
+    // contention only happens on first deploy.
+    return await this.db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(${ORG_SETTINGS_SEED_LOCK})`,
+      );
+      const [recheck] = await tx
+        .select()
+        .from(orgSettings)
+        .orderBy(asc(orgSettings.createdAt))
+        .limit(1);
+      if (recheck) return recheck;
+      const [created] = await tx.insert(orgSettings).values({}).returning();
+      return created;
+    });
   }
 }
 

--- a/apps/api/src/org-settings/org-settings.service.ts
+++ b/apps/api/src/org-settings/org-settings.service.ts
@@ -6,12 +6,13 @@ import { DATABASE, type Database } from '../database/database.module.js';
 export interface OrgSettingsView {
   id: string;
   /**
-   * Monthly company-wide budget target (cents). 0 means "no target
-   * set" — UI hides over-budget banners + Projected pill, future
-   * chat-transport hard-cap gate (phase 2) will treat the same value
-   * as "unlimited".
+   * Monthly company-wide budget target (cents). Tri-state, mirrors
+   * `team_members.monthlyCapCents`:
+   *   - null → no target set (gate silent-passes, UI shows "No target")
+   *   - 0    → org-wide chat suspended (gate 402s with ORG_SUSPENDED)
+   *   - >0   → enforced when org spend + estimate >= cap
    */
-  monthlyBudgetCents: number;
+  monthlyBudgetCents: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -22,30 +23,32 @@ export class OrgSettingsService {
 
   /**
    * Singleton getter: returns the oldest row, lazy-seeding an empty
-   * one on first call. Cheaper than running a migration for fresh
-   * deployments and matches the pattern used by the (defunct)
-   * `companies` table earlier on the branch.
+   * one (monthlyBudgetCents=null) on first call. Cheaper than
+   * running a migration for fresh deployments.
    */
   async getCurrent(): Promise<OrgSettingsView> {
     return toView(await this.fetchOrSeed());
   }
 
   async update(input: {
-    monthlyBudgetCents?: number;
+    /** undefined → leave the saved value alone; null → clear the
+     *  target back to "no enforcement"; integer → save (0 suspends,
+     *  >0 enforces). */
+    monthlyBudgetCents?: number | null;
   }): Promise<OrgSettingsView> {
-    // Validate before any DB call so the BadRequest path is tight and
-    // testable from a stub.
+    // Validate before any DB call so the BadRequest path stays tight
+    // and testable from a stub.
     const updates: Record<string, unknown> = { updatedAt: new Date() };
     if (input.monthlyBudgetCents !== undefined) {
-      if (
-        !Number.isInteger(input.monthlyBudgetCents) ||
-        input.monthlyBudgetCents < 0
-      ) {
-        throw new BadRequestException(
-          'Monthly budget must be a non-negative integer (cents).',
-        );
+      const next = input.monthlyBudgetCents;
+      if (next !== null) {
+        if (!Number.isInteger(next) || next < 0) {
+          throw new BadRequestException(
+            'Monthly budget must be null or a non-negative integer (cents).',
+          );
+        }
       }
-      updates.monthlyBudgetCents = input.monthlyBudgetCents;
+      updates.monthlyBudgetCents = next;
     }
 
     const current = await this.fetchOrSeed();

--- a/apps/api/src/org-settings/org-settings.service.ts
+++ b/apps/api/src/org-settings/org-settings.service.ts
@@ -1,0 +1,79 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { asc, eq } from 'drizzle-orm';
+import { orgSettings } from '@worken/database/schema';
+import { DATABASE, type Database } from '../database/database.module.js';
+
+export interface OrgSettingsView {
+  id: string;
+  /**
+   * Monthly company-wide budget target (cents). 0 means "no target
+   * set" — UI hides over-budget banners + Projected pill, future
+   * chat-transport hard-cap gate (phase 2) will treat the same value
+   * as "unlimited".
+   */
+  monthlyBudgetCents: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+@Injectable()
+export class OrgSettingsService {
+  constructor(@Inject(DATABASE) private readonly db: Database) {}
+
+  /**
+   * Singleton getter: returns the oldest row, lazy-seeding an empty
+   * one on first call. Cheaper than running a migration for fresh
+   * deployments and matches the pattern used by the (defunct)
+   * `companies` table earlier on the branch.
+   */
+  async getCurrent(): Promise<OrgSettingsView> {
+    return toView(await this.fetchOrSeed());
+  }
+
+  async update(input: {
+    monthlyBudgetCents?: number;
+  }): Promise<OrgSettingsView> {
+    // Validate before any DB call so the BadRequest path is tight and
+    // testable from a stub.
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
+    if (input.monthlyBudgetCents !== undefined) {
+      if (
+        !Number.isInteger(input.monthlyBudgetCents) ||
+        input.monthlyBudgetCents < 0
+      ) {
+        throw new BadRequestException(
+          'Monthly budget must be a non-negative integer (cents).',
+        );
+      }
+      updates.monthlyBudgetCents = input.monthlyBudgetCents;
+    }
+
+    const current = await this.fetchOrSeed();
+    await this.db
+      .update(orgSettings)
+      .set(updates)
+      .where(eq(orgSettings.id, current.id));
+    return this.getCurrent();
+  }
+
+  private async fetchOrSeed() {
+    const [existing] = await this.db
+      .select()
+      .from(orgSettings)
+      .orderBy(asc(orgSettings.createdAt))
+      .limit(1);
+    if (existing) return existing;
+
+    const [created] = await this.db.insert(orgSettings).values({}).returning();
+    return created;
+  }
+}
+
+function toView(row: typeof orgSettings.$inferSelect): OrgSettingsView {
+  return {
+    id: row.id,
+    monthlyBudgetCents: row.monthlyBudgetCents,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -351,34 +351,9 @@ export class TeamsService {
       membersMap.set(row.teamId, arr);
     }
 
-    // Fetch usage data for each team's OpenRouter key
-    const usageMap = new Map<
-      string,
-      { spentCents: number; projectedCents: number }
-    >();
-    for (const t of allTeams) {
-      if (t.openrouterKeyId) {
-        const usage = await this.provisioningService.getKeyUsage(
-          t.openrouterKeyId,
-        );
-        if (usage) {
-          const dayOfMonth = new Date().getDate();
-          const daysInMonth = new Date(
-            new Date().getFullYear(),
-            new Date().getMonth() + 1,
-            0,
-          ).getDate();
-          const projectedCents =
-            dayOfMonth > 0
-              ? Math.round((usage.usageCents / dayOfMonth) * daysInMonth)
-              : usage.usageCents;
-          usageMap.set(t.id, {
-            spentCents: usage.usageCents,
-            projectedCents,
-          });
-        }
-      }
-    }
+    // Per-team spent / projected from observability_events — see
+    // computeTeamUsageMap for why this replaced the OpenRouter lookup.
+    const usageMap = await this.computeTeamUsageMap(allTeams.map((t) => t.id));
 
     return allTeams.map((t) => {
       const usage = usageMap.get(t.id);
@@ -430,29 +405,16 @@ export class TeamsService {
       .leftJoin(users, eq(teamMembers.userId, users.id))
       .where(eq(teamMembers.teamId, teamId));
 
-    // Fetch usage data from OpenRouter key
-    let spentCents = 0;
-    let projectedCents = 0;
-    if (team.openrouterKeyId) {
-      const usage = await this.provisioningService.getKeyUsage(
-        team.openrouterKeyId,
-      );
-      if (usage) {
-        spentCents = usage.usageCents;
-        const dayOfMonth = new Date().getDate();
-        const daysInMonth = new Date(
-          new Date().getFullYear(),
-          new Date().getMonth() + 1,
-          0,
-        ).getDate();
-        projectedCents =
-          dayOfMonth > 0
-            ? Math.round((usage.usageCents / dayOfMonth) * daysInMonth)
-            : usage.usageCents;
-      }
-    }
-
-    return { ...team, members, spentCents, projectedCents };
+    // Per-team spent / projected from observability_events — same
+    // shape as findAll, see computeTeamUsageMap for rationale.
+    const usageMap = await this.computeTeamUsageMap([team.id]);
+    const usage = usageMap.get(team.id);
+    return {
+      ...team,
+      members,
+      spentCents: usage?.spentCents ?? 0,
+      projectedCents: usage?.projectedCents ?? 0,
+    };
   }
 
   async inviteMember(
@@ -1013,33 +975,9 @@ export class TeamsService {
       membersMap.set(row.teamId, arr);
     }
 
-    // Usage data per subteam
-    const usageMap = new Map<
-      string,
-      { spentCents: number; projectedCents: number }
-    >();
-    for (const t of subteams) {
-      if (t.openrouterKeyId) {
-        const usage = await this.provisioningService.getKeyUsage(
-          t.openrouterKeyId,
-        );
-        if (usage) {
-          const dayOfMonth = new Date().getDate();
-          const daysInMonth = new Date(
-            new Date().getFullYear(),
-            new Date().getMonth() + 1,
-            0,
-          ).getDate();
-          usageMap.set(t.id, {
-            spentCents: usage.usageCents,
-            projectedCents:
-              dayOfMonth > 0
-                ? Math.round((usage.usageCents / dayOfMonth) * daysInMonth)
-                : usage.usageCents,
-          });
-        }
-      }
-    }
+    // Per-subteam spent / projected from observability_events — same
+    // shape as findAll, see computeTeamUsageMap for rationale.
+    const usageMap = await this.computeTeamUsageMap(subteams.map((t) => t.id));
 
     return subteams.map((t) => {
       const usage = usageMap.get(t.id);
@@ -1684,6 +1622,67 @@ export class TeamsService {
       throw new NotFoundException('Member not found');
     }
     return updated;
+  }
+
+  /**
+   * Per-team spent + projected for the current calendar month, sourced
+   * from `observability_events`. Replaces the older
+   * `provisioningService.getKeyUsage()` lookup so the numbers shown on
+   * the Teams listing + detail pages match what the chat-time gate
+   * actually enforces (which also reads observability and therefore
+   * counts BYOK + Custom routes that bypass OpenRouter's sub-account
+   * limit). Catalog-priced cost is approximate vs OpenRouter's "actual
+   * billed" number — the trade-off is consistency with enforcement,
+   * which matters more than dollar-perfect display.
+   *
+   * Custom routes log cost=null and contribute $0 to the sum, same as
+   * in the chat gate. Projection is the existing linear extrapolation
+   * (current spend × daysInMonth / dayOfMonth).
+   */
+  private async computeTeamUsageMap(
+    teamIds: string[],
+  ): Promise<Map<string, { spentCents: number; projectedCents: number }>> {
+    const usage = new Map<
+      string,
+      { spentCents: number; projectedCents: number }
+    >();
+    if (teamIds.length === 0) return usage;
+
+    const startOfMonth = sql`date_trunc('month', now())`;
+    const rows = await this.db
+      .select({
+        teamId: observabilityEvents.teamId,
+        total: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)`,
+      })
+      .from(observabilityEvents)
+      .where(
+        and(
+          inArray(observabilityEvents.teamId, teamIds),
+          eq(observabilityEvents.success, true),
+          gte(observabilityEvents.createdAt, startOfMonth),
+        ),
+      )
+      .groupBy(observabilityEvents.teamId);
+
+    const now = new Date();
+    const dayOfMonth = now.getDate();
+    const daysInMonth = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+    ).getDate();
+
+    for (const row of rows) {
+      if (!row.teamId) continue; // teamId is nullable on the table — skip orgless events
+      const spentUsd = parseFloat(row.total);
+      const spentCents = Math.round(spentUsd * 100);
+      const projectedCents =
+        dayOfMonth > 0
+          ? Math.round((spentCents / dayOfMonth) * daysInMonth)
+          : spentCents;
+      usage.set(row.teamId, { spentCents, projectedCents });
+    }
+    return usage;
   }
 }
 

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -1673,7 +1673,7 @@ export class TeamsService {
     ).getDate();
 
     for (const row of rows) {
-      if (!row.teamId) continue; // teamId is nullable on the table — skip orgless events
+      if (!row.teamId) continue; // teamId is nullable on the table — skip teamless events
       const spentUsd = parseFloat(row.total);
       const spentCents = Math.round(spentUsd * 100);
       const projectedCents =

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
+  AlertTriangle,
   Check,
   Pencil,
   Plus,
@@ -454,6 +455,21 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   const projected = team.projectedCents / 100;
   const onTrack = projected <= budget;
 
+  // Sum positive per-member caps. `null` (no cap, shares team budget)
+  // and `0` (suspended) don't allocate any team dollars, so they're
+  // skipped. When the sum exceeds the team budget, surface a soft
+  // warning above the Users table — chat-time gate enforces the
+  // budget anyway, but pre-warning admins about over-allocation
+  // saves a "why is one member blocked while caps look fine"
+  // debugging round-trip.
+  const allocatedCapsCents = team.members.reduce((acc, m) => {
+    const cap = m.monthlyCapCents;
+    return cap != null && cap > 0 ? acc + cap : acc;
+  }, 0);
+  const overAllocated =
+    team.monthlyBudgetCents > 0 &&
+    allocatedCapsCents > team.monthlyBudgetCents;
+
   const myMembership = team.members.find(
     (m) =>
       m.userId &&
@@ -830,6 +846,26 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
 
       {/* ── Users ─────────────────────────────────────────────────── */}
       <div className="space-y-3">
+        {/* Over-allocation soft warning. Soft because chat-time gate
+            already enforces the team budget regardless of member-cap
+            sum — this just gives the admin a heads-up so they don't
+            have to debug "why did Marko hit a cap when his per-member
+            cap looks fine". Only shown when the sum strictly exceeds
+            the team budget (equality is fine). */}
+        {overAllocated && (
+          <div className="flex items-start gap-2 rounded-lg border border-warning-3 bg-warning-1/40 px-3 py-2">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-warning-7 mt-0.5" />
+            <p className="text-[13px] text-warning-7 leading-snug">
+              Member caps total{" "}
+              <strong>{formatCurrency(allocatedCapsCents / 100)}</strong>,
+              over the team&rsquo;s monthly budget of{" "}
+              <strong>{formatCurrency(budget)}</strong>. Members will be
+              blocked once team total reaches the budget regardless of
+              individual caps — trim caps or raise the team budget to
+              line them up.
+            </p>
+          </div>
+        )}
         <div className="flex items-center justify-between">
           <p className="text-[18px] font-bold text-text-1">Users</p>
           {canManageTeam ? (

--- a/apps/web/src/components/management/company-tab.tsx
+++ b/apps/web/src/components/management/company-tab.tsx
@@ -201,17 +201,19 @@ export function CompanyTab() {
     setEditCompanyName(profile.companyName ?? "");
     setEditIndustry(profile.industry ?? "");
     setEditTeamSize(profile.teamSize ?? "");
-    // Seed the budget editor from the current org-settings row. 0 is
-    // the no-target sentinel — show it as an empty string so the
-    // input doesn't read like a deliberate $0/mo target.
-    const seedBudgetCents = orgSettings?.monthlyBudgetCents ?? 0;
+    // Seed the budget editor from the current org-settings row.
+    //   - null → empty input (= "no target")
+    //   - 0    → "0,00" (= explicit suspend; admin sees their kill
+    //     switch and can clear it back)
+    //   - >0   → formatted currency value
+    const seedBudgetCents = orgSettings?.monthlyBudgetCents ?? null;
     setEditBudget(
-      seedBudgetCents > 0
-        ? (seedBudgetCents / 100).toLocaleString("de-DE", {
+      seedBudgetCents === null
+        ? ""
+        : (seedBudgetCents / 100).toLocaleString("de-DE", {
             minimumFractionDigits: 2,
             maximumFractionDigits: 2,
-          })
-        : "",
+          }),
     );
     setIsEditing(true);
   };
@@ -232,12 +234,14 @@ export function CompanyTab() {
       return;
     }
 
-    // Parse de-DE budget: "1.234,56" → 1234.56. Empty string is the
-    // "clear the target" gesture and lands as 0.
-    let parsedBudgetCents = orgSettings?.monthlyBudgetCents ?? 0;
+    // Parse de-DE budget: "1.234,56" → 1234.56.
+    //   empty input → null  (clear the target, no enforcement)
+    //   "0"         → 0     (explicit org-wide suspend)
+    //   "$X"        → cents (enforced)
+    let parsedBudgetCents: number | null;
     const trimmedBudget = editBudget.trim();
     if (trimmedBudget.length === 0) {
-      parsedBudgetCents = 0;
+      parsedBudgetCents = null;
     } else {
       const raw = trimmedBudget.replace(/\./g, "").replace(",", ".");
       const num = parseFloat(raw);
@@ -252,7 +256,7 @@ export function CompanyTab() {
     const industryChanged = editIndustry !== (profile.industry ?? "");
     const teamSizeChanged = editTeamSize !== (profile.teamSize ?? "");
     const budgetChanged =
-      parsedBudgetCents !== (orgSettings?.monthlyBudgetCents ?? 0);
+      parsedBudgetCents !== (orgSettings?.monthlyBudgetCents ?? null);
     if (
       !nameChanged &&
       !industryChanged &&
@@ -359,13 +363,18 @@ export function CompanyTab() {
     teams.reduce((acc, t) => acc + (t.projectedCents ?? 0), 0) +
     orgUsers.reduce((acc, u) => acc + (u.projectedCents ?? 0), 0);
 
-  // Company-level monthly target sourced from /org-settings. 0 means
-  // "no target set" — the UI hides budget-comparison affordances and
-  // falls back to plain spend reporting.
-  const targetCents = orgSettings?.monthlyBudgetCents ?? 0;
-  const hasTarget = targetCents > 0;
+  // Company-level monthly target sourced from /org-settings. Tri-state:
+  //   - null → no target (UI hides budget-comparison affordances and
+  //     falls back to plain spend reporting; chat-transport gate is
+  //     a silent pass).
+  //   - 0    → org-wide chat suspended (the kill switch matches team
+  //     and per-member 0-semantics).
+  //   - >0   → enforced.
+  const targetCents = orgSettings?.monthlyBudgetCents ?? null;
+  const isSuspended = targetCents === 0;
+  const hasTarget = targetCents !== null && targetCents > 0;
 
-  const target = targetCents / 100;
+  const target = (targetCents ?? 0) / 100;
   const allocated = allocatedCents / 100;
   const spent = totalSpentCents / 100;
   const remaining = target - spent;
@@ -382,11 +391,33 @@ export function CompanyTab() {
 
   return (
     <div className="py-6 space-y-6">
-      {/* Over-budget banner. Shows when admin has set a target and
-          either current spend or projected spend exceeds it. Sits
-          above every other card so it's the first thing the admin
-          reads when they enter the tab. Self-dismisses (re-renders
-          out) once the situation resolves. */}
+      {/* Suspended banner — separate from over-budget because the
+          fix is different (admin set a $0 kill switch on purpose;
+          they need to clear it, not raise other caps). Shown when
+          the explicit suspend value is in play. */}
+      {isSuspended && (
+        <div className="flex items-start gap-3 rounded-lg border border-danger-3 bg-danger-1/40 px-4 py-3">
+          <AlertTriangle className="h-5 w-5 shrink-0 text-danger-6 mt-0.5" />
+          <div className="flex-1 space-y-1">
+            <p className="text-[14px] font-semibold text-danger-6">
+              Org-wide chat is paused
+            </p>
+            <p className="text-[13px] text-text-1">
+              Company Monthly Budget is set to{" "}
+              <strong>$0</strong>, which blocks every chat call across
+              the organization.{" "}
+              {isAdmin
+                ? "Open the Pencil and clear the budget (or set a positive target) to resume."
+                : "Ask an admin to clear the budget or set a positive target to resume."}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Over-budget banner. Shows when admin has set a positive
+          target and either current spend or projected spend exceeds
+          it. Sits above every other card so it's the first thing the
+          admin reads when they enter the tab. */}
       {overBudget && (
         <div className="flex items-start gap-3 rounded-lg border border-danger-3 bg-danger-1/40 px-4 py-3">
           <AlertTriangle className="h-5 w-5 shrink-0 text-danger-6 mt-0.5" />
@@ -600,7 +631,9 @@ export function CompanyTab() {
               </div>
             ) : (
               <div className="flex h-[56px] items-center px-1 text-[16px] text-text-1">
-                {hasTarget ? (
+                {isSuspended ? (
+                  <span className="text-danger-6">Suspended ($0)</span>
+                ) : hasTarget ? (
                   <span>{formatCurrency(target)}</span>
                 ) : (
                   <span className="text-text-3">No target set</span>

--- a/apps/web/src/components/management/company-tab.tsx
+++ b/apps/web/src/components/management/company-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import {
+  AlertTriangle,
   Check,
   Info,
   Loader2,
@@ -41,13 +42,15 @@ import { useAuth } from "@/components/providers";
 import {
   deleteCompanyProfile,
   fetchOnboardingProfile,
+  fetchOrgSettings,
   fetchOrgUsers,
   fetchTeams,
   removeOrgUser,
   updateOnboardingProfile,
+  updateOrgSettings,
   type OrgUser,
 } from "@/lib/api";
-import { formatCurrency } from "@/lib/utils";
+import { formatBudgetInput, formatCurrency } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { InviteUserDialog } from "@/components/invite-user-dialog";
 import { DisabledReasonTooltip } from "@/components/ui/tooltip";
@@ -117,11 +120,16 @@ export function CompanyTab() {
     queryKey: ["teams"],
     queryFn: fetchTeams,
   });
+  const { data: orgSettings } = useQuery({
+    queryKey: ["org-settings"],
+    queryFn: fetchOrgSettings,
+  });
 
   const [isEditing, setIsEditing] = useState(false);
   const [editCompanyName, setEditCompanyName] = useState("");
   const [editIndustry, setEditIndustry] = useState("");
   const [editTeamSize, setEditTeamSize] = useState("");
+  const [editBudget, setEditBudget] = useState("");
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState("");
   // Pending org-user removal target. Triggered by the per-row "Remove
@@ -141,6 +149,9 @@ export function CompanyTab() {
 
   const updateMutation = useMutation({
     mutationFn: updateOnboardingProfile,
+  });
+  const updateBudgetMutation = useMutation({
+    mutationFn: updateOrgSettings,
   });
   const removeUserMutation = useMutation({
     mutationFn: (userId: string) => removeOrgUser(userId),
@@ -182,13 +193,26 @@ export function CompanyTab() {
   });
 
   const editing = isAdmin && isEditing;
-  const isSaving = updateMutation.isPending;
+  const isSaving =
+    updateMutation.isPending || updateBudgetMutation.isPending;
 
   const enterEdit = () => {
     if (!profile) return;
     setEditCompanyName(profile.companyName ?? "");
     setEditIndustry(profile.industry ?? "");
     setEditTeamSize(profile.teamSize ?? "");
+    // Seed the budget editor from the current org-settings row. 0 is
+    // the no-target sentinel — show it as an empty string so the
+    // input doesn't read like a deliberate $0/mo target.
+    const seedBudgetCents = orgSettings?.monthlyBudgetCents ?? 0;
+    setEditBudget(
+      seedBudgetCents > 0
+        ? (seedBudgetCents / 100).toLocaleString("de-DE", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })
+        : "",
+    );
     setIsEditing(true);
   };
 
@@ -197,6 +221,7 @@ export function CompanyTab() {
     setEditCompanyName("");
     setEditIndustry("");
     setEditTeamSize("");
+    setEditBudget("");
   };
 
   const confirmEdit = async () => {
@@ -207,25 +232,73 @@ export function CompanyTab() {
       return;
     }
 
+    // Parse de-DE budget: "1.234,56" → 1234.56. Empty string is the
+    // "clear the target" gesture and lands as 0.
+    let parsedBudgetCents = orgSettings?.monthlyBudgetCents ?? 0;
+    const trimmedBudget = editBudget.trim();
+    if (trimmedBudget.length === 0) {
+      parsedBudgetCents = 0;
+    } else {
+      const raw = trimmedBudget.replace(/\./g, "").replace(",", ".");
+      const num = parseFloat(raw);
+      if (!Number.isFinite(num) || num < 0) {
+        toast.error("Budget must be a non-negative number.");
+        return;
+      }
+      parsedBudgetCents = Math.round(num * 100);
+    }
+
     const nameChanged = trimmedName !== (profile.companyName ?? "");
     const industryChanged = editIndustry !== (profile.industry ?? "");
     const teamSizeChanged = editTeamSize !== (profile.teamSize ?? "");
-    if (!nameChanged && !industryChanged && !teamSizeChanged) {
+    const budgetChanged =
+      parsedBudgetCents !== (orgSettings?.monthlyBudgetCents ?? 0);
+    if (
+      !nameChanged &&
+      !industryChanged &&
+      !teamSizeChanged &&
+      !budgetChanged
+    ) {
       setIsEditing(false);
       return;
     }
 
-    try {
-      await updateMutation.mutateAsync({
-        ...(nameChanged ? { companyName: trimmedName } : {}),
-        ...(industryChanged ? { industry: editIndustry } : {}),
-        ...(teamSizeChanged ? { teamSize: editTeamSize } : {}),
-      });
-      toast.success("Company profile updated.");
-      queryClient.invalidateQueries({ queryKey: ["onboarding-profile"] });
+    // Profile + budget land on different endpoints. Fire them in
+    // parallel via Promise.allSettled and surface a single success
+    // toast only when both succeed; partial failures keep edit mode
+    // open so the admin can retry from the staged values.
+    const tasks: Array<Promise<unknown>> = [];
+    if (nameChanged || industryChanged || teamSizeChanged) {
+      tasks.push(
+        updateMutation
+          .mutateAsync({
+            ...(nameChanged ? { companyName: trimmedName } : {}),
+            ...(industryChanged ? { industry: editIndustry } : {}),
+            ...(teamSizeChanged ? { teamSize: editTeamSize } : {}),
+          })
+          .catch((err: Error) => {
+            toast.error(err.message || "Couldn't update company profile.");
+            throw err;
+          }),
+      );
+    }
+    if (budgetChanged) {
+      tasks.push(
+        updateBudgetMutation
+          .mutateAsync({ monthlyBudgetCents: parsedBudgetCents })
+          .catch((err: Error) => {
+            toast.error(err.message || "Couldn't update company budget.");
+            throw err;
+          }),
+      );
+    }
+
+    const results = await Promise.allSettled(tasks);
+    queryClient.invalidateQueries({ queryKey: ["onboarding-profile"] });
+    queryClient.invalidateQueries({ queryKey: ["org-settings"] });
+    if (results.every((r) => r.status === "fulfilled")) {
+      toast.success("Company updated.");
       setIsEditing(false);
-    } catch (err) {
-      toast.error((err as Error).message || "Couldn't update company.");
     }
   };
 
@@ -273,10 +346,10 @@ export function CompanyTab() {
     );
   }
 
-  // Org-wide rollups. Per-user spentCents covers personal projects +
-  // arena; per-team spentCents covers team-routed chats. They
-  // partition the org's spend so summing them is safe.
-  const totalBudgetCents =
+  // Per-user spentCents covers personal projects + arena; per-team
+  // spentCents covers team-routed chats. They partition the org's
+  // spend so summing them is safe.
+  const allocatedCents =
     teams.reduce((acc, t) => acc + (t.monthlyBudgetCents ?? 0), 0) +
     orgUsers.reduce((acc, u) => acc + (u.monthlyBudgetCents ?? 0), 0);
   const totalSpentCents =
@@ -286,12 +359,20 @@ export function CompanyTab() {
     teams.reduce((acc, t) => acc + (t.projectedCents ?? 0), 0) +
     orgUsers.reduce((acc, u) => acc + (u.projectedCents ?? 0), 0);
 
-  const budget = totalBudgetCents / 100;
+  // Company-level monthly target sourced from /org-settings. 0 means
+  // "no target set" — the UI hides budget-comparison affordances and
+  // falls back to plain spend reporting.
+  const targetCents = orgSettings?.monthlyBudgetCents ?? 0;
+  const hasTarget = targetCents > 0;
+
+  const target = targetCents / 100;
+  const allocated = allocatedCents / 100;
   const spent = totalSpentCents / 100;
-  const remaining = budget - spent;
+  const remaining = target - spent;
   const projected = totalProjectedCents / 100;
-  const onTrack = projected <= budget;
-  const pct = budget > 0 ? Math.min((spent / budget) * 100, 100) : 0;
+  const onTrack = !hasTarget || projected <= target;
+  const overBudget = hasTarget && (spent > target || projected > target);
+  const pct = hasTarget ? Math.min((spent / target) * 100, 100) : 0;
 
   const admins = orgUsers.filter((u) => u.role === "admin");
   // Everyone who isn't an admin — basic + advanced both land here.
@@ -301,6 +382,39 @@ export function CompanyTab() {
 
   return (
     <div className="py-6 space-y-6">
+      {/* Over-budget banner. Shows when admin has set a target and
+          either current spend or projected spend exceeds it. Sits
+          above every other card so it's the first thing the admin
+          reads when they enter the tab. Self-dismisses (re-renders
+          out) once the situation resolves. */}
+      {overBudget && (
+        <div className="flex items-start gap-3 rounded-lg border border-danger-3 bg-danger-1/40 px-4 py-3">
+          <AlertTriangle className="h-5 w-5 shrink-0 text-danger-6 mt-0.5" />
+          <div className="flex-1 space-y-1">
+            <p className="text-[14px] font-semibold text-danger-6">
+              Over the company budget
+            </p>
+            <p className="text-[13px] text-text-1">
+              {spent > target ? (
+                <>
+                  Spent <strong>{formatCurrency(spent)}</strong> of the{" "}
+                  <strong>{formatCurrency(target)}</strong> monthly target.
+                </>
+              ) : (
+                <>
+                  Projected to spend <strong>{formatCurrency(projected)}</strong>{" "}
+                  by month-end against a <strong>{formatCurrency(target)}</strong>{" "}
+                  target.
+                </>
+              )}{" "}
+              {isAdmin
+                ? "Raise the target with the Pencil button, or trim per-team / per-member caps."
+                : "Ask an admin to raise the target or trim per-team / per-member caps."}
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Company card */}
       <div className="bg-bg-white rounded p-4 space-y-[30px]">
         <div className="flex items-start justify-between gap-3">
@@ -441,18 +555,64 @@ export function CompanyTab() {
           </div>
         </div>
 
-        {/* Budget aggregate row — derived from existing teams + users
-            data, no separate org-level cap. */}
+        {/* Budget row.
+            - Company Monthly Budget: admin-set target (org_settings).
+              Editable in edit mode; 0 = "no target set". Sub-line
+              shows the seuvent of per-team + per-member caps so the
+              admin can sanity-check that allocation lines up with
+              intent.
+            - Spent / Remaining: comparison against the target. With
+              no target the right-hand value falls back to "—" so the
+              card doesn't pretend at math it can't do.
+            - Projected: linear extrapolation already on the rollup
+              data; pill goes red when target is set and projected
+              exceeds it. */}
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-3">
-            <p className="text-[18px] font-bold text-text-1">Total Budget</p>
-            <div className="flex h-[56px] items-center px-1 text-[16px] text-text-1">
-              {budget > 0 ? (
-                <span>{formatCurrency(budget)}</span>
-              ) : (
-                <span className="text-text-3">No budgets configured</span>
-              )}
-            </div>
+            <p className="text-[18px] font-bold text-text-1">
+              Company Monthly Budget
+            </p>
+            {editing ? (
+              <div className="relative">
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-[16px] text-text-2">
+                  $
+                </span>
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  value={editBudget}
+                  onChange={(e) =>
+                    setEditBudget(formatBudgetInput(e.target.value))
+                  }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      void confirmEdit();
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      cancelEdit();
+                    }
+                  }}
+                  placeholder="No target"
+                  disabled={isSaving}
+                  className="w-full h-[56px] rounded border border-border-4 bg-transparent pl-7 pr-4 text-[16px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+            ) : (
+              <div className="flex h-[56px] items-center px-1 text-[16px] text-text-1">
+                {hasTarget ? (
+                  <span>{formatCurrency(target)}</span>
+                ) : (
+                  <span className="text-text-3">No target set</span>
+                )}
+              </div>
+            )}
+            <p className="text-[12px] text-text-3">
+              Allocated across teams + members:{" "}
+              <strong className="text-text-2">
+                {formatCurrency(allocated)}
+              </strong>
+            </p>
           </div>
 
           <div className="space-y-3">
@@ -460,15 +620,21 @@ export function CompanyTab() {
             <div className="flex items-center gap-3 h-[56px]">
               <span className="text-[16px] text-text-2">
                 {formatCurrency(spent)} /{" "}
-                {remaining > 0 ? formatCurrency(remaining) : formatCurrency(0)}
+                {hasTarget
+                  ? remaining > 0
+                    ? formatCurrency(remaining)
+                    : formatCurrency(0)
+                  : "—"}
               </span>
-              <div className="flex items-center h-[7px] w-[68px] shrink-0 rounded-full border border-border-4 overflow-hidden">
-                <div
-                  className={`h-full shrink-0 ${remaining < 0 ? "bg-danger-5" : "bg-success-2"}`}
-                  style={{ width: `${pct}%` }}
-                />
-                <div className="h-full flex-1 bg-bg-white" />
-              </div>
+              {hasTarget && (
+                <div className="flex items-center h-[7px] w-[68px] shrink-0 rounded-full border border-border-4 overflow-hidden">
+                  <div
+                    className={`h-full shrink-0 ${remaining < 0 ? "bg-danger-5" : "bg-success-2"}`}
+                    style={{ width: `${pct}%` }}
+                  />
+                  <div className="h-full flex-1 bg-bg-white" />
+                </div>
+              )}
             </div>
           </div>
 
@@ -479,13 +645,17 @@ export function CompanyTab() {
             </div>
             <div className="flex items-center gap-2.5 h-[56px]">
               <span className="text-[16px] text-text-1">{formatCurrency(projected)}</span>
-              <span
-                className={`rounded-lg px-2 py-1 text-[13px] ${
-                  onTrack ? "bg-success-1 text-text-1" : "bg-bg-1 text-text-3"
-                }`}
-              >
-                {onTrack ? "On track" : "Over Budget"}
-              </span>
+              {hasTarget && (
+                <span
+                  className={`rounded-lg px-2 py-1 text-[13px] ${
+                    onTrack
+                      ? "bg-success-1 text-text-1"
+                      : "bg-danger-1 text-danger-6"
+                  }`}
+                >
+                  {onTrack ? "On track" : "Over Budget"}
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1779,6 +1779,40 @@ export async function deleteCompanyProfile(): Promise<{
   return res.json();
 }
 
+// ─── Org-level settings (singleton, currently just monthly budget) ──
+
+export interface OrgSettings {
+  id: string;
+  /** Monthly company-wide budget target (cents). 0 = no target set. */
+  monthlyBudgetCents: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchOrgSettings(): Promise<OrgSettings> {
+  const res = await apiFetch("/org-settings");
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || "Failed to fetch org settings");
+  }
+  return res.json();
+}
+
+export async function updateOrgSettings(input: {
+  monthlyBudgetCents?: number;
+}): Promise<OrgSettings> {
+  const res = await apiFetch("/org-settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || "Failed to update org settings");
+  }
+  return res.json();
+}
+
 /**
  * Resume-flow draft. Mirrors the BE `OnboardingDraft` — every field
  * optional, no API keys, no files. Persisted server-side per user

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1783,8 +1783,14 @@ export async function deleteCompanyProfile(): Promise<{
 
 export interface OrgSettings {
   id: string;
-  /** Monthly company-wide budget target (cents). 0 = no target set. */
-  monthlyBudgetCents: number;
+  /**
+   * Monthly company-wide budget target (cents). Tri-state, mirrors
+   * team_members.monthlyCapCents:
+   *   - null → no target set (gate silent-passes, UI shows "No target")
+   *   - 0    → org-wide chat suspended (gate 402s)
+   *   - >0   → enforced when org spend + estimate >= cap
+   */
+  monthlyBudgetCents: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -1799,7 +1805,9 @@ export async function fetchOrgSettings(): Promise<OrgSettings> {
 }
 
 export async function updateOrgSettings(input: {
-  monthlyBudgetCents?: number;
+  /** undefined → leave alone; null → clear target (no enforcement);
+   *  0 → suspend org-wide chat; >0 → enforced cap. */
+  monthlyBudgetCents?: number | null;
 }): Promise<OrgSettings> {
   const res = await apiFetch("/org-settings", {
     method: "PATCH",

--- a/apps/web/src/lib/chat-errors.ts
+++ b/apps/web/src/lib/chat-errors.ts
@@ -61,6 +61,19 @@ export function humanizeChatError(err: unknown): string {
     );
   }
 
+  // Org-wide monthly budget. Fires after per-team / per-member caps
+  // pass — the call would tip the *company* over its admin-set
+  // target. Different message than the workspace-budget-exhausted
+  // branch below because the admin-actionable surface is different
+  // (Management → Company vs. Management → Teams).
+  const orgBudgetMatch = raw.match(/ORG_BUDGET_EXCEEDED:\s*([^\r\n]+)/);
+  if (orgBudgetMatch) {
+    return (
+      orgBudgetMatch[1].trim() ||
+      "Your company's monthly AI budget is reached. Resets on the 1st of next month, or ask an admin to raise the target in Management → Company."
+    );
+  }
+
   // 402 — OpenRouter's body for budget-exhausted hits is full of
   // "max_tokens" and "total limit" wording that would otherwise false-
   // positive into the context-length branch below. The HTTP status code

--- a/apps/web/src/lib/chat-errors.ts
+++ b/apps/web/src/lib/chat-errors.ts
@@ -61,6 +61,25 @@ export function humanizeChatError(err: unknown): string {
     );
   }
 
+  // Team-level budget gate (our own). Distinct from OpenRouter's
+  // budget-exhausted hit below — this fires for BYOK / Custom routes
+  // too, where OpenRouter doesn't see the call. Lets the user know
+  // the *team* is over, not the workspace as a whole.
+  const teamBudgetMatch = raw.match(/TEAM_BUDGET_EXCEEDED:\s*([^\r\n]+)/);
+  if (teamBudgetMatch) {
+    return (
+      teamBudgetMatch[1].trim() ||
+      "Your team's monthly budget is reached. Resets on the 1st of next month, or ask an admin to raise the team's Monthly Budget."
+    );
+  }
+  const teamSuspendedMatch = raw.match(/TEAM_SUSPENDED:\s*([^\r\n]+)/);
+  if (teamSuspendedMatch) {
+    return (
+      teamSuspendedMatch[1].trim() ||
+      "This team is suspended (budget set to $0). Ask an admin to raise the team's Monthly Budget."
+    );
+  }
+
   // Org-wide monthly budget. Fires after per-team / per-member caps
   // pass — the call would tip the *company* over its admin-set
   // target. Different message than the workspace-budget-exhausted

--- a/apps/web/src/lib/chat-errors.ts
+++ b/apps/web/src/lib/chat-errors.ts
@@ -92,6 +92,13 @@ export function humanizeChatError(err: unknown): string {
       "Your company's monthly AI budget is reached. Resets on the 1st of next month, or ask an admin to raise the target in Management → Company."
     );
   }
+  const orgSuspendedMatch = raw.match(/ORG_SUSPENDED:\s*([^\r\n]+)/);
+  if (orgSuspendedMatch) {
+    return (
+      orgSuspendedMatch[1].trim() ||
+      "Org-wide chat is paused (Company Monthly Budget set to $0). Ask an admin to clear or raise it in Management → Company."
+    );
+  }
 
   // 402 — OpenRouter's body for budget-exhausted hits is full of
   // "max_tokens" and "total limit" wording that would otherwise false-

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -208,6 +208,16 @@ export const observabilityEvents = pgTable(
     index("observability_events_team_created_idx").on(table.teamId, table.createdAt),
     index("observability_events_model_created_idx").on(table.model, table.createdAt),
     index("observability_events_type_created_idx").on(table.eventType, table.createdAt),
+    // Org-wide spend aggregate runs on every chat call when an admin
+    // has set a Company Monthly Budget — `assertOrgBudgetNotExceeded`
+    // sums cost_usd filtered by success=true AND createdAt >=
+    // date_trunc('month', now()). The existing per-user / per-team
+    // indexes don't help (no user/team filter on this query), so a
+    // dedicated partial index on (created_at) WHERE success = true
+    // keeps the gate cheap as observability_events grows.
+    index("observability_events_success_created_idx")
+      .on(table.createdAt)
+      .where(sql`${table.success} = true`),
   ],
 );
 

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -534,3 +534,23 @@ export const integrations = pgTable(
       .where(sql`${table.apiUrl} IS NULL AND ${table.teamId} IS NOT NULL`),
   ],
 );
+
+// Org-level singleton settings. The Company tab on the FE renders a
+// "Company Monthly Budget" target the admin sets here; future org-wide
+// flags (logo URL, default infraChoice, branding overrides…) will land
+// on the same row instead of needing one table per setting. We don't
+// enforce singleton via a partial unique index — the get/upsert logic
+// in the service deterministically reads the oldest row, so an
+// accidental second row would just be hidden, not cause data loss.
+//
+// Default monthlyBudgetCents=0 means "no company target set" (UI hides
+// over-budget banner / projected pill until admin types a number). A
+// future hard-cap gate in chat-transport may treat 0 differently
+// (likely "unlimited" to avoid breaking deployments that never set
+// one) — settled when phase 2 lands.
+export const orgSettings = pgTable("org_settings", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  monthlyBudgetCents: integer("monthly_budget_cents").notNull().default(0),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -543,14 +543,21 @@ export const integrations = pgTable(
 // in the service deterministically reads the oldest row, so an
 // accidental second row would just be hidden, not cause data loss.
 //
-// Default monthlyBudgetCents=0 means "no company target set" (UI hides
-// over-budget banner / projected pill until admin types a number). A
-// future hard-cap gate in chat-transport may treat 0 differently
-// (likely "unlimited" to avoid breaking deployments that never set
-// one) — settled when phase 2 lands.
+// monthlyBudgetCents follows the same tri-state shape as
+// team_members.monthlyCapCents:
+//   - NULL → no company target set (chat-transport gate is a silent
+//     pass, UI shows "No target set" + hides over-budget banner /
+//     projected pill). Default for fresh deployments and lazy-seeded
+//     rows so existing installs that never open the Company tab
+//     keep working unchanged.
+//   - 0    → org-wide chat suspended (every chat call hits the gate
+//     and 402s with ORG_SUSPENDED). Same semantics as team /
+//     member 0 — a deliberate kill switch admins can flip when
+//     something goes wrong.
+//   - >0   → enforced. Gate blocks when org spend + estimate >= cap.
 export const orgSettings = pgTable("org_settings", {
   id: uuid("id").primaryKey().defaultRandom(),
-  monthlyBudgetCents: integer("monthly_budget_cents").notNull().default(0),
+  monthlyBudgetCents: integer("monthly_budget_cents"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
 ## Povzetek

  Prej so se budget-i obnašali nekonsistentno glede na to, **kako** je klic šel ven:

  - **Team Monthly Budget** = OpenRouter sub-account limit. BYOK klici na team-shared Anthropic ključ so ga **zaobšli** (Anthropic je plačan direktno, OpenRouter ni vmes). Admin je tako lahko nezavedno presegel
   team budget.
  - **Company Monthly Budget** sploh ni obstajal — "Total Budget" na Company tabu je bil samo seštevek caps-ov, brez realnega cap-a kjerkoli.

  Ta PR uskladi vse, da **vsi cap-i berejo iz `observability_events`** — istega vira, ki ga uporablja per-member cap gate. BYOK in Custom klici tako štejejo enako kot OpenRouter klici, ne glede na to, kdo
  dejansko plača.

  ## Kaj je narejeno

  ### 1. Org-level singleton (`org_settings`)

  - Nova tabela `org_settings` z eno vrstico: `monthly_budget_cents` (default 0 = "no target set"), timestamps. Predviden vsebovalec za prihodnja org-level polja (logo, branding, default infraChoice).
  - `OrgSettingsModule` — service + controller z `GET /org-settings` (vsi avth user-ji) in `PATCH /org-settings` (admin only). Lazy-seed-a row na prvi `GET`. Validate-before-DB.
  - 3 unit testi pokrivajo BadRequest poti (negative / non-integer / NaN).

  ### 2. CompanyTab UI (`/teams?tab=company`)

  - **Pencil edit-mode** zdaj zajame Company Monthly Budget — live de-DE format-irani input z `formatBudgetInput`, `Enter`/`Esc` shortcut-i. `confirmEdit` pelje profile + budget mutation paralelno
  (`Promise.allSettled`), partial failure ohrani edit mode.
  - **"Monthly Budget"** kartica zamenja prejšnji "Total Budget". Pod njo manjši text "Allocated across teams + members: $X" — sum team + user budgetov ostane kot informativni sanity-check.
  - **Spent / Remaining** se primerja s targetom. Brez targeta desni del prikaže "—".
  - **Projected pill** rdeč ("Over Budget") namesto sive, ko target obstaja preseže.
  - **Top-of-tab banner** ko `target > 0 && (spent > target || projected > target)` — rdeč alert s konkretnimi številkami, drugačnim sporočilom za admine vs. ne-admine.

  ### 3. Chat-time gate-i

  #### `assertOrgBudgetNotExceeded` (chat-transport.service.ts)

  - Bere `org_settings.monthlyBudgetCents`, agregira spend org-wide iz `observability_events` za tekoči mesec, prišteje pre-flight estimate, vrže **402 + `ORG_BUDGET_EXCEEDED`** marker, ko prečka.
  - `target === 0` → silent pass. Obstoječi deployment-i delujejo neblokirano, dokler admin ne nastavi targeta.
  - Pre-flight ("would push the company past $X") vs post-flight ("is reached") wording.

  #### `assertTeamBudgetNotExceeded` (chat-transport.service.ts)

  - Mirror per-member shape, ampak scoped na **team** namesto member. Bere `teams.monthlyBudgetCents`, agregira `observability_events.cost_usd` po `team_id` za mesec.
  - Zakaj **dodatno** k OpenRouter sub-account limitu: BYOK + Custom rute zaobidejo OpenRouter, ta gate ujame tudi te klice. Admin ne more več tiho preseči team budget-a samo z aktivacijo team-shared Anthropic
  ključa.
  - `budget === 0` → 402 + **`TEAM_SUSPENDED`** (teh klic admin lahko sprosti z dvigom budget-a).
  - `budget > 0 && (spent + estimate) >= budget` → 402 + **`TEAM_BUDGET_EXCEEDED`**.

  #### Vrstni red gate-ov pri chat call-u

  1. Personal budget       (samo personal chat)        — BUDGET_PENDING_APPROVAL
  2. Per-member team cap   (samo team chat)            — TEAM_MEMBER_CAP_REACHED / TEAM_MEMBER_SUSPENDED
  3. Team Monthly Budget   (samo team chat)            — TEAM_BUDGET_EXCEEDED / TEAM_SUSPENDED
  4. Company Monthly Budget (vedno, če je nastavljen)  — ORG_BUDGET_EXCEEDED
  5. OpenRouter / provider (zadnja obramba)

  Najmanjši fix vedno fire-a prvi: če je samo *tvoj* cap presežen, dobiš sporočilo o per-member cap-u, ne o team budget-u. Admin takoj ve, kaj povišati.

  #### FE error humanizer (`chat-errors.ts`)

  - Novi matcher-ji za `TEAM_BUDGET_EXCEEDED`, `TEAM_SUSPENDED`, `ORG_BUDGET_EXCEEDED` — actionable copy z usmeritvami na pravi management screen.

  #### Unit testi

  - 11 novih testov v `chat-transport.service.spec.ts` (skupaj 31): no-team scope, team-deletion race, suspended (budget=0), under-cap, post-flight breach, pre-flight breach — za team gate; isto za org gate.

  ### 4. Team UI Spent display alignment (`teams.service.ts`)

  - **Posledica novih gate-ov:** prej so Teams listing + detail stran prikazali `spentCents` iz **OpenRouter sub-account usage-a** (samo OpenRouter klici), ampak novi team-budget gate enforce-a iz
  `observability_events` (vsi route-i). Inkonsistenca: admin v UI vidi $250/$500, gate pa že fire-a, ker je dejanski total $480.
  - Uveden private helper `computeTeamUsageMap(teamIds[])` v `teams.service.ts`. Enkraten group-by query po `observability_events.team_id`, vrne `Map<teamId, { spentCents, projectedCents }>`. Replace-an v
  `findAll`, `findOne`, `findSubteams`.
  - **Trade-off:** catalog-priced cost je estimate, ne actual billed znesek (kot ga vrne OpenRouter). Konsistenca z gate-om je pomembnejša od dollar-perfect display-a.

  ## Test plan

  - [x] Sveže deployment: Company tab pokaže "No target set", chat call-i delujejo brez blokade. Pencil flow lazy-seed-a `org_settings` row pri prvi PATCH-i.
  - [x] Admin nastavi company target $500 → chat call-i blokirani, ko spend prečka cap; toast usmerja na "Management → Company".
  - [ ] Spent/projected prečka company target → top-of-tab banner s konkretnimi številkami.
  - [ ] Per-member cap udari prej kot team budget → user vidi member-cap sporočilo (ne team-budget).
  - [ ] Admin nastavi team budget $100, član opravi BYOK klic na team-shared Anthropic key → klic se logira v observability, ko `(spent + estimate) >= 100` chat se blokira z `TEAM_BUDGET_EXCEEDED`.
  - [ ] Team budget = 0 → vsi team chat-i (vključno z Custom LLM) blokirani z `TEAM_SUSPENDED`.
  - [ ] Teams kartica prikazuje spent, ki vključuje BYOK + custom usage (catalog-priced).
  - [ ] Custom LLM klic se ne všteva v spent (cost=null), ampak suspendiran user/team ne more chat-at niti preko Custom-a.
  - [ ] Non-admin uporabnik: Company tab Pencil + budget input nista vidna; banner copy preusmeri na "Ask an admin".

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
