### PR TITLE
  feat: notifications inbox, team admin/manager roles, KC dedup + teams visibility + project integration, dashboard polish + tests and fixes

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { KnowledgeCoreModule } from './knowledge-core/knowledge-core.module';
 import { ProjectsModule } from './projects/projects.module';
 import { RedisModule } from './redis/redis.module';
 import { ModelsModule } from './models/models.module';
+import { NotificationsModule } from './notifications/notifications.module';
 import { ObservabilityModule } from './observability/observability.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
 import { OrgSettingsModule } from './org-settings/org-settings.module';
@@ -41,6 +42,7 @@ import { UsersModule } from './users/users.module';
     IntegrationsModule,
     KnowledgeCoreModule,
     ModelsModule,
+    NotificationsModule,
     ObservabilityModule,
     OnboardingModule,
     OrgSettingsModule,

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -508,7 +508,43 @@ export class AuthService {
     }
 
     const userRole = (user.role as string) || 'basic';
-    const canCreateProject = userRole === 'admin' || userRole === 'advanced';
+    // Personal-project creation is gated on the user's org-level
+    // role (admin / advanced). Basic users can ALSO create projects
+    // when they hold a manager-tier role on at least one team
+    // (owner / admin / manager / editor) — those flow into the
+    // team-scope branch of projects.service.create, which doesn't
+    // care about the org-level role. Detecting that here so the
+    // FE can render the "Create project" button instead of hiding
+    // it for everyone who isn't admin/advanced.
+    let canCreateProject = userRole === 'admin' || userRole === 'advanced';
+    if (!canCreateProject) {
+      const ownedTeam = await this.db
+        .select({ id: teams.id })
+        .from(teams)
+        .where(eq(teams.ownerId, user.id))
+        .limit(1);
+      if (ownedTeam.length > 0) {
+        canCreateProject = true;
+      } else {
+        const managedTeam = await this.db
+          .select({ id: teamMembers.id })
+          .from(teamMembers)
+          .where(
+            and(
+              eq(teamMembers.userId, user.id),
+              eq(teamMembers.status, 'accepted'),
+              inArray(teamMembers.role, [
+                'admin',
+                'manager',
+                'editor',
+                'advanced',
+              ]),
+            ),
+          )
+          .limit(1);
+        canCreateProject = managedTeam.length > 0;
+      }
+    }
 
     return {
       id: user.id,

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -533,12 +533,7 @@ export class AuthService {
             and(
               eq(teamMembers.userId, user.id),
               eq(teamMembers.status, 'accepted'),
-              inArray(teamMembers.role, [
-                'admin',
-                'manager',
-                'editor',
-                'advanced',
-              ]),
+              inArray(teamMembers.role, ['admin', 'manager', 'editor']),
             ),
           )
           .limit(1);

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -24,6 +24,7 @@ import { ChatTransportService } from '../integrations/chat-transport.service.js'
 import { KnowledgeIngestionService } from '../knowledge-core/knowledge-ingestion.service.js';
 import { OpenRouterCatalogService } from '../models/openrouter-catalog.service.js';
 import { ObservabilityService } from '../observability/observability.service.js';
+import { ProjectKnowledgeService } from '../projects/project-knowledge.service.js';
 import { ChatService } from './chat.service.js';
 
 interface ChatRequestBody {
@@ -45,6 +46,7 @@ export class ChatController {
     private readonly observabilityService: ObservabilityService,
     private readonly guardrails: GuardrailEvaluatorService,
     private readonly knowledgeIngestion: KnowledgeIngestionService,
+    private readonly projectKnowledge: ProjectKnowledgeService,
     @Inject(DATABASE) private readonly db: Database,
   ) {}
 
@@ -161,11 +163,28 @@ export class ChatController {
 
     const contextChunks: string[] = [];
     if (body.projectId) {
+      // Project-scoped paste-text snippets (legacy + still active).
       const relevant = await this.documentsService.searchRelevant(
         body.projectId,
         safePrompt,
       );
       for (const doc of relevant) contextChunks.push(doc.content);
+
+      // KC files explicitly attached to the project — separate from
+      // the user-wide `searchAccessibleChunks` below so the
+      // attachment itself authorises read access (visibility scopes
+      // are bypassed for these). Resolve attached ids first; if
+      // none, skip the embedding round-trip.
+      const attachedFileIds =
+        await this.projectKnowledge.getAttachedFileIds(body.projectId);
+      if (attachedFileIds.length > 0) {
+        const attachedChunks =
+          await this.knowledgeIngestion.searchProjectAttachedChunks(
+            attachedFileIds,
+            safePrompt,
+          );
+        for (const chunk of attachedChunks) contextChunks.push(chunk.content);
+      }
     }
     const userKnowledge =
       await this.knowledgeIngestion.searchAccessibleChunks(

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -171,15 +171,18 @@ export class ChatController {
       for (const doc of relevant) contextChunks.push(doc.content);
 
       // KC files explicitly attached to the project — separate from
-      // the user-wide `searchAccessibleChunks` below so the
-      // attachment itself authorises read access (visibility scopes
-      // are bypassed for these). Resolve attached ids first; if
-      // none, skip the embedding round-trip.
+      // the user-wide `searchAccessibleChunks` below to keep the
+      // attached-file path narrowly scoped. Visibility scopes still
+      // apply (the inner service enforces them per chunk), so an
+      // 'admins'-only file remains admins-only even when attached.
+      // Resolve attached ids first; if none, skip the embedding
+      // round-trip.
       const attachedFileIds =
         await this.projectKnowledge.getAttachedFileIds(body.projectId);
       if (attachedFileIds.length > 0) {
         const attachedChunks =
           await this.knowledgeIngestion.searchProjectAttachedChunks(
+            user.id,
             attachedFileIds,
             safePrompt,
           );

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -151,6 +151,7 @@ export class ChatController {
     });
     await this.chatTransport.assertOrgBudgetNotExceeded({
       estimatedCostCents,
+      callerUserId: user.id,
     });
 
     const apiMessages = conversationAfterPersist.messages.map((m) => ({

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -9,6 +9,7 @@ import { IntegrationsModule } from '../integrations/integrations.module.js';
 import { KnowledgeCoreModule } from '../knowledge-core/knowledge-core.module.js';
 import { ModelsModule } from '../models/models.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
+import { ProjectsModule } from '../projects/projects.module.js';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { OpenRouterModule } from '../openrouter/openrouter.module.js';
     KnowledgeCoreModule, // KnowledgeIngestionService for user-scoped RAG
     ModelsModule,
     OpenRouterModule,
+    ProjectsModule, // ProjectKnowledgeService for project-attached KC RAG
   ],
   controllers: [ChatController],
   providers: [ChatService],

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -669,6 +669,10 @@ export class CompareModelsController {
       .select({
         id: arenaRuns.id,
         question: arenaRuns.question,
+        // models is `jsonb` on the row — the FE renders avatars per
+        // model, so include it in the summary so the dashboard /
+        // sidebar don't have to round-trip back through /runs/:id.
+        models: arenaRuns.models,
         createdAt: arenaRuns.createdAt,
       })
       .from(arenaRuns)
@@ -676,7 +680,10 @@ export class CompareModelsController {
       .orderBy(desc(arenaRuns.createdAt))
       .limit(50);
 
-    return rows;
+    return rows.map((r) => ({
+      ...r,
+      models: Array.isArray(r.models) ? (r.models as string[]) : [],
+    }));
   }
 
   @Get('runs/:id')

--- a/apps/api/src/compare-models/compare-models.controller.ts
+++ b/apps/api/src/compare-models/compare-models.controller.ts
@@ -338,6 +338,7 @@ export class CompareModelsController {
           });
           await this.chatTransport.assertOrgBudgetNotExceeded({
             estimatedCostCents,
+            callerUserId: user.id,
           });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/guardrails/guardrails-section.module.ts
+++ b/apps/api/src/guardrails/guardrails-section.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { GuardrailEvaluatorService } from './guardrail-evaluator.service.js';
 import { GuardrailsSectionController } from './guardrails-section.controller.js';
 import { GuardrailsSectionService } from './guardrails-section.service.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 import { TeamsModule } from '../teams/teams.module.js';
 
 @Module({
-  imports: [TeamsModule],
+  imports: [TeamsModule, NotificationsModule],
   controllers: [GuardrailsSectionController],
   providers: [GuardrailsSectionService, GuardrailEvaluatorService],
   // Evaluator is consumed by ChatModule + CompareModelsModule, so

--- a/apps/api/src/guardrails/guardrails-section.service.ts
+++ b/apps/api/src/guardrails/guardrails-section.service.ts
@@ -13,6 +13,7 @@ import {
   users,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 import { TeamsService } from '../teams/teams.service.js';
 import { COMPLIANCE_TEMPLATES } from './compliance-templates.js';
 
@@ -35,6 +36,7 @@ export class GuardrailsSectionService {
   constructor(
     @Inject(DATABASE) private readonly db: Database,
     private readonly teamsService: TeamsService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   async findAll(userId: string) {
@@ -357,12 +359,72 @@ export class GuardrailsSectionService {
     // shouldn't list already-linked teams, but a double-click race
     // shouldn't 409 either. Return the resulting link so the FE can
     // refresh its picker state.
-    await this.db
+    const linkRows = await this.db
       .insert(guardrailTeams)
       .values({ guardrailId, teamId, assignedBy: userId })
-      .onConflictDoNothing();
+      .onConflictDoNothing()
+      .returning({ guardrailId: guardrailTeams.guardrailId });
+
+    // Only announce when the INSERT actually landed (new link).
+    // Re-assignments shouldn't fire a fresh "X added a guardrail"
+    // toast at every member because someone clicked twice. Pulled
+    // outside the conditional helper so we can also pre-resolve
+    // rule + team names once.
+    if (linkRows.length > 0) {
+      await this.announceGuardrailAssignedToTeam(guardrailId, teamId, userId);
+    }
 
     return this.getRuleWithTeams(guardrailId);
+  }
+
+  /**
+   * Tell every team member (minus the assigner) that a new
+   * guardrail is now active for their team. Best-effort, never
+   * throws. Resolves rule + team names so the title reads
+   * naturally without the FE having to do another lookup.
+   */
+  private async announceGuardrailAssignedToTeam(
+    guardrailId: string,
+    teamId: string,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const [rule] = await this.db
+        .select({ name: guardrails.name })
+        .from(guardrails)
+        .where(eq(guardrails.id, guardrailId))
+        .limit(1);
+      const [team] = await this.db
+        .select({ name: teams.name })
+        .from(teams)
+        .where(eq(teams.id, teamId))
+        .limit(1);
+      const recipients = (
+        await this.notifications.getTeamMembers(teamId)
+      ).filter((id) => id !== callerUserId);
+      const ruleName = rule?.name ?? 'A guardrail';
+      const teamName = team?.name ?? 'team';
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'guardrail_added',
+            title: `Guardrail "${ruleName}" is now active for "${teamName}"`,
+            body: null,
+            data: {
+              scope: 'team',
+              guardrailId,
+              guardrailName: ruleName,
+              teamId,
+              teamName,
+              actorId: callerUserId,
+            },
+          }),
+        ),
+      );
+    } catch {
+      // swallow — informational
+    }
   }
 
   /**
@@ -452,12 +514,59 @@ export class GuardrailsSectionService {
       }
     }
 
+    const nextOrgWide = !rule.isOrgWide;
     await this.db
       .update(guardrails)
-      .set({ isOrgWide: !rule.isOrgWide, updatedAt: new Date() })
+      .set({ isOrgWide: nextOrgWide, updatedAt: new Date() })
       .where(eq(guardrails.id, guardrailId));
 
+    // Only fire the company-wide transparency notif when the rule
+    // becomes org-wide — not on the reverse transition (turning it
+    // back off doesn't need to ping everyone).
+    if (nextOrgWide) {
+      await this.announceGuardrailOrgWide(guardrailId, userId);
+    }
+
     return this.getRuleWithTeams(guardrailId);
+  }
+
+  /**
+   * Fan out a 'guardrail_added' (scope='org') notification to every
+   * user in the caller's company so they know a new rule applies
+   * to all their chats. Best-effort.
+   */
+  private async announceGuardrailOrgWide(
+    guardrailId: string,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const [rule] = await this.db
+        .select({ name: guardrails.name })
+        .from(guardrails)
+        .where(eq(guardrails.id, guardrailId))
+        .limit(1);
+      const ruleName = rule?.name ?? 'A guardrail';
+      const recipients =
+        await this.notifications.getCompanyUsers(callerUserId);
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'guardrail_added',
+            title: `Guardrail "${ruleName}" now applies company-wide`,
+            body: null,
+            data: {
+              scope: 'org',
+              guardrailId,
+              guardrailName: ruleName,
+              actorId: callerUserId,
+            },
+          }),
+        ),
+      );
+    } catch {
+      // swallow — informational
+    }
   }
 
   /**

--- a/apps/api/src/guardrails/guardrails-section.service.ts
+++ b/apps/api/src/guardrails/guardrails-section.service.ts
@@ -342,9 +342,14 @@ export class GuardrailsSectionService {
     if (teamRole === null) {
       throw new NotFoundException('Team not found');
     }
-    if (teamRole !== 'owner' && teamRole !== 'admin' && teamRole !== 'editor') {
+    if (
+      teamRole !== 'owner' &&
+      teamRole !== 'admin' &&
+      teamRole !== 'manager' &&
+      teamRole !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can assign guardrails to a team',
+        'Only team owners, admins, managers, or editors can assign guardrails to a team',
       );
     }
 

--- a/apps/api/src/guardrails/guardrails-section.service.ts
+++ b/apps/api/src/guardrails/guardrails-section.service.ts
@@ -342,9 +342,9 @@ export class GuardrailsSectionService {
     if (teamRole === null) {
       throw new NotFoundException('Team not found');
     }
-    if (teamRole !== 'owner' && teamRole !== 'editor') {
+    if (teamRole !== 'owner' && teamRole !== 'admin' && teamRole !== 'editor') {
       throw new ForbiddenException(
-        'Only team owners or editors can assign guardrails to a team',
+        'Only team owners, admins, or editors can assign guardrails to a team',
       );
     }
 

--- a/apps/api/src/integrations/chat-transport.service.spec.ts
+++ b/apps/api/src/integrations/chat-transport.service.spec.ts
@@ -176,6 +176,17 @@ describe('ChatTransportService.assertTeamMemberCapNotExceeded', () => {
       {} as any,
 
       {} as any,
+
+      // NotificationsService stub — budget-alert fanout is fire-
+      // and-forget here, only `getTeamBudgetRecipients` /
+      // `getOrgBudgetRecipients` would matter and both default to
+      // empty (no recipients → no rows enqueued).
+      {
+        getTeamBudgetRecipients: async () => [] as string[],
+        getOrgBudgetRecipients: async () => [] as string[],
+        createIfNotExists: async () => null,
+        create: async () => null,
+      } as any,
     );
   }
 
@@ -307,6 +318,17 @@ describe('ChatTransportService.assertOrgBudgetNotExceeded', () => {
       {} as any,
 
       {} as any,
+
+      // NotificationsService stub — budget-alert fanout is fire-
+      // and-forget here, only `getTeamBudgetRecipients` /
+      // `getOrgBudgetRecipients` would matter and both default to
+      // empty (no recipients → no rows enqueued).
+      {
+        getTeamBudgetRecipients: async () => [] as string[],
+        getOrgBudgetRecipients: async () => [] as string[],
+        createIfNotExists: async () => null,
+        create: async () => null,
+      } as any,
     );
   }
 
@@ -367,7 +389,17 @@ describe('ChatTransportService.assertTeamBudgetNotExceeded', () => {
 
   function makeService(rowSets: unknown[][]) {
     const db = makeChainableDb(rowSets);
-    return new ChatTransportService(db as never, {} as never, {} as never);
+    return new ChatTransportService(
+      db as never,
+      {} as never,
+      {} as never,
+      {
+        getTeamBudgetRecipients: async () => [] as string[],
+        getOrgBudgetRecipients: async () => [] as string[],
+        createIfNotExists: async () => null,
+        create: async () => null,
+      } as never,
+    );
   }
 
   it('skips when no team is in scope (personal chat)', async () => {

--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -11,6 +11,7 @@ import {
   users,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
 import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 import { NATIVE_ENDPOINTS, providerOfModel } from './native-endpoints.js';
@@ -156,7 +157,48 @@ export class ChatTransportService {
     @Inject(DATABASE) private readonly db: Database,
     private readonly encryptionService: EncryptionService,
     private readonly keyResolverService: KeyResolverService,
+    private readonly notifications: NotificationsService,
   ) {}
+
+  /**
+   * Synthetic threshold-key carried in the notification `data`
+   * payload so `NotificationsService.createIfNotExists` can dedupe
+   * within a calendar month. Crossing 80% in May 2026 generates one
+   * row regardless of how many chat calls also cross it; June
+   * resets via a different key.
+   */
+  private periodKey(): string {
+    const now = new Date();
+    const yyyy = now.getUTCFullYear();
+    const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+    return `${yyyy}-${mm}`;
+  }
+
+  /**
+   * Fan out a budget-threshold notification to a set of recipients.
+   * Failures are logged but never thrown — alerts are advisory,
+   * they must not break the chat path.
+   */
+  private async fanoutBudgetAlert(
+    recipients: string[],
+    type: 'budget_alert',
+    thresholdKey: string,
+    title: string,
+    body: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    await Promise.allSettled(
+      recipients.map((userId) =>
+        this.notifications.createIfNotExists({
+          userId,
+          type,
+          title,
+          body,
+          data: { ...data, thresholdKey },
+        }),
+      ),
+    );
+  }
 
   async resolve(input: {
     userId: string;
@@ -624,7 +666,64 @@ export class ChatTransportService {
 
     const estimateCents = Math.max(options.estimatedCostCents ?? 0, 0);
     const projectedCents = spentCents + estimateCents;
+
+    // 80% threshold alert: fire once per month the first time the
+    // team's projected spend crosses 0.8 * budget. The dedupe in
+    // NotificationsService.createIfNotExists ensures we don't spam
+    // even if a hundred chat calls in a row all sit past 80%.
+    // Recipients = team owner + every team admin. Failures here
+    // can never abort the chat call (Promise.allSettled +
+    // try/catch inside service).
+    const eightyPct = Math.floor(team.budget * 0.8);
+    if (
+      team.budget > 0 &&
+      spentCents < eightyPct &&
+      projectedCents >= eightyPct
+    ) {
+      const recipients = await this.notifications.getTeamBudgetRecipients(
+        teamId,
+      );
+      await this.fanoutBudgetAlert(
+        recipients,
+        'budget_alert',
+        `${this.periodKey()}:team:${teamId}:80`,
+        `Team "${team.name}" has used 80% of its monthly budget`,
+        `Spent ~$${(projectedCents / 100).toFixed(2)} of $${(team.budget / 100).toFixed(2)}.`,
+        {
+          scope: 'team',
+          teamId,
+          teamName: team.name,
+          threshold: 80,
+          budgetCents: team.budget,
+          spentCents: projectedCents,
+        },
+      );
+    }
+
     if (projectedCents < team.budget) return;
+
+    // 100% threshold alert: fire the moment a call brings the team
+    // to / past its full budget. Same dedupe + fanout as above.
+    if (spentCents < team.budget) {
+      const recipients = await this.notifications.getTeamBudgetRecipients(
+        teamId,
+      );
+      await this.fanoutBudgetAlert(
+        recipients,
+        'budget_alert',
+        `${this.periodKey()}:team:${teamId}:100`,
+        `Team "${team.name}" has hit its monthly budget`,
+        `Spent ~$${(projectedCents / 100).toFixed(2)} of $${(team.budget / 100).toFixed(2)}. Chat is blocked until you raise the cap or next month resets.`,
+        {
+          scope: 'team',
+          teamId,
+          teamName: team.name,
+          threshold: 100,
+          budgetCents: team.budget,
+          spentCents: projectedCents,
+        },
+      );
+    }
 
     const capUsd = (team.budget / 100).toFixed(2);
     const spentUsdStr = (spentCents / 100).toFixed(2);
@@ -667,6 +766,13 @@ export class ChatTransportService {
        * skip the pre-flight branch.
        */
       estimatedCostCents?: number;
+      /**
+       * Caller's user id. Optional for back-compat with tests that
+       * exercise the gate without a user context. When set, lets us
+       * resolve company-scoped admin recipients for the budget-
+       * threshold notification fanout.
+       */
+      callerUserId?: string;
     } = {},
   ): Promise<void> {
     const [settings] = await this.db
@@ -703,7 +809,58 @@ export class ChatTransportService {
 
     const estimateCents = Math.max(options.estimatedCostCents ?? 0, 0);
     const projectedCents = spentCents + estimateCents;
+
+    // 80% / 100% threshold alerts — same shape as the team-budget
+    // gate above. Recipients = every admin sharing the caller's
+    // company_name. Skipped when callerUserId is absent (test
+    // call path) or the user has no company (personal profile).
+    const eightyPct = Math.floor(targetCents * 0.8);
+    if (
+      options.callerUserId &&
+      spentCents < eightyPct &&
+      projectedCents >= eightyPct
+    ) {
+      const recipients = await this.notifications.getOrgBudgetRecipients(
+        options.callerUserId,
+      );
+      await this.fanoutBudgetAlert(
+        recipients,
+        'budget_alert',
+        `${this.periodKey()}:org:80`,
+        `Your company has used 80% of its monthly AI budget`,
+        `Spent ~$${(projectedCents / 100).toFixed(2)} of $${(targetCents / 100).toFixed(2)}.`,
+        {
+          scope: 'org',
+          threshold: 80,
+          budgetCents: targetCents,
+          spentCents: projectedCents,
+        },
+      );
+    }
+
     if (projectedCents < targetCents) return;
+
+    if (
+      options.callerUserId &&
+      spentCents < targetCents
+    ) {
+      const recipients = await this.notifications.getOrgBudgetRecipients(
+        options.callerUserId,
+      );
+      await this.fanoutBudgetAlert(
+        recipients,
+        'budget_alert',
+        `${this.periodKey()}:org:100`,
+        `Your company has hit its monthly AI budget`,
+        `Spent ~$${(projectedCents / 100).toFixed(2)} of $${(targetCents / 100).toFixed(2)}. Org-wide chat is blocked until the cap is raised or next month resets.`,
+        {
+          scope: 'org',
+          threshold: 100,
+          budgetCents: targetCents,
+          spentCents: projectedCents,
+        },
+      );
+    }
 
     const targetUsd = (targetCents / 100).toFixed(2);
     const spentUsdStr = (spentCents / 100).toFixed(2);

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -3,10 +3,14 @@ import { AnthropicClientService } from './anthropic-client.service.js';
 import { ChatTransportService } from './chat-transport.service.js';
 import { IntegrationsController } from './integrations.controller.js';
 import { IntegrationsService } from './integrations.service.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
-  imports: [OpenRouterModule], // EncryptionService + KeyResolverService
+  // OpenRouter brings EncryptionService + KeyResolverService;
+  // Notifications brings NotificationsService used by the budget
+  // gates for threshold alerts.
+  imports: [OpenRouterModule, NotificationsModule],
   controllers: [IntegrationsController],
   providers: [
     IntegrationsService,

--- a/apps/api/src/knowledge-core/knowledge-core.controller.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.controller.ts
@@ -103,18 +103,29 @@ export class KnowledgeCoreController {
     @UploadedFiles() files: Express.Multer.File[],
     // Multer parses non-file fields onto the request body; multipart
     // strings come through verbatim. Service validates the value
-    // against the 'all' | 'admins' | 'teams' enum.
+    // against the 'all' | 'admins' | 'teams' | 'project' enum.
     //
-    // teamIds arrives as either a single string ("uuid") or an array
-    // depending on how the FE serialized it ("teamIds=a" vs. multiple
-    // `teamIds=a&teamIds=b` appends). Normalize before passing on so
-    // the service only deals with `string[]`.
-    @Body() body: { visibility?: string; teamIds?: string | string[] },
+    // teamIds / projectIds arrive as either a single string ("uuid")
+    // or an array depending on how the FE serialized it
+    // ("teamIds=a" vs. multiple `teamIds=a&teamIds=b` appends).
+    // Normalize before passing on so the service only deals with
+    // `string[]`.
+    @Body()
+    body: {
+      visibility?: string;
+      teamIds?: string | string[];
+      projectIds?: string | string[];
+    },
   ) {
     const teamIds = Array.isArray(body?.teamIds)
       ? body.teamIds
       : body?.teamIds
         ? [body.teamIds]
+        : [];
+    const projectIds = Array.isArray(body?.projectIds)
+      ? body.projectIds
+      : body?.projectIds
+        ? [body.projectIds]
         : [];
     return this.service.uploadFiles(
       folderId,
@@ -122,6 +133,7 @@ export class KnowledgeCoreController {
       files,
       body?.visibility,
       teamIds,
+      projectIds,
     );
   }
 
@@ -134,7 +146,8 @@ export class KnowledgeCoreController {
   @Patch('files/:id/visibility')
   updateFileVisibility(
     @Param('id') id: string,
-    @Body() body: { visibility: string; teamIds?: string[] },
+    @Body()
+    body: { visibility: string; teamIds?: string[]; projectIds?: string[] },
     @CurrentUser() user: AuthenticatedUser,
   ) {
     return this.service.updateFileVisibility(
@@ -142,6 +155,7 @@ export class KnowledgeCoreController {
       user.id,
       body?.visibility,
       body?.teamIds,
+      body?.projectIds,
     );
   }
 
@@ -190,6 +204,7 @@ export class KnowledgeCoreController {
       fileIds: string[];
       visibility: string;
       teamIds?: string[];
+      projectIds?: string[];
     },
     @CurrentUser() user: AuthenticatedUser,
   ) {
@@ -198,6 +213,7 @@ export class KnowledgeCoreController {
       user.id,
       body?.visibility,
       body?.teamIds,
+      body?.projectIds,
     );
   }
 

--- a/apps/api/src/knowledge-core/knowledge-core.controller.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.controller.ts
@@ -103,10 +103,26 @@ export class KnowledgeCoreController {
     @UploadedFiles() files: Express.Multer.File[],
     // Multer parses non-file fields onto the request body; multipart
     // strings come through verbatim. Service validates the value
-    // against the 'all' | 'admins' enum.
-    @Body() body: { visibility?: string },
+    // against the 'all' | 'admins' | 'teams' enum.
+    //
+    // teamIds arrives as either a single string ("uuid") or an array
+    // depending on how the FE serialized it ("teamIds=a" vs. multiple
+    // `teamIds=a&teamIds=b` appends). Normalize before passing on so
+    // the service only deals with `string[]`.
+    @Body() body: { visibility?: string; teamIds?: string | string[] },
   ) {
-    return this.service.uploadFiles(folderId, user.id, files, body?.visibility);
+    const teamIds = Array.isArray(body?.teamIds)
+      ? body.teamIds
+      : body?.teamIds
+        ? [body.teamIds]
+        : [];
+    return this.service.uploadFiles(
+      folderId,
+      user.id,
+      files,
+      body?.visibility,
+      teamIds,
+    );
   }
 
   /**
@@ -118,10 +134,15 @@ export class KnowledgeCoreController {
   @Patch('files/:id/visibility')
   updateFileVisibility(
     @Param('id') id: string,
-    @Body() body: { visibility: string },
+    @Body() body: { visibility: string; teamIds?: string[] },
     @CurrentUser() user: AuthenticatedUser,
   ) {
-    return this.service.updateFileVisibility(id, user.id, body?.visibility);
+    return this.service.updateFileVisibility(
+      id,
+      user.id,
+      body?.visibility,
+      body?.teamIds,
+    );
   }
 
   /**
@@ -150,13 +171,19 @@ export class KnowledgeCoreController {
    */
   @Patch('files/visibility')
   updateFilesVisibility(
-    @Body() body: { fileIds: string[]; visibility: string },
+    @Body()
+    body: {
+      fileIds: string[];
+      visibility: string;
+      teamIds?: string[];
+    },
     @CurrentUser() user: AuthenticatedUser,
   ) {
     return this.service.updateFilesVisibility(
       body?.fileIds ?? [],
       user.id,
       body?.visibility,
+      body?.teamIds,
     );
   }
 

--- a/apps/api/src/knowledge-core/knowledge-core.controller.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.controller.ts
@@ -160,6 +160,20 @@ export class KnowledgeCoreController {
   }
 
   /**
+   * Wipe a file's embeddings without deleting the upload. Owner-only;
+   * blocked if mid-ingestion. The row stays in KC (still listed,
+   * still downloadable), but chat-time RAG won't surface it until
+   * the owner triggers Retrain.
+   */
+  @Post('files/:id/untrain')
+  untrainFile(
+    @Param('id') id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.service.untrainFile(id, user.id);
+  }
+
+  /**
    * Bulk variant of the per-file PATCH. Lets the multi-select action
    * bar flip many rows in one round-trip and one DB transaction.
    * Admin-only — same gate as the per-file endpoint, just applied

--- a/apps/api/src/knowledge-core/knowledge-core.module.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.module.ts
@@ -3,6 +3,7 @@ import { KnowledgeCoreController } from './knowledge-core.controller.js';
 import { KnowledgeCoreService } from './knowledge-core.service.js';
 import { KnowledgeIngestionService } from './knowledge-ingestion.service.js';
 import { DocumentsModule } from '../documents/documents.module.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
@@ -11,6 +12,9 @@ import { OpenRouterModule } from '../openrouter/openrouter.module.js';
     // KeyResolverService for the OCR path in ingestOneFile — image
     // uploads route through OpenRouter using the uploader's key.
     OpenRouterModule,
+    // Used by the ingestion path to drop a 'file_ingestion_failed'
+    // notification when a file can't be chunked / embedded.
+    NotificationsModule,
   ],
   controllers: [KnowledgeCoreController],
   providers: [KnowledgeCoreService, KnowledgeIngestionService],

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -421,15 +421,12 @@ export class KnowledgeCoreService {
         this.knowledgeIngestion.ingestPendingFilesForUser(userId);
       }
 
-      // Stamp the inserted rows with the team set so the FE doesn't
-      // have to refetch separately to render the row badge. Empty
-      // array for non-teams visibility keeps the shape uniform.
-      const insertedWithTeams = inserted.map((row) => ({
-        ...row,
-        teamIds: visibility === 'teams' ? allowedTeamIds : [],
-      }));
-
-      return { uploaded: insertedWithTeams, duplicates };
+      // Keep the upload response aligned with KnowledgeFile —
+      // callers refetch the folder detail after upload, which
+      // hydrates `teams: [{id,name}]` via hydrateTeamLinks. Adding
+      // an ad-hoc `teamIds` here would break that contract for no
+      // benefit.
+      return { uploaded: inserted, duplicates };
     } catch (error) {
       await Promise.allSettled(
         toInsert
@@ -670,10 +667,20 @@ export class KnowledgeCoreService {
         id: knowledgeFiles.id,
         folderId: knowledgeFiles.folderId,
         ingestionStatus: knowledgeFiles.ingestionStatus,
+        scope: knowledgeFiles.scope,
       })
       .from(knowledgeFiles)
       .where(eq(knowledgeFiles.id, fileId));
     if (!file) throw new NotFoundException('File not found');
+    // Mirror the upload-path invariant: 'teams' is only meaningful
+    // for company-scope rows. Personal files are owner-only at chat
+    // time, so a teams-restricted personal file would just leave
+    // stray knowledge_file_teams links nobody ever reads.
+    if (visibilityInput === 'teams' && file.scope === 'personal') {
+      throw new BadRequestException(
+        'Team visibility requires a company profile — personal-scope files are owner-only.',
+      );
+    }
     // Block visibility flips while the worker is mid-ingestion.
     // KnowledgeIngestionService captures `visibility` at claim time
     // and inserts chunks with that captured value — if we updated the
@@ -778,13 +785,28 @@ export class KnowledgeCoreService {
     // here would leave them out of sync. Skip processing rows
     // entirely so the rest of the batch still flips, and return the
     // skipped ids so the FE can surface a partial-success toast.
+    //
+    // Also fetch scope so we can enforce the same invariant the
+    // upload path does — 'teams' visibility is meaningless on a
+    // personal-scope row (owner-only already). Reject the whole
+    // batch up front rather than half-flipping it; in legitimate FE
+    // flows a single bulk PATCH never mixes scopes anyway.
     const statuses = await this.db
       .select({
         id: knowledgeFiles.id,
         ingestionStatus: knowledgeFiles.ingestionStatus,
+        scope: knowledgeFiles.scope,
       })
       .from(knowledgeFiles)
       .where(inArray(knowledgeFiles.id, uniqueIds));
+    if (visibilityInput === 'teams') {
+      const personal = statuses.filter((r) => r.scope === 'personal');
+      if (personal.length > 0) {
+        throw new BadRequestException(
+          'Team visibility requires a company profile — personal-scope files are owner-only.',
+        );
+      }
+    }
     const eligibleIds: string[] = [];
     const skippedIds: string[] = [];
     for (const row of statuses) {

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -866,12 +866,15 @@ export class KnowledgeCoreService {
   }
 
   /**
-   * Flip an existing file's visibility between 'all' and 'admins'.
-   * Admin-only — non-admins can't elevate (would be a privilege
-   * escalation) nor demote (no good reason; admin owns the curation).
-   * Mirrored onto knowledge_chunks so the RAG filter (which only
-   * reads chunks, never re-JOINs to the file row) immediately
-   * respects the new setting.
+   * Flip an existing file's visibility across the four tiers
+   * (all / admins / teams / project). Allowed for the file's
+   * uploader (so users can re-target their own uploads post-hoc)
+   * OR for admins (org-wide management). Non-admin uploaders are
+   * still blocked from setting 'admins' visibility — that tier is
+   * an admin privilege; the lower tiers (all / teams / project) are
+   * fair game for the owner. Mirrored onto knowledge_chunks so the
+   * RAG filter (which only reads chunks, never re-JOINs to the file
+   * row) immediately respects the new setting.
    */
   async updateFileVisibility(
     fileId: string,
@@ -884,11 +887,7 @@ export class KnowledgeCoreService {
       .select({ role: users.role })
       .from(users)
       .where(eq(users.id, callerId));
-    if (caller?.role !== 'admin') {
-      throw new ForbiddenException(
-        'Only admins can change a file\'s visibility.',
-      );
-    }
+    const isAdmin = caller?.role === 'admin';
     if (
       visibilityInput !== 'all' &&
       visibilityInput !== 'admins' &&
@@ -906,10 +905,22 @@ export class KnowledgeCoreService {
         folderId: knowledgeFiles.folderId,
         ingestionStatus: knowledgeFiles.ingestionStatus,
         scope: knowledgeFiles.scope,
+        uploadedById: knowledgeFiles.uploadedById,
       })
       .from(knowledgeFiles)
       .where(eq(knowledgeFiles.id, fileId));
     if (!file) throw new NotFoundException('File not found');
+    const isOwner = file.uploadedById === callerId;
+    if (!isOwner && !isAdmin) {
+      throw new ForbiddenException(
+        "Only the file's uploader or an admin can change its visibility.",
+      );
+    }
+    if (visibilityInput === 'admins' && !isAdmin) {
+      throw new ForbiddenException(
+        "Only admins can mark a file as admin-only.",
+      );
+    }
     // Mirror the upload-path invariant: 'teams' / 'project' are only
     // meaningful for company-scope rows. Personal files are owner-
     // only at chat time, so a restricted personal file would just
@@ -938,17 +949,23 @@ export class KnowledgeCoreService {
     // Resolve link sets BEFORE the transaction so validation errors
     // don't leave a half-applied state. Empty arrays for unrelated
     // visibility levels are intentional — the transaction below wipes
-    // any pre-existing links regardless.
+    // any pre-existing links regardless. isAdmin gates whether the
+    // caller can target arbitrary teams/projects; non-admin owners
+    // are limited to their own membership.
     const teamIds =
       visibilityInput === 'teams'
-        ? await this.resolveAssignableTeamIds(teamIdsInput ?? [], callerId, true)
+        ? await this.resolveAssignableTeamIds(
+            teamIdsInput ?? [],
+            callerId,
+            isAdmin,
+          )
         : [];
     const projectIds =
       visibilityInput === 'project'
         ? await this.resolveAssignableProjectIds(
             projectIdsInput ?? [],
             callerId,
-            true,
+            isAdmin,
           )
         : [];
 
@@ -990,12 +1007,13 @@ export class KnowledgeCoreService {
   }
 
   /**
-   * Bulk variant of `updateFileVisibility`. Same gates (admin-only,
-   * enum validation), one transaction so a partial run can't leave
-   * the user in a half-flipped state. Drops unknown / invalid IDs
-   * silently (caller-side typically constructs the array from rows
-   * it already rendered, so the only way IDs go stale is concurrent
-   * deletes — surfacing a 404 in that race would be misleading).
+   * Bulk variant of `updateFileVisibility`. Same gates (owner-or-
+   * admin per row, enum validation), one transaction so a partial
+   * run can't leave the user in a half-flipped state. Drops unknown
+   * / invalid IDs silently (caller-side typically constructs the
+   * array from rows it already rendered, so the only way IDs go
+   * stale is concurrent deletes — surfacing a 404 in that race
+   * would be misleading).
    *
    * Returns the affected ids so the FE knows exactly which rows to
    * optimistically update.
@@ -1011,11 +1029,7 @@ export class KnowledgeCoreService {
       .select({ role: users.role })
       .from(users)
       .where(eq(users.id, callerId));
-    if (caller?.role !== 'admin') {
-      throw new ForbiddenException(
-        'Only admins can change a file\'s visibility.',
-      );
-    }
+    const isAdmin = caller?.role === 'admin';
     if (
       visibilityInput !== 'all' &&
       visibilityInput !== 'admins' &&
@@ -1026,23 +1040,32 @@ export class KnowledgeCoreService {
         `Invalid visibility "${visibilityInput}". Must be 'all', 'admins', 'teams', or 'project'.`,
       );
     }
+    if (visibilityInput === 'admins' && !isAdmin) {
+      throw new ForbiddenException(
+        "Only admins can mark a file as admin-only.",
+      );
+    }
     if (!Array.isArray(fileIds) || fileIds.length === 0) {
       throw new BadRequestException('`fileIds` must be a non-empty array.');
     }
 
-    // Same pre-transaction link resolution as the per-file path.
-    // Empty arrays for unrelated visibility levels are intentional —
-    // the transaction below wipes any pre-existing links regardless.
+    // Same pre-transaction link resolution as the per-file path —
+    // non-admin owners can only point to teams/projects they
+    // themselves can reach.
     const teamIds =
       visibilityInput === 'teams'
-        ? await this.resolveAssignableTeamIds(teamIdsInput ?? [], callerId, true)
+        ? await this.resolveAssignableTeamIds(
+            teamIdsInput ?? [],
+            callerId,
+            isAdmin,
+          )
         : [];
     const projectIds =
       visibilityInput === 'project'
         ? await this.resolveAssignableProjectIds(
             projectIdsInput ?? [],
             callerId,
-            true,
+            isAdmin,
           )
         : [];
 
@@ -1067,9 +1090,18 @@ export class KnowledgeCoreService {
         id: knowledgeFiles.id,
         ingestionStatus: knowledgeFiles.ingestionStatus,
         scope: knowledgeFiles.scope,
+        uploadedById: knowledgeFiles.uploadedById,
       })
       .from(knowledgeFiles)
       .where(inArray(knowledgeFiles.id, uniqueIds));
+    if (!isAdmin) {
+      const notOwned = statuses.filter((r) => r.uploadedById !== callerId);
+      if (notOwned.length > 0) {
+        throw new ForbiddenException(
+          "Only the file's uploader or an admin can change its visibility.",
+        );
+      }
+    }
     if (visibilityInput === 'teams' || visibilityInput === 'project') {
       const personal = statuses.filter((r) => r.scope === 'personal');
       if (personal.length > 0) {

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { eq, desc, inArray, sql } from 'drizzle-orm';
+import { and, eq, desc, inArray, sql } from 'drizzle-orm';
 import {
   knowledgeFolders,
   knowledgeFiles,
@@ -14,8 +14,26 @@ import {
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { KnowledgeIngestionService } from './knowledge-ingestion.service.js';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+
+/**
+ * Stream a file from disk through SHA-256. Avoids loading the whole
+ * buffer into memory — multer already wrote the file to disk so we
+ * just need a hash, not the bytes. Used by the upload path to
+ * detect duplicates the same user already has in their KC.
+ */
+export async function sha256File(filePath: string): Promise<string> {
+  const hash = crypto.createHash('sha256');
+  await new Promise<void>((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve());
+    stream.on('error', reject);
+  });
+  return hash.digest('hex');
+}
 
 @Injectable()
 export class KnowledgeCoreService {
@@ -174,7 +192,121 @@ export class KnowledgeCoreService {
       uploader?.role,
     );
 
-    const values = files.map((file) => {
+    // Hash every uploaded file up front so we can dedupe within the
+    // batch and against the DB in two passes. Multer already wrote
+    // each file to disk; we stream from there to keep memory flat.
+    const hashed = await Promise.all(
+      files.map(async (file) => ({
+        file,
+        hash: await sha256File(file.path),
+      })),
+    );
+
+    // Look up existing rows by this user with any of the candidate
+    // hashes. Scope is the uploader's whole KC (across all their
+    // folders) per product decision — re-uploading the same bytes
+    // anywhere surfaces the prior copy instead of creating a second
+    // row. Limited to non-null hashes because legacy rows opt out.
+    const candidateHashes = Array.from(new Set(hashed.map((h) => h.hash)));
+    const existingRows = candidateHashes.length
+      ? await this.db
+          .select({
+            id: knowledgeFiles.id,
+            name: knowledgeFiles.name,
+            folderId: knowledgeFiles.folderId,
+            contentSha256: knowledgeFiles.contentSha256,
+            folderName: knowledgeFolders.name,
+          })
+          .from(knowledgeFiles)
+          .innerJoin(
+            knowledgeFolders,
+            eq(knowledgeFolders.id, knowledgeFiles.folderId),
+          )
+          .where(
+            and(
+              eq(knowledgeFiles.uploadedById, userId),
+              inArray(knowledgeFiles.contentSha256, candidateHashes),
+            ),
+          )
+      : [];
+    const existingByHash = new Map<
+      string,
+      { id: string; name: string; folderId: string; folderName: string }
+    >();
+    for (const row of existingRows) {
+      if (!row.contentSha256 || existingByHash.has(row.contentSha256)) continue;
+      existingByHash.set(row.contentSha256, {
+        id: row.id,
+        name: row.name,
+        folderId: row.folderId,
+        folderName: row.folderName,
+      });
+    }
+
+    // Split the batch: hashes already present in DB are duplicates;
+    // remaining hashes that appear more than once within the batch
+    // keep only the first occurrence (rest are flagged against the
+    // first). The first occurrence is what gets inserted.
+    const duplicates: Array<{
+      name: string;
+      existing: {
+        id: string | null;
+        name: string;
+        folderId: string;
+        folderName: string;
+      };
+    }> = [];
+    const toInsert: Array<{
+      file: Express.Multer.File;
+      hash: string;
+    }> = [];
+    const firstInBatch = new Map<
+      string,
+      { name: string; folderName: string }
+    >();
+    for (const entry of hashed) {
+      const dbHit = existingByHash.get(entry.hash);
+      if (dbHit) {
+        duplicates.push({
+          name: entry.file.originalname,
+          existing: dbHit,
+        });
+        continue;
+      }
+      const batchHit = firstInBatch.get(entry.hash);
+      if (batchHit) {
+        duplicates.push({
+          name: entry.file.originalname,
+          existing: {
+            id: null,
+            name: batchHit.name,
+            folderId,
+            folderName: batchHit.folderName,
+          },
+        });
+        continue;
+      }
+      firstInBatch.set(entry.hash, {
+        name: entry.file.originalname,
+        folderName: folder.name,
+      });
+      toInsert.push(entry);
+    }
+
+    // Disk hygiene: tmp files multer wrote for duplicates won't be
+    // referenced by any row, so they'd leak otherwise. Best-effort —
+    // a leftover here is harmless except for disk space.
+    if (duplicates.length > 0) {
+      await Promise.allSettled(
+        hashed
+          .filter(
+            (h) => !toInsert.includes(h) && h.file.path,
+          )
+          .map((h) => fs.promises.unlink(h.file.path)),
+      );
+    }
+
+    const values = toInsert.map(({ file, hash }) => {
       const ext = path.extname(file.originalname).replace('.', '').toUpperCase();
       const fileType = ext || 'FILE';
       return {
@@ -189,6 +321,7 @@ export class KnowledgeCoreService {
         uploadedById: userId,
         scope,
         visibility,
+        contentSha256: hash,
       };
     });
 
@@ -197,10 +330,12 @@ export class KnowledgeCoreService {
         ? await this.db.insert(knowledgeFiles).values(values).returning()
         : [];
 
-      await this.db
-        .update(knowledgeFolders)
-        .set({ updatedAt: new Date() })
-        .where(eq(knowledgeFolders.id, folderId));
+      if (inserted.length > 0) {
+        await this.db
+          .update(knowledgeFolders)
+          .set({ updatedAt: new Date() })
+          .where(eq(knowledgeFolders.id, folderId));
+      }
 
       // Kick off chunk + embed in the background. Same fire-and-
       // forget pattern as onboarding ingestion — the HTTP response
@@ -212,12 +347,12 @@ export class KnowledgeCoreService {
         this.knowledgeIngestion.ingestPendingFilesForUser(userId);
       }
 
-      return inserted;
+      return { uploaded: inserted, duplicates };
     } catch (error) {
       await Promise.allSettled(
-        files
-          .filter((file) => file.path)
-          .map((file) => fs.promises.unlink(file.path)),
+        toInsert
+          .filter((entry) => entry.file.path)
+          .map((entry) => fs.promises.unlink(entry.file.path)),
       );
       throw error;
     }

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -9,7 +9,10 @@ import { and, eq, desc, inArray, sql } from 'drizzle-orm';
 import {
   knowledgeFolders,
   knowledgeFiles,
+  knowledgeFileTeams,
   knowledgeChunks,
+  teamMembers,
+  teams,
   users,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
@@ -110,7 +113,43 @@ export class KnowledgeCoreService {
       .where(eq(knowledgeFiles.folderId, id))
       .orderBy(desc(knowledgeFiles.createdAt));
 
-    return { ...folder, files };
+    // Hydrate team links for files in 'teams' visibility mode. One
+    // round-trip for the whole folder keeps this O(1) round-trips
+    // regardless of file count.
+    const teamLinks = await this.hydrateTeamLinks(files.map((f) => f.id));
+    const filesWithTeams = files.map((f) => ({
+      ...f,
+      teams: teamLinks.get(f.id) ?? [],
+    }));
+
+    return { ...folder, files: filesWithTeams };
+  }
+
+  /**
+   * Resolve per-file team-link maps in a single query so callers
+   * (folder detail, recent list) can stamp `teams: [{id, name}]`
+   * onto every file without an N+1.
+   */
+  private async hydrateTeamLinks(
+    fileIds: string[],
+  ): Promise<Map<string, Array<{ id: string; name: string }>>> {
+    const out = new Map<string, Array<{ id: string; name: string }>>();
+    if (fileIds.length === 0) return out;
+    const links = await this.db
+      .select({
+        fileId: knowledgeFileTeams.fileId,
+        teamId: teams.id,
+        teamName: teams.name,
+      })
+      .from(knowledgeFileTeams)
+      .innerJoin(teams, eq(teams.id, knowledgeFileTeams.teamId))
+      .where(inArray(knowledgeFileTeams.fileId, fileIds));
+    for (const link of links) {
+      const arr = out.get(link.fileId) ?? [];
+      arr.push({ id: link.teamId, name: link.teamName });
+      out.set(link.fileId, arr);
+    }
+    return out;
   }
 
   async createFolder(name: string, userId: string) {
@@ -159,6 +198,7 @@ export class KnowledgeCoreService {
     userId: string,
     files: Express.Multer.File[],
     visibilityInput?: string,
+    teamIdsInput?: string[],
   ) {
     const [folder] = await this.db
       .select()
@@ -190,7 +230,22 @@ export class KnowledgeCoreService {
     const visibility = this.resolveUploadVisibility(
       visibilityInput,
       uploader?.role,
+      scope,
     );
+
+    // For 'teams' visibility: resolve the caller-supplied team IDs to
+    // a validated set the caller actually belongs to (admin bypass —
+    // any company team is fair game). Bail out before any file write
+    // if the input is empty or contains a team the caller can't
+    // assign to.
+    const allowedTeamIds =
+      visibility === 'teams'
+        ? await this.resolveAssignableTeamIds(
+            teamIdsInput ?? [],
+            userId,
+            uploader?.role === 'admin',
+          )
+        : [];
 
     // Hash every uploaded file up front so we can dedupe within the
     // batch and against the DB in two passes. Multer already wrote
@@ -330,6 +385,25 @@ export class KnowledgeCoreService {
         ? await this.db.insert(knowledgeFiles).values(values).returning()
         : [];
 
+      // Link every inserted file to the resolved team set so the
+      // chat-time RAG filter (and the FE row badge) can see which
+      // teams have access. Done in one INSERT regardless of how many
+      // files / teams to keep the upload path fast.
+      if (
+        visibility === 'teams' &&
+        inserted.length > 0 &&
+        allowedTeamIds.length > 0
+      ) {
+        await this.db.insert(knowledgeFileTeams).values(
+          inserted.flatMap((row) =>
+            allowedTeamIds.map((teamId) => ({
+              fileId: row.id,
+              teamId,
+            })),
+          ),
+        );
+      }
+
       if (inserted.length > 0) {
         await this.db
           .update(knowledgeFolders)
@@ -347,7 +421,15 @@ export class KnowledgeCoreService {
         this.knowledgeIngestion.ingestPendingFilesForUser(userId);
       }
 
-      return { uploaded: inserted, duplicates };
+      // Stamp the inserted rows with the team set so the FE doesn't
+      // have to refetch separately to render the row badge. Empty
+      // array for non-teams visibility keeps the shape uniform.
+      const insertedWithTeams = inserted.map((row) => ({
+        ...row,
+        teamIds: visibility === 'teams' ? allowedTeamIds : [],
+      }));
+
+      return { uploaded: insertedWithTeams, duplicates };
     } catch (error) {
       await Promise.allSettled(
         toInsert
@@ -362,15 +444,22 @@ export class KnowledgeCoreService {
    * Validate the visibility enum + enforce the admin-only privilege
    * for 'admins'. Shared between upload and PATCH so the same gate
    * applies regardless of how a row gets flipped.
+   *
+   * 'teams' is only meaningful for company-scope uploads — personal
+   * scope is owner-only already, so a teams-restricted personal file
+   * would just be owner-only with extra steps. Rejected up front
+   * instead of silently downgraded so the FE can show a clear error
+   * if it ever sends the wrong shape.
    */
   private resolveUploadVisibility(
     input: string | undefined,
     callerRole: string | null | undefined,
-  ): 'all' | 'admins' {
+    scope?: 'personal' | 'company',
+  ): 'all' | 'admins' | 'teams' {
     if (input == null || input === '') return 'all';
-    if (input !== 'all' && input !== 'admins') {
+    if (input !== 'all' && input !== 'admins' && input !== 'teams') {
       throw new BadRequestException(
-        `Invalid visibility "${input}". Must be 'all' or 'admins'.`,
+        `Invalid visibility "${input}". Must be 'all', 'admins', or 'teams'.`,
       );
     }
     if (input === 'admins' && callerRole !== 'admin') {
@@ -378,7 +467,93 @@ export class KnowledgeCoreService {
         'Only admins can mark a knowledge file as admin-only.',
       );
     }
+    if (input === 'teams' && scope === 'personal') {
+      throw new BadRequestException(
+        'Team visibility requires a company profile — personal-scope files are owner-only.',
+      );
+    }
     return input;
+  }
+
+  /**
+   * Normalize + authorize the team-IDs array a caller sends with a
+   * 'teams' visibility request. Rules:
+   *
+   *   - Non-empty after dedupe; otherwise 'teams' visibility is
+   *     meaningless (no one can read the file). 400.
+   *   - Non-admin: every supplied id must be a team the caller owns
+   *     or is an accepted member of. Surfacing 403 here catches a
+   *     client passing arbitrary team uuids.
+   *   - Admin: bypasses membership — admins have org-wide management
+   *     privilege, so any team id that exists is fair game. We still
+   *     validate the rows exist so a typo doesn't silently create
+   *     orphan link rows (FK would catch insert-time, but a 404-style
+   *     400 is friendlier).
+   *
+   * Returns the deduped, validated array ready for INSERT.
+   */
+  private async resolveAssignableTeamIds(
+    input: string[],
+    callerId: string,
+    isAdmin: boolean,
+  ): Promise<string[]> {
+    if (!Array.isArray(input)) {
+      throw new BadRequestException(
+        '`teamIds` must be an array when visibility is "teams".',
+      );
+    }
+    const unique = Array.from(new Set(input.filter((s) => typeof s === 'string' && s.length > 0)));
+    if (unique.length === 0) {
+      throw new BadRequestException(
+        'Pick at least one team for "Teams" visibility.',
+      );
+    }
+
+    if (isAdmin) {
+      // Admins can target any existing team. Validate existence so a
+      // stale id surfaces as a clear 400 rather than an FK error.
+      const rows = await this.db
+        .select({ id: teams.id })
+        .from(teams)
+        .where(inArray(teams.id, unique));
+      const existing = new Set(rows.map((r) => r.id));
+      const missing = unique.filter((id) => !existing.has(id));
+      if (missing.length > 0) {
+        throw new BadRequestException(
+          `Unknown team id(s): ${missing.join(', ')}.`,
+        );
+      }
+      return unique;
+    }
+
+    // Non-admin: union of owned + accepted-member team ids.
+    const [ownedRows, memberRows] = await Promise.all([
+      this.db
+        .select({ id: teams.id })
+        .from(teams)
+        .where(and(eq(teams.ownerId, callerId), inArray(teams.id, unique))),
+      this.db
+        .select({ teamId: teamMembers.teamId })
+        .from(teamMembers)
+        .where(
+          and(
+            eq(teamMembers.userId, callerId),
+            eq(teamMembers.status, 'accepted'),
+            inArray(teamMembers.teamId, unique),
+          ),
+        ),
+    ]);
+    const allowed = new Set<string>([
+      ...ownedRows.map((r) => r.id),
+      ...memberRows.map((r) => r.teamId),
+    ]);
+    const denied = unique.filter((id) => !allowed.has(id));
+    if (denied.length > 0) {
+      throw new ForbiddenException(
+        'You can only assign teams you own or are a member of.',
+      );
+    }
+    return unique;
   }
 
   /**
@@ -469,6 +644,7 @@ export class KnowledgeCoreService {
     fileId: string,
     callerId: string,
     visibilityInput: string,
+    teamIdsInput?: string[],
   ) {
     const [caller] = await this.db
       .select({ role: users.role })
@@ -479,9 +655,13 @@ export class KnowledgeCoreService {
         'Only admins can change a file\'s visibility.',
       );
     }
-    if (visibilityInput !== 'all' && visibilityInput !== 'admins') {
+    if (
+      visibilityInput !== 'all' &&
+      visibilityInput !== 'admins' &&
+      visibilityInput !== 'teams'
+    ) {
       throw new BadRequestException(
-        `Invalid visibility "${visibilityInput}". Must be 'all' or 'admins'.`,
+        `Invalid visibility "${visibilityInput}". Must be 'all', 'admins', or 'teams'.`,
       );
     }
 
@@ -507,6 +687,14 @@ export class KnowledgeCoreService {
       );
     }
 
+    // Resolve the team set BEFORE the transaction so validation
+    // errors don't leave a half-applied state. Empty teamIds for
+    // non-teams visibility is fine (we'll clear any existing links).
+    const teamIds =
+      visibilityInput === 'teams'
+        ? await this.resolveAssignableTeamIds(teamIdsInput ?? [], callerId, true)
+        : [];
+
     await this.db.transaction(async (tx) => {
       await tx
         .update(knowledgeFiles)
@@ -516,9 +704,21 @@ export class KnowledgeCoreService {
         .update(knowledgeChunks)
         .set({ visibility: visibilityInput })
         .where(eq(knowledgeChunks.fileId, fileId));
+      // Replace, not merge: wiping and re-inserting keeps the link
+      // set authoritative — flipping away from 'teams' clears the
+      // links entirely; flipping into 'teams' replaces any old set
+      // with the new one. Simpler than diffing.
+      await tx
+        .delete(knowledgeFileTeams)
+        .where(eq(knowledgeFileTeams.fileId, fileId));
+      if (visibilityInput === 'teams' && teamIds.length > 0) {
+        await tx
+          .insert(knowledgeFileTeams)
+          .values(teamIds.map((teamId) => ({ fileId, teamId })));
+      }
     });
 
-    return { id: fileId, visibility: visibilityInput };
+    return { id: fileId, visibility: visibilityInput, teamIds };
   }
 
   /**
@@ -536,6 +736,7 @@ export class KnowledgeCoreService {
     fileIds: string[],
     callerId: string,
     visibilityInput: string,
+    teamIdsInput?: string[],
   ) {
     const [caller] = await this.db
       .select({ role: users.role })
@@ -546,14 +747,26 @@ export class KnowledgeCoreService {
         'Only admins can change a file\'s visibility.',
       );
     }
-    if (visibilityInput !== 'all' && visibilityInput !== 'admins') {
+    if (
+      visibilityInput !== 'all' &&
+      visibilityInput !== 'admins' &&
+      visibilityInput !== 'teams'
+    ) {
       throw new BadRequestException(
-        `Invalid visibility "${visibilityInput}". Must be 'all' or 'admins'.`,
+        `Invalid visibility "${visibilityInput}". Must be 'all', 'admins', or 'teams'.`,
       );
     }
     if (!Array.isArray(fileIds) || fileIds.length === 0) {
       throw new BadRequestException('`fileIds` must be a non-empty array.');
     }
+
+    // Same pre-transaction team resolution as the per-file path.
+    // For non-teams visibility the empty array is intentional — the
+    // transaction below will wipe any pre-existing links.
+    const teamIds =
+      visibilityInput === 'teams'
+        ? await this.resolveAssignableTeamIds(teamIdsInput ?? [], callerId, true)
+        : [];
 
     // Cheap dedupe in case the FE accidentally sends duplicates;
     // drizzle inArray would still work but we'd update twice.
@@ -597,12 +810,27 @@ export class KnowledgeCoreService {
             .update(knowledgeChunks)
             .set({ visibility: visibilityInput })
             .where(inArray(knowledgeChunks.fileId, affectedIds));
+          // Replace team links for every affected row. Same shape as
+          // the per-file path — wipe-then-insert is cheaper than
+          // diffing for the bulk case and keeps the link set
+          // authoritative regardless of prior state.
+          await tx
+            .delete(knowledgeFileTeams)
+            .where(inArray(knowledgeFileTeams.fileId, affectedIds));
+          if (visibilityInput === 'teams' && teamIds.length > 0) {
+            await tx.insert(knowledgeFileTeams).values(
+              affectedIds.flatMap((fileId) =>
+                teamIds.map((teamId) => ({ fileId, teamId })),
+              ),
+            );
+          }
         }
       });
     }
 
     return {
-      visibility: visibilityInput as 'all' | 'admins',
+      visibility: visibilityInput as 'all' | 'admins' | 'teams',
+      teamIds,
       affectedIds,
       skippedIds,
     };
@@ -733,6 +961,7 @@ export class KnowledgeCoreService {
       .orderBy(desc(knowledgeFiles.createdAt))
       .limit(10);
 
-    return rows;
+    const teamLinks = await this.hydrateTeamLinks(rows.map((r) => r.id));
+    return rows.map((r) => ({ ...r, teams: teamLinks.get(r.id) ?? [] }));
   }
 }

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -11,6 +11,7 @@ import {
   knowledgeFiles,
   knowledgeFileTeams,
   knowledgeChunks,
+  projectKnowledgeFiles,
   teamMembers,
   teams,
   users,
@@ -630,6 +631,64 @@ export class KnowledgeCoreService {
   }
 
   /**
+   * Wipe a file's chunks while keeping the file row + disk copy.
+   * Exposed as the "Untrain" action — the inverse of "Retrain":
+   *
+   *   Retrain → drop chunks, requeue for ingestion
+   *   Untrain → drop chunks, mark as 'untrained' so the worker
+   *             (which only claims 'pending') leaves it alone
+   *
+   * Useful when the owner wants to take a file out of RAG without
+   * deleting the underlying upload (e.g. paused content, archival).
+   * Re-training via the same dialog flips it back to 'pending' and
+   * the worker rehydrates the embeddings.
+   *
+   * Same ownership + processing-race gates as reingestFile so the
+   * two paths share a coherent invariant.
+   */
+  async untrainFile(fileId: string, callerId: string) {
+    const [file] = await this.db
+      .select({
+        id: knowledgeFiles.id,
+        folderId: knowledgeFiles.folderId,
+        ingestionStatus: knowledgeFiles.ingestionStatus,
+        ownerId: knowledgeFolders.ownerId,
+      })
+      .from(knowledgeFiles)
+      .innerJoin(
+        knowledgeFolders,
+        eq(knowledgeFolders.id, knowledgeFiles.folderId),
+      )
+      .where(eq(knowledgeFiles.id, fileId));
+
+    if (!file) throw new NotFoundException('File not found');
+    if (file.ownerId !== callerId) {
+      throw new ForbiddenException('Access denied');
+    }
+    if (file.ingestionStatus === 'processing') {
+      throw new BadRequestException(
+        'This file is being trained right now. Try again once the current run finishes.',
+      );
+    }
+
+    await this.db.transaction(async (tx) => {
+      await tx
+        .delete(knowledgeChunks)
+        .where(eq(knowledgeChunks.fileId, fileId));
+      await tx
+        .update(knowledgeFiles)
+        .set({
+          ingestionStatus: 'untrained',
+          ingestionError: null,
+          ingestionCompletedAt: null,
+        })
+        .where(eq(knowledgeFiles.id, fileId));
+    });
+
+    return { id: fileId, ingestionStatus: 'untrained' as const };
+  }
+
+  /**
    * Flip an existing file's visibility between 'all' and 'admins'.
    * Admin-only — non-admins can't elevate (would be a privilege
    * escalation) nor demote (no good reason; admin owns the curation).
@@ -951,7 +1010,24 @@ export class KnowledgeCoreService {
       }
     }
 
-    await this.db.delete(knowledgeFiles).where(eq(knowledgeFiles.id, fileId));
+    // Defense-in-depth: clear child rows explicitly inside a
+    // transaction before deleting the file. FK cascade should handle
+    // this, but explicit deletes guarantee chat-time RAG no longer
+    // surfaces this file even if the live DB lost the CASCADE rule.
+    // Order: chunks (RAG embeddings) → team links → project
+    // attachments → the file row itself.
+    await this.db.transaction(async (tx) => {
+      await tx
+        .delete(knowledgeChunks)
+        .where(eq(knowledgeChunks.fileId, fileId));
+      await tx
+        .delete(knowledgeFileTeams)
+        .where(eq(knowledgeFileTeams.fileId, fileId));
+      await tx
+        .delete(projectKnowledgeFiles)
+        .where(eq(projectKnowledgeFiles.fileId, fileId));
+      await tx.delete(knowledgeFiles).where(eq(knowledgeFiles.id, fileId));
+    });
 
     await this.db
       .update(knowledgeFolders)

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -12,6 +12,7 @@ import {
   knowledgeFileTeams,
   knowledgeChunks,
   projectKnowledgeFiles,
+  projects,
   teamMembers,
   teams,
   users,
@@ -114,16 +115,21 @@ export class KnowledgeCoreService {
       .where(eq(knowledgeFiles.folderId, id))
       .orderBy(desc(knowledgeFiles.createdAt));
 
-    // Hydrate team links for files in 'teams' visibility mode. One
-    // round-trip for the whole folder keeps this O(1) round-trips
-    // regardless of file count.
-    const teamLinks = await this.hydrateTeamLinks(files.map((f) => f.id));
-    const filesWithTeams = files.map((f) => ({
+    // Hydrate team + project links so the row badge can render names
+    // without an N+1. Two round-trips for the whole folder keeps
+    // this O(1) regardless of file count.
+    const fileIds = files.map((f) => f.id);
+    const [teamLinks, projectLinks] = await Promise.all([
+      this.hydrateTeamLinks(fileIds),
+      this.hydrateProjectLinks(fileIds),
+    ]);
+    const filesWithLinks = files.map((f) => ({
       ...f,
       teams: teamLinks.get(f.id) ?? [],
+      projects: projectLinks.get(f.id) ?? [],
     }));
 
-    return { ...folder, files: filesWithTeams };
+    return { ...folder, files: filesWithLinks };
   }
 
   /**
@@ -148,6 +154,33 @@ export class KnowledgeCoreService {
     for (const link of links) {
       const arr = out.get(link.fileId) ?? [];
       arr.push({ id: link.teamId, name: link.teamName });
+      out.set(link.fileId, arr);
+    }
+    return out;
+  }
+
+  /**
+   * Mirror of hydrateTeamLinks but for project links — used to stamp
+   * `projects: [{id, name}]` onto files with visibility='project' so
+   * the row badge can render names without a per-file lookup.
+   */
+  private async hydrateProjectLinks(
+    fileIds: string[],
+  ): Promise<Map<string, Array<{ id: string; name: string }>>> {
+    const out = new Map<string, Array<{ id: string; name: string }>>();
+    if (fileIds.length === 0) return out;
+    const links = await this.db
+      .select({
+        fileId: projectKnowledgeFiles.fileId,
+        projectId: projects.id,
+        projectName: projects.name,
+      })
+      .from(projectKnowledgeFiles)
+      .innerJoin(projects, eq(projects.id, projectKnowledgeFiles.projectId))
+      .where(inArray(projectKnowledgeFiles.fileId, fileIds));
+    for (const link of links) {
+      const arr = out.get(link.fileId) ?? [];
+      arr.push({ id: link.projectId, name: link.projectName });
       out.set(link.fileId, arr);
     }
     return out;
@@ -200,6 +233,7 @@ export class KnowledgeCoreService {
     files: Express.Multer.File[],
     visibilityInput?: string,
     teamIdsInput?: string[],
+    projectIdsInput?: string[],
   ) {
     const [folder] = await this.db
       .select()
@@ -243,6 +277,19 @@ export class KnowledgeCoreService {
       visibility === 'teams'
         ? await this.resolveAssignableTeamIds(
             teamIdsInput ?? [],
+            userId,
+            uploader?.role === 'admin',
+          )
+        : [];
+
+    // For 'project' visibility: same shape as teams but for projects.
+    // The project link rows in project_knowledge_files double as the
+    // access grant — chat-time RAG only surfaces these chunks inside
+    // the linked project, never via the org-wide search.
+    const allowedProjectIds =
+      visibility === 'project'
+        ? await this.resolveAssignableProjectIds(
+            projectIdsInput ?? [],
             userId,
             uploader?.role === 'admin',
           )
@@ -405,6 +452,27 @@ export class KnowledgeCoreService {
         );
       }
 
+      // 'project' visibility reuses project_knowledge_files for the
+      // access grant — same table Manage Context populates when the
+      // user attaches a KC file to a project. Inserting here both
+      // pins the file to the chosen project's chat and surfaces it
+      // in the project's Manage Context list automatically.
+      if (
+        visibility === 'project' &&
+        inserted.length > 0 &&
+        allowedProjectIds.length > 0
+      ) {
+        await this.db.insert(projectKnowledgeFiles).values(
+          inserted.flatMap((row) =>
+            allowedProjectIds.map((projectId) => ({
+              projectId,
+              fileId: row.id,
+              attachedBy: userId,
+            })),
+          ),
+        );
+      }
+
       if (inserted.length > 0) {
         await this.db
           .update(knowledgeFolders)
@@ -443,21 +511,26 @@ export class KnowledgeCoreService {
    * for 'admins'. Shared between upload and PATCH so the same gate
    * applies regardless of how a row gets flipped.
    *
-   * 'teams' is only meaningful for company-scope uploads — personal
-   * scope is owner-only already, so a teams-restricted personal file
-   * would just be owner-only with extra steps. Rejected up front
-   * instead of silently downgraded so the FE can show a clear error
-   * if it ever sends the wrong shape.
+   * 'teams' / 'project' are only meaningful for company-scope uploads
+   * — personal scope is owner-only already, so a teams- or project-
+   * restricted personal file would just be owner-only with extra
+   * steps. Rejected up front instead of silently downgraded so the FE
+   * can show a clear error if it ever sends the wrong shape.
    */
   private resolveUploadVisibility(
     input: string | undefined,
     callerRole: string | null | undefined,
     scope?: 'personal' | 'company',
-  ): 'all' | 'admins' | 'teams' {
+  ): 'all' | 'admins' | 'teams' | 'project' {
     if (input == null || input === '') return 'all';
-    if (input !== 'all' && input !== 'admins' && input !== 'teams') {
+    if (
+      input !== 'all' &&
+      input !== 'admins' &&
+      input !== 'teams' &&
+      input !== 'project'
+    ) {
       throw new BadRequestException(
-        `Invalid visibility "${input}". Must be 'all', 'admins', or 'teams'.`,
+        `Invalid visibility "${input}". Must be 'all', 'admins', 'teams', or 'project'.`,
       );
     }
     if (input === 'admins' && callerRole !== 'admin') {
@@ -468,6 +541,11 @@ export class KnowledgeCoreService {
     if (input === 'teams' && scope === 'personal') {
       throw new BadRequestException(
         'Team visibility requires a company profile — personal-scope files are owner-only.',
+      );
+    }
+    if (input === 'project' && scope === 'personal') {
+      throw new BadRequestException(
+        'Project visibility requires a company profile — personal-scope files are owner-only.',
       );
     }
     return input;
@@ -549,6 +627,105 @@ export class KnowledgeCoreService {
     if (denied.length > 0) {
       throw new ForbiddenException(
         'You can only assign teams you own or are a member of.',
+      );
+    }
+    return unique;
+  }
+
+  /**
+   * Same shape as resolveAssignableTeamIds but for project visibility.
+   * A project-visibility file is one the uploader wants pinned to a
+   * specific project's chat — searchable only inside that project,
+   * never via the org-wide RAG path.
+   *
+   * Rules mirror project-knowledge.service.ts#assertProjectAccess:
+   *   - admin: any project in the deployment, validate existence only
+   *   - non-admin: project owner, team owner of project's team, or
+   *     accepted team member
+   *
+   * Returns the deduped, validated array ready to insert into
+   * project_knowledge_files (which doubles as the access grant).
+   */
+  private async resolveAssignableProjectIds(
+    input: string[],
+    callerId: string,
+    isAdmin: boolean,
+  ): Promise<string[]> {
+    if (!Array.isArray(input)) {
+      throw new BadRequestException(
+        '`projectIds` must be an array when visibility is "project".',
+      );
+    }
+    const unique = Array.from(
+      new Set(input.filter((s) => typeof s === 'string' && s.length > 0)),
+    );
+    if (unique.length === 0) {
+      throw new BadRequestException(
+        'Pick at least one project for "Project" visibility.',
+      );
+    }
+
+    const rows = await this.db
+      .select({
+        id: projects.id,
+        ownerId: projects.userId,
+        teamId: projects.teamId,
+      })
+      .from(projects)
+      .where(inArray(projects.id, unique));
+    const existing = new Set(rows.map((r) => r.id));
+    const missing = unique.filter((id) => !existing.has(id));
+    if (missing.length > 0) {
+      throw new BadRequestException(
+        `Unknown project id(s): ${missing.join(', ')}.`,
+      );
+    }
+    if (isAdmin) return unique;
+
+    // Non-admin: must own the project OR be team-owner / accepted
+    // member of the project's team. One round-trip to pull all team
+    // memberships referenced by these projects.
+    const teamIds = Array.from(
+      new Set(rows.map((r) => r.teamId).filter((id): id is string => !!id)),
+    );
+    const [teamRows, memberRows] =
+      teamIds.length > 0
+        ? await Promise.all([
+            this.db
+              .select({ id: teams.id, ownerId: teams.ownerId })
+              .from(teams)
+              .where(inArray(teams.id, teamIds)),
+            this.db
+              .select({ teamId: teamMembers.teamId })
+              .from(teamMembers)
+              .where(
+                and(
+                  eq(teamMembers.userId, callerId),
+                  eq(teamMembers.status, 'accepted'),
+                  inArray(teamMembers.teamId, teamIds),
+                ),
+              ),
+          ])
+        : [
+            [] as Array<{ id: string; ownerId: string }>,
+            [] as Array<{ teamId: string }>,
+          ];
+    const teamOwners = new Map(teamRows.map((t) => [t.id, t.ownerId]));
+    const memberOf = new Set(memberRows.map((r) => r.teamId));
+
+    const denied = rows
+      .filter((r) => {
+        if (r.ownerId === callerId) return false;
+        if (r.teamId) {
+          if (teamOwners.get(r.teamId) === callerId) return false;
+          if (memberOf.has(r.teamId)) return false;
+        }
+        return true;
+      })
+      .map((r) => r.id);
+    if (denied.length > 0) {
+      throw new ForbiddenException(
+        'You can only assign projects you own or have team access to.',
       );
     }
     return unique;
@@ -701,6 +878,7 @@ export class KnowledgeCoreService {
     callerId: string,
     visibilityInput: string,
     teamIdsInput?: string[],
+    projectIdsInput?: string[],
   ) {
     const [caller] = await this.db
       .select({ role: users.role })
@@ -714,10 +892,11 @@ export class KnowledgeCoreService {
     if (
       visibilityInput !== 'all' &&
       visibilityInput !== 'admins' &&
-      visibilityInput !== 'teams'
+      visibilityInput !== 'teams' &&
+      visibilityInput !== 'project'
     ) {
       throw new BadRequestException(
-        `Invalid visibility "${visibilityInput}". Must be 'all', 'admins', or 'teams'.`,
+        `Invalid visibility "${visibilityInput}". Must be 'all', 'admins', 'teams', or 'project'.`,
       );
     }
 
@@ -731,13 +910,16 @@ export class KnowledgeCoreService {
       .from(knowledgeFiles)
       .where(eq(knowledgeFiles.id, fileId));
     if (!file) throw new NotFoundException('File not found');
-    // Mirror the upload-path invariant: 'teams' is only meaningful
-    // for company-scope rows. Personal files are owner-only at chat
-    // time, so a teams-restricted personal file would just leave
-    // stray knowledge_file_teams links nobody ever reads.
-    if (visibilityInput === 'teams' && file.scope === 'personal') {
+    // Mirror the upload-path invariant: 'teams' / 'project' are only
+    // meaningful for company-scope rows. Personal files are owner-
+    // only at chat time, so a restricted personal file would just
+    // leave stray link rows nobody ever reads.
+    if (
+      (visibilityInput === 'teams' || visibilityInput === 'project') &&
+      file.scope === 'personal'
+    ) {
       throw new BadRequestException(
-        'Team visibility requires a company profile — personal-scope files are owner-only.',
+        `${visibilityInput === 'teams' ? 'Team' : 'Project'} visibility requires a company profile — personal-scope files are owner-only.`,
       );
     }
     // Block visibility flips while the worker is mid-ingestion.
@@ -753,12 +935,21 @@ export class KnowledgeCoreService {
       );
     }
 
-    // Resolve the team set BEFORE the transaction so validation
-    // errors don't leave a half-applied state. Empty teamIds for
-    // non-teams visibility is fine (we'll clear any existing links).
+    // Resolve link sets BEFORE the transaction so validation errors
+    // don't leave a half-applied state. Empty arrays for unrelated
+    // visibility levels are intentional — the transaction below wipes
+    // any pre-existing links regardless.
     const teamIds =
       visibilityInput === 'teams'
         ? await this.resolveAssignableTeamIds(teamIdsInput ?? [], callerId, true)
+        : [];
+    const projectIds =
+      visibilityInput === 'project'
+        ? await this.resolveAssignableProjectIds(
+            projectIdsInput ?? [],
+            callerId,
+            true,
+          )
         : [];
 
     await this.db.transaction(async (tx) => {
@@ -771,20 +962,31 @@ export class KnowledgeCoreService {
         .set({ visibility: visibilityInput })
         .where(eq(knowledgeChunks.fileId, fileId));
       // Replace, not merge: wiping and re-inserting keeps the link
-      // set authoritative — flipping away from 'teams' clears the
-      // links entirely; flipping into 'teams' replaces any old set
-      // with the new one. Simpler than diffing.
+      // sets authoritative — flipping away clears the prior links;
+      // flipping in replaces with the new set.
       await tx
         .delete(knowledgeFileTeams)
         .where(eq(knowledgeFileTeams.fileId, fileId));
+      await tx
+        .delete(projectKnowledgeFiles)
+        .where(eq(projectKnowledgeFiles.fileId, fileId));
       if (visibilityInput === 'teams' && teamIds.length > 0) {
         await tx
           .insert(knowledgeFileTeams)
           .values(teamIds.map((teamId) => ({ fileId, teamId })));
       }
+      if (visibilityInput === 'project' && projectIds.length > 0) {
+        await tx.insert(projectKnowledgeFiles).values(
+          projectIds.map((projectId) => ({
+            projectId,
+            fileId,
+            attachedBy: callerId,
+          })),
+        );
+      }
     });
 
-    return { id: fileId, visibility: visibilityInput, teamIds };
+    return { id: fileId, visibility: visibilityInput, teamIds, projectIds };
   }
 
   /**
@@ -803,6 +1005,7 @@ export class KnowledgeCoreService {
     callerId: string,
     visibilityInput: string,
     teamIdsInput?: string[],
+    projectIdsInput?: string[],
   ) {
     const [caller] = await this.db
       .select({ role: users.role })
@@ -816,22 +1019,31 @@ export class KnowledgeCoreService {
     if (
       visibilityInput !== 'all' &&
       visibilityInput !== 'admins' &&
-      visibilityInput !== 'teams'
+      visibilityInput !== 'teams' &&
+      visibilityInput !== 'project'
     ) {
       throw new BadRequestException(
-        `Invalid visibility "${visibilityInput}". Must be 'all', 'admins', or 'teams'.`,
+        `Invalid visibility "${visibilityInput}". Must be 'all', 'admins', 'teams', or 'project'.`,
       );
     }
     if (!Array.isArray(fileIds) || fileIds.length === 0) {
       throw new BadRequestException('`fileIds` must be a non-empty array.');
     }
 
-    // Same pre-transaction team resolution as the per-file path.
-    // For non-teams visibility the empty array is intentional — the
-    // transaction below will wipe any pre-existing links.
+    // Same pre-transaction link resolution as the per-file path.
+    // Empty arrays for unrelated visibility levels are intentional —
+    // the transaction below wipes any pre-existing links regardless.
     const teamIds =
       visibilityInput === 'teams'
         ? await this.resolveAssignableTeamIds(teamIdsInput ?? [], callerId, true)
+        : [];
+    const projectIds =
+      visibilityInput === 'project'
+        ? await this.resolveAssignableProjectIds(
+            projectIdsInput ?? [],
+            callerId,
+            true,
+          )
         : [];
 
     // Cheap dedupe in case the FE accidentally sends duplicates;
@@ -858,11 +1070,11 @@ export class KnowledgeCoreService {
       })
       .from(knowledgeFiles)
       .where(inArray(knowledgeFiles.id, uniqueIds));
-    if (visibilityInput === 'teams') {
+    if (visibilityInput === 'teams' || visibilityInput === 'project') {
       const personal = statuses.filter((r) => r.scope === 'personal');
       if (personal.length > 0) {
         throw new BadRequestException(
-          'Team visibility requires a company profile — personal-scope files are owner-only.',
+          `${visibilityInput === 'teams' ? 'Team' : 'Project'} visibility requires a company profile — personal-scope files are owner-only.`,
         );
       }
     }
@@ -891,17 +1103,31 @@ export class KnowledgeCoreService {
             .update(knowledgeChunks)
             .set({ visibility: visibilityInput })
             .where(inArray(knowledgeChunks.fileId, affectedIds));
-          // Replace team links for every affected row. Same shape as
-          // the per-file path — wipe-then-insert is cheaper than
-          // diffing for the bulk case and keeps the link set
+          // Replace team/project links for every affected row. Same
+          // shape as the per-file path — wipe-then-insert is cheaper
+          // than diffing for the bulk case and keeps the link sets
           // authoritative regardless of prior state.
           await tx
             .delete(knowledgeFileTeams)
             .where(inArray(knowledgeFileTeams.fileId, affectedIds));
+          await tx
+            .delete(projectKnowledgeFiles)
+            .where(inArray(projectKnowledgeFiles.fileId, affectedIds));
           if (visibilityInput === 'teams' && teamIds.length > 0) {
             await tx.insert(knowledgeFileTeams).values(
               affectedIds.flatMap((fileId) =>
                 teamIds.map((teamId) => ({ fileId, teamId })),
+              ),
+            );
+          }
+          if (visibilityInput === 'project' && projectIds.length > 0) {
+            await tx.insert(projectKnowledgeFiles).values(
+              affectedIds.flatMap((fileId) =>
+                projectIds.map((projectId) => ({
+                  projectId,
+                  fileId,
+                  attachedBy: callerId,
+                })),
               ),
             );
           }
@@ -910,8 +1136,9 @@ export class KnowledgeCoreService {
     }
 
     return {
-      visibility: visibilityInput as 'all' | 'admins' | 'teams',
+      visibility: visibilityInput as 'all' | 'admins' | 'teams' | 'project',
       teamIds,
+      projectIds,
       affectedIds,
       skippedIds,
     };
@@ -1059,7 +1286,15 @@ export class KnowledgeCoreService {
       .orderBy(desc(knowledgeFiles.createdAt))
       .limit(10);
 
-    const teamLinks = await this.hydrateTeamLinks(rows.map((r) => r.id));
-    return rows.map((r) => ({ ...r, teams: teamLinks.get(r.id) ?? [] }));
+    const fileIds = rows.map((r) => r.id);
+    const [teamLinks, projectLinks] = await Promise.all([
+      this.hydrateTeamLinks(fileIds),
+      this.hydrateProjectLinks(fileIds),
+    ]);
+    return rows.map((r) => ({
+      ...r,
+      teams: teamLinks.get(r.id) ?? [],
+      projects: projectLinks.get(r.id) ?? [],
+    }));
   }
 }

--- a/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
@@ -330,19 +330,24 @@ export class KnowledgeIngestionService {
     const [queryEmbedding] = await this.documentsService.embed([query]);
     const similarity = sql<number>`1 - (${cosineDistance(knowledgeChunks.embedding, queryEmbedding)})`;
 
-    // Company-scope filter, now tri-state:
-    //   - admin caller: every company chunk is fair game (admins see
-    //     all + admins-only + every teams-restricted file regardless
-    //     of membership; admins manage the org).
-    //   - non-admin caller: 'all' chunks always; 'teams' chunks only
-    //     when caller is an accepted member of one of the linked
-    //     teams. 'admins' chunks are off-limits.
+    // Company-scope filter — four-state:
+    //   - 'all'     : every company user including admin
+    //   - 'admins'  : admin caller only
+    //   - 'teams'   : admin OR accepted member of one of the linked
+    //                 teams
+    //   - 'project' : NEVER reached by this org-wide path; project-
+    //                 only chunks are surfaced exclusively via
+    //                 searchProjectAttachedChunks inside that
+    //                 project's chat. Excluded even for admin.
     //
     // The teams branch probes via EXISTS against the join table.
     // Indexes on knowledge_file_teams (file_id) and team_members
     // (user_id, status) keep this sub-millisecond per chunk.
     const companyBranch = isAdmin
-      ? eq(knowledgeChunks.scope, 'company')
+      ? and(
+          eq(knowledgeChunks.scope, 'company'),
+          sql`${knowledgeChunks.visibility} <> 'project'`,
+        )
       : or(
           and(
             eq(knowledgeChunks.scope, 'company'),
@@ -413,11 +418,15 @@ export class KnowledgeIngestionService {
     const [queryEmbedding] = await this.documentsService.embed([query]);
     const similarity = sql<number>`1 - (${cosineDistance(knowledgeChunks.embedding, queryEmbedding)})`;
 
-    // Same tri-state company-scope filter searchAccessibleChunks uses,
-    // just constrained to the attached fileIds. Admin gets every
-    // company chunk; non-admin needs visibility='all' or membership in
-    // a linked team for visibility='teams'. 'admins'-visibility chunks
-    // remain off-limits to non-admins regardless of attachment.
+    // Visibility filter constrained to the attached fileIds:
+    //   - admin: any company chunk (admins-only / teams / project all
+    //     OK; project files are by definition attached or wouldn't
+    //     be in fileIds)
+    //   - non-admin: visibility='all'; OR visibility='teams' AND
+    //     member of a linked team; OR visibility='project' (no
+    //     further check — being in fileIds means the file is in
+    //     project_knowledge_files, which is the access grant for
+    //     project visibility). 'admins'-visibility stays off-limits.
     const companyBranch = isAdmin
       ? eq(knowledgeChunks.scope, 'company')
       : or(
@@ -437,6 +446,10 @@ export class KnowledgeIngestionService {
                 AND tm.user_id = ${userId}
                 AND tm.status = 'accepted'
             )`,
+          ),
+          and(
+            eq(knowledgeChunks.scope, 'company'),
+            eq(knowledgeChunks.visibility, 'project'),
           ),
         );
 

--- a/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
@@ -13,6 +13,7 @@ import {
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { DocumentsService } from '../documents/documents.service.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 import { KeyResolverService } from '../openrouter/key-resolver.service.js';
 
 // Mirror of the constant in OnboardingService — kept inline rather than
@@ -76,6 +77,7 @@ export class KnowledgeIngestionService {
     @Inject(DATABASE) private readonly db: Database,
     private readonly documentsService: DocumentsService,
     private readonly keyResolver: KeyResolverService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   /**
@@ -170,6 +172,12 @@ export class KnowledgeIngestionService {
             ingestionCompletedAt: new Date(),
           })
           .where(eq(knowledgeFiles.id, file.id));
+        await this.notifyIngestionFailure(
+          userId,
+          file.id,
+          file.name,
+          'No extractable text',
+        );
         return;
       }
 
@@ -209,6 +217,32 @@ export class KnowledgeIngestionService {
           ingestionCompletedAt: new Date(),
         })
         .where(eq(knowledgeFiles.id, file.id));
+      await this.notifyIngestionFailure(userId, file.id, file.name, message);
+    }
+  }
+
+  /**
+   * Notify the uploader that one of their Knowledge Core files
+   * didn't make it through ingestion. Best-effort — alert failures
+   * never bubble up; the worker keeps going on the remaining
+   * `pending` rows.
+   */
+  private async notifyIngestionFailure(
+    uploaderId: string,
+    fileId: string,
+    fileName: string,
+    reason: string,
+  ): Promise<void> {
+    try {
+      await this.notifications.create({
+        userId: uploaderId,
+        type: 'file_ingestion_failed',
+        title: `"${fileName}" couldn't be added to Knowledge Core`,
+        body: reason.slice(0, 200),
+        data: { fileId, fileName, reason: reason.slice(0, 500) },
+      });
+    } catch {
+      // swallow — this is fire-and-forget audit
     }
   }
 

--- a/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
@@ -386,23 +386,60 @@ export class KnowledgeIngestionService {
 
   /**
    * Cosine-similarity search restricted to KC files explicitly
-   * attached to a project. Unlike `searchAccessibleChunks`, this
-   * bypasses the visibility scopes — attaching a file to a
-   * project is itself an authoritative share, so project members
-   * see those chunks in RAG regardless of the file's broader
-   * audience.
+   * attached to a project. Applies the SAME visibility scopes as
+   * `searchAccessibleChunks` so flipping a file to 'admins' / 'teams'
+   * also restricts its content inside any project it's attached to.
+   * Attaching is a discoverability signal, not a privilege override —
+   * the file owner's visibility choice is authoritative.
    *
-   * The `fileIds` set is pre-resolved by the chat path so this
-   * service doesn't have to know about `project_knowledge_files`.
+   * The `fileIds` set is pre-resolved by the chat path (project's
+   * project_knowledge_files rows); this service then enforces who's
+   * allowed to read each one's chunks.
    */
   async searchProjectAttachedChunks(
+    userId: string,
     fileIds: string[],
     query: string,
     limit = 5,
   ) {
     if (fileIds.length === 0) return [];
+
+    const [caller] = await this.db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, userId));
+    const isAdmin = caller?.role === 'admin';
+
     const [queryEmbedding] = await this.documentsService.embed([query]);
     const similarity = sql<number>`1 - (${cosineDistance(knowledgeChunks.embedding, queryEmbedding)})`;
+
+    // Same tri-state company-scope filter searchAccessibleChunks uses,
+    // just constrained to the attached fileIds. Admin gets every
+    // company chunk; non-admin needs visibility='all' or membership in
+    // a linked team for visibility='teams'. 'admins'-visibility chunks
+    // remain off-limits to non-admins regardless of attachment.
+    const companyBranch = isAdmin
+      ? eq(knowledgeChunks.scope, 'company')
+      : or(
+          and(
+            eq(knowledgeChunks.scope, 'company'),
+            eq(knowledgeChunks.visibility, 'all'),
+          ),
+          and(
+            eq(knowledgeChunks.scope, 'company'),
+            eq(knowledgeChunks.visibility, 'teams'),
+            sql`EXISTS (
+              SELECT 1
+              FROM ${knowledgeFileTeams} kft
+              INNER JOIN ${teamMembers} tm
+                ON tm.team_id = kft.team_id
+              WHERE kft.file_id = ${knowledgeChunks.fileId}
+                AND tm.user_id = ${userId}
+                AND tm.status = 'accepted'
+            )`,
+          ),
+        );
+
     return this.db
       .select({
         id: knowledgeChunks.id,
@@ -411,7 +448,20 @@ export class KnowledgeIngestionService {
         similarity,
       })
       .from(knowledgeChunks)
-      .where(inArray(knowledgeChunks.fileId, fileIds))
+      .where(
+        and(
+          inArray(knowledgeChunks.fileId, fileIds),
+          or(
+            // Personal-scope files attached to a project are still
+            // owner-only — attaching doesn't escalate read access.
+            and(
+              eq(knowledgeChunks.userId, userId),
+              eq(knowledgeChunks.scope, 'personal'),
+            ),
+            companyBranch,
+          ),
+        ),
+      )
       .orderBy(desc(similarity))
       .limit(limit);
   }

--- a/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { and, cosineDistance, desc, eq, or, sql } from 'drizzle-orm';
+import { and, cosineDistance, desc, eq, inArray, or, sql } from 'drizzle-orm';
 import OpenAI from 'openai';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
@@ -380,6 +380,38 @@ export class KnowledgeIngestionService {
           companyBranch,
         ),
       )
+      .orderBy(desc(similarity))
+      .limit(limit);
+  }
+
+  /**
+   * Cosine-similarity search restricted to KC files explicitly
+   * attached to a project. Unlike `searchAccessibleChunks`, this
+   * bypasses the visibility scopes — attaching a file to a
+   * project is itself an authoritative share, so project members
+   * see those chunks in RAG regardless of the file's broader
+   * audience.
+   *
+   * The `fileIds` set is pre-resolved by the chat path so this
+   * service doesn't have to know about `project_knowledge_files`.
+   */
+  async searchProjectAttachedChunks(
+    fileIds: string[],
+    query: string,
+    limit = 5,
+  ) {
+    if (fileIds.length === 0) return [];
+    const [queryEmbedding] = await this.documentsService.embed([query]);
+    const similarity = sql<number>`1 - (${cosineDistance(knowledgeChunks.embedding, queryEmbedding)})`;
+    return this.db
+      .select({
+        id: knowledgeChunks.id,
+        fileId: knowledgeChunks.fileId,
+        content: knowledgeChunks.content,
+        similarity,
+      })
+      .from(knowledgeChunks)
+      .where(inArray(knowledgeChunks.fileId, fileIds))
       .orderBy(desc(similarity))
       .limit(limit);
   }

--- a/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-ingestion.service.ts
@@ -6,7 +6,9 @@ import { resolve } from 'node:path';
 import {
   knowledgeChunks,
   knowledgeFiles,
+  knowledgeFileTeams,
   knowledgeFolders,
+  teamMembers,
   users,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
@@ -294,15 +296,37 @@ export class KnowledgeIngestionService {
     const [queryEmbedding] = await this.documentsService.embed([query]);
     const similarity = sql<number>`1 - (${cosineDistance(knowledgeChunks.embedding, queryEmbedding)})`;
 
-    // Company-scope filter: 'all' is universally readable; 'admins'
-    // is only readable when the caller is admin. Building the
-    // company branch as a sub-AND keeps the personal branch alone
-    // when the caller isn't admin AND the chunk is admin-only.
+    // Company-scope filter, now tri-state:
+    //   - admin caller: every company chunk is fair game (admins see
+    //     all + admins-only + every teams-restricted file regardless
+    //     of membership; admins manage the org).
+    //   - non-admin caller: 'all' chunks always; 'teams' chunks only
+    //     when caller is an accepted member of one of the linked
+    //     teams. 'admins' chunks are off-limits.
+    //
+    // The teams branch probes via EXISTS against the join table.
+    // Indexes on knowledge_file_teams (file_id) and team_members
+    // (user_id, status) keep this sub-millisecond per chunk.
     const companyBranch = isAdmin
       ? eq(knowledgeChunks.scope, 'company')
-      : and(
-          eq(knowledgeChunks.scope, 'company'),
-          eq(knowledgeChunks.visibility, 'all'),
+      : or(
+          and(
+            eq(knowledgeChunks.scope, 'company'),
+            eq(knowledgeChunks.visibility, 'all'),
+          ),
+          and(
+            eq(knowledgeChunks.scope, 'company'),
+            eq(knowledgeChunks.visibility, 'teams'),
+            sql`EXISTS (
+              SELECT 1
+              FROM ${knowledgeFileTeams} kft
+              INNER JOIN ${teamMembers} tm
+                ON tm.team_id = kft.team_id
+              WHERE kft.file_id = ${knowledgeChunks.fileId}
+                AND tm.user_id = ${userId}
+                AND tm.status = 'accepted'
+            )`,
+          ),
         );
 
     return this.db

--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -1,0 +1,107 @@
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthenticatedUser } from '../auth/types.js';
+import { TeamsService } from '../teams/teams.service.js';
+import { NotificationsService } from './notifications.service.js';
+
+@Controller('notifications')
+export class NotificationsController {
+  constructor(
+    private readonly notifications: NotificationsService,
+    private readonly teams: TeamsService,
+  ) {}
+
+  @Get()
+  list(@CurrentUser() user: AuthenticatedUser) {
+    return this.notifications.findForUser(user.id);
+  }
+
+  @Get('unread-count')
+  async unreadCount(@CurrentUser() user: AuthenticatedUser) {
+    const count = await this.notifications.unreadCount(user.id);
+    return { count };
+  }
+
+  @Patch(':id/read')
+  markRead(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.notifications.markRead(id, user.id);
+  }
+
+  @Patch('read-all')
+  @HttpCode(200)
+  markAllRead(@CurrentUser() user: AuthenticatedUser) {
+    return this.notifications.markAllRead(user.id);
+  }
+
+  /**
+   * Accept an actionable notification. Today only team_invite is
+   * supported — org_invite is auto-accepted server-side at user-
+   * row creation time, budget_alert is info-only. Delegates the
+   * real work to TeamsService.acceptInviteByToken so there's one
+   * source of truth for flipping membership rows.
+   */
+  @Post(':id/accept')
+  @HttpCode(200)
+  async accept(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    const row = await this.notifications.getForCaller(id, user.id);
+    if (row.status !== 'pending') {
+      throw new BadRequestException(
+        'This notification has already been resolved.',
+      );
+    }
+    if (row.type !== 'team_invite') {
+      throw new BadRequestException(
+        `Notifications of type '${row.type}' don't support Accept.`,
+      );
+    }
+    const data = (row.data ?? {}) as Record<string, unknown>;
+    const token =
+      typeof data.invitationToken === 'string' ? data.invitationToken : null;
+    if (!token) {
+      throw new BadRequestException(
+        'Invitation token missing from this notification — accept via the email link.',
+      );
+    }
+    const accepted = await this.teams.acceptInviteByToken(
+      token,
+      user.id,
+      user.email,
+    );
+    await this.notifications.markActed(id, user.id);
+    return { type: row.type, teamId: accepted.teamId };
+  }
+
+  @Post(':id/decline')
+  @HttpCode(200)
+  decline(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.notifications.declineTeamInvite(id, user.id);
+  }
+
+  @Delete(':id')
+  @HttpCode(200)
+  dismiss(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.notifications.dismiss(id, user.id);
+  }
+}

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -1,0 +1,14 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { TeamsModule } from '../teams/teams.module.js';
+import { NotificationsController } from './notifications.controller.js';
+import { NotificationsService } from './notifications.service.js';
+
+@Module({
+  // forwardRef matches the TeamsModule side; without it Nest can't
+  // resolve the cycle on first boot.
+  imports: [forwardRef(() => TeamsModule)],
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -33,7 +33,10 @@ export type NotificationType =
   | 'account_role_changed'
   | 'account_budget_changed'
   | 'member_cap_changed'
-  | 'file_ingestion_failed';
+  | 'file_ingestion_failed'
+  | 'project_created'
+  | 'project_deleted'
+  | 'guardrail_added';
 
 export type NotificationStatus = 'pending' | 'acted' | 'dismissed';
 
@@ -342,6 +345,27 @@ export class NotificationsService {
       if (r.userId) set.add(r.userId);
     }
     return Array.from(set);
+  }
+
+  /**
+   * Every user in the caller's company. Used by transparency-style
+   * notifications (org-wide guardrail added, etc) where the audience
+   * is the whole org, not just admins. Excludes the caller; if the
+   * caller has no company_name (personal profile), returns empty.
+   */
+  async getCompanyUsers(callerUserId: string): Promise<string[]> {
+    const callerRow = await this.db
+      .select({ companyName: users.companyName })
+      .from(users)
+      .where(eq(users.id, callerUserId))
+      .limit(1);
+    const companyName = callerRow[0]?.companyName ?? null;
+    if (!companyName) return [];
+    const rows = await this.db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.companyName, companyName));
+    return rows.map((r) => r.id).filter((id) => id !== callerUserId);
   }
 
   /**

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import {
   notifications,
   teamMembers,
@@ -268,17 +268,37 @@ export class NotificationsService {
     const data = (row.data ?? {}) as Record<string, unknown>;
     const memberId = typeof data.memberId === 'string' ? data.memberId : null;
     if (memberId) {
-      // Revoke the pending team_members row directly — keeps the
-      // existing row shape (status='pending', invitationStatus=
-      // 'revoked') the inviter sees in their pending-list UI.
-      await this.db
-        .update(teamMembers)
-        .set({
-          invitationStatus: 'revoked',
-          invitationRevokedAt: new Date(),
-          invitationToken: null,
-        })
-        .where(eq(teamMembers.id, memberId));
+      // Defense-in-depth: scope the UPDATE to a row that actually
+      // belongs to the caller (email match) and is still actionable
+      // (status='pending', invitationStatus pending/null). Without
+      // this, a wrong memberId in notification.data would revoke an
+      // unrelated row. If the invite was already resolved elsewhere
+      // (owner revoked, expired) the update is a no-op and we still
+      // flip the notification to 'acted' so the inbox clears.
+      const [caller] = await this.db
+        .select({ email: users.email })
+        .from(users)
+        .where(eq(users.id, userId));
+      if (caller?.email) {
+        await this.db
+          .update(teamMembers)
+          .set({
+            invitationStatus: 'revoked',
+            invitationRevokedAt: new Date(),
+            invitationToken: null,
+          })
+          .where(
+            and(
+              eq(teamMembers.id, memberId),
+              eq(teamMembers.email, caller.email),
+              eq(teamMembers.status, 'pending'),
+              or(
+                isNull(teamMembers.invitationStatus),
+                eq(teamMembers.invitationStatus, 'pending'),
+              ),
+            ),
+          );
+      }
     }
     await this.markActed(id, userId);
     return { ok: true };

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -1,0 +1,341 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import {
+  notifications,
+  teamMembers,
+  teams,
+  users,
+} from '@worken/database/schema';
+import { DATABASE, type Database } from '../database/database.module.js';
+
+/**
+ * Discriminated `type` values the FE knows how to render. Loose-
+ * typed in the DB on purpose so a new type can be added without a
+ * migration, but kept as a TS union here so the wire-in points get
+ * compile-time coverage.
+ */
+export type NotificationType =
+  | 'team_invite'
+  | 'org_invite'
+  | 'budget_alert';
+
+export type NotificationStatus = 'pending' | 'acted' | 'dismissed';
+
+/**
+ * Shape returned to the FE. `data` is intentionally loose — each
+ * type carries its own payload (team invite: invitationToken /
+ * memberId / teamName; budget alert: threshold / scope / period).
+ */
+export interface NotificationView {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string | null;
+  data: Record<string, unknown>;
+  status: NotificationStatus;
+  readAt: string | null;
+  createdAt: string;
+}
+
+/**
+ * Standalone enqueue surface used by other services (teams, users,
+ * chat-transport) to drop a notification onto a user's inbox.
+ * Kept narrow: callers don't pick status, readAt, etc — those are
+ * lifecycle, not input.
+ */
+export interface CreateNotificationInput {
+  userId: string;
+  type: NotificationType;
+  title: string;
+  body?: string | null;
+  data?: Record<string, unknown>;
+}
+
+@Injectable()
+export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+
+  constructor(@Inject(DATABASE) private readonly db: Database) {}
+
+  /**
+   * Insert a single notification. Returns the new row so callers
+   * have the id for tests / audit logs. Failures (eg DB down) are
+   * logged but NOT thrown — a missed in-app notification shouldn't
+   * abort the parent action (invite, chat call). Email remains as
+   * the backup channel anyway.
+   */
+  async create(input: CreateNotificationInput): Promise<NotificationView | null> {
+    try {
+      const [row] = await this.db
+        .insert(notifications)
+        .values({
+          userId: input.userId,
+          type: input.type,
+          title: input.title,
+          body: input.body ?? null,
+          data: input.data ?? {},
+        })
+        .returning();
+      return this.toView(row);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to create notification (type=${input.type}, user=${input.userId}): ${msg}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Budget-alert-specific enqueue that dedupes on a synthetic
+   * `thresholdKey` carried in `data` (eg "2026-05:org:80"). Two
+   * concurrent chat calls crossing the same threshold both run
+   * `create` here; the SELECT-then-INSERT race window is small
+   * enough that an occasional duplicate is acceptable — worst case
+   * the user sees one notif row twice. Cheaper than a partial
+   * unique index, simpler than an advisory lock.
+   */
+  async createIfNotExists(input: CreateNotificationInput & {
+    data: Record<string, unknown> & { thresholdKey: string };
+  }): Promise<NotificationView | null> {
+    try {
+      const existing = await this.db
+        .select({ id: notifications.id })
+        .from(notifications)
+        .where(
+          and(
+            eq(notifications.userId, input.userId),
+            eq(notifications.type, input.type),
+            sql`${notifications.data} ->> 'thresholdKey' = ${input.data.thresholdKey}`,
+          ),
+        )
+        .limit(1);
+      if (existing.length > 0) return null;
+      return await this.create(input);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to dedupe notification (type=${input.type}, user=${input.userId}, threshold=${input.data.thresholdKey}): ${msg}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Default list: pending + acted (recent), newest first, capped at
+   * 50. Dismissed rows are filtered out entirely — they're meant to
+   * disappear from the user's view. Recipients only — callers never
+   * peek at someone else's inbox.
+   */
+  async findForUser(userId: string): Promise<NotificationView[]> {
+    const rows = await this.db
+      .select()
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.userId, userId),
+          sql`${notifications.status} != 'dismissed'`,
+        ),
+      )
+      .orderBy(desc(notifications.createdAt))
+      .limit(50);
+    return rows.map((r) => this.toView(r));
+  }
+
+  /**
+   * Unread count = pending OR acted with read_at IS NULL. Drives
+   * the sidebar badge.
+   */
+  async unreadCount(userId: string): Promise<number> {
+    const [row] = await this.db
+      .select({ count: sql<number>`cast(count(*) as int)` })
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.userId, userId),
+          sql`${notifications.status} != 'dismissed'`,
+          isNull(notifications.readAt),
+        ),
+      );
+    return row?.count ?? 0;
+  }
+
+  async markRead(id: string, userId: string): Promise<NotificationView> {
+    const [row] = await this.db
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(
+        and(eq(notifications.id, id), eq(notifications.userId, userId)),
+      )
+      .returning();
+    if (!row) throw new NotFoundException('Notification not found');
+    return this.toView(row);
+  }
+
+  async markAllRead(userId: string): Promise<{ markedCount: number }> {
+    const rows = await this.db
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(
+        and(
+          eq(notifications.userId, userId),
+          isNull(notifications.readAt),
+        ),
+      )
+      .returning({ id: notifications.id });
+    return { markedCount: rows.length };
+  }
+
+  async dismiss(id: string, userId: string): Promise<{ id: string }> {
+    const [row] = await this.db
+      .update(notifications)
+      .set({ status: 'dismissed' })
+      .where(
+        and(eq(notifications.id, id), eq(notifications.userId, userId)),
+      )
+      .returning({ id: notifications.id });
+    if (!row) throw new NotFoundException('Notification not found');
+    return row;
+  }
+
+  /**
+   * Look up a notification scoped to the caller. Throws 404 if it
+   * doesn't exist or belongs to someone else.
+   */
+  async getForCaller(id: string, userId: string) {
+    const [row] = await this.db
+      .select()
+      .from(notifications)
+      .where(
+        and(eq(notifications.id, id), eq(notifications.userId, userId)),
+      );
+    if (!row) throw new NotFoundException('Notification not found');
+    return row;
+  }
+
+  /**
+   * Flip a notification to status='acted'. Used by the
+   * controller after delegating the real accept/decline work
+   * (which lives in the owning service — TeamsService for team
+   * invites) so business logic stays where it already is.
+   */
+  async markActed(id: string, userId: string): Promise<void> {
+    await this.db
+      .update(notifications)
+      .set({ status: 'acted', readAt: new Date() })
+      .where(
+        and(eq(notifications.id, id), eq(notifications.userId, userId)),
+      );
+  }
+
+  /**
+   * Decline a team invite — revoke the pending team_members row so
+   * the inviter sees the decline reflected in their pending list,
+   * then flip the notification to 'acted'. The invitee acts on
+   * their own row here; no team-owner gate (it's their inbox).
+   */
+  async declineTeamInvite(id: string, userId: string): Promise<{ ok: true }> {
+    const row = await this.getForCaller(id, userId);
+    if (row.status !== 'pending') {
+      throw new BadRequestException(
+        'This notification has already been resolved.',
+      );
+    }
+    if (row.type !== 'team_invite') {
+      throw new BadRequestException(
+        `Notifications of type '${row.type}' don't support Decline.`,
+      );
+    }
+    const data = (row.data ?? {}) as Record<string, unknown>;
+    const memberId = typeof data.memberId === 'string' ? data.memberId : null;
+    if (memberId) {
+      // Revoke the pending team_members row directly — keeps the
+      // existing row shape (status='pending', invitationStatus=
+      // 'revoked') the inviter sees in their pending-list UI.
+      await this.db
+        .update(teamMembers)
+        .set({
+          invitationStatus: 'revoked',
+          invitationRevokedAt: new Date(),
+          invitationToken: null,
+        })
+        .where(eq(teamMembers.id, memberId));
+    }
+    await this.markActed(id, userId);
+    return { ok: true };
+  }
+
+  /**
+   * Resolve the set of users who should receive a team-budget
+   * alert: team owner + every accepted member with role='admin'.
+   * Used by the chat-transport budget gates.
+   */
+  async getTeamBudgetRecipients(teamId: string): Promise<string[]> {
+    const ownerRow = await this.db
+      .select({ ownerId: teams.ownerId })
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+    const owner = ownerRow[0]?.ownerId;
+    const adminRows = await this.db
+      .select({ userId: teamMembers.userId })
+      .from(teamMembers)
+      .where(
+        and(
+          eq(teamMembers.teamId, teamId),
+          eq(teamMembers.role, 'admin'),
+          eq(teamMembers.status, 'accepted'),
+        ),
+      );
+    const set = new Set<string>();
+    if (owner) set.add(owner);
+    for (const r of adminRows) {
+      if (r.userId) set.add(r.userId);
+    }
+    return Array.from(set);
+  }
+
+  /**
+   * Resolve the set of users who should receive an org-budget
+   * alert: every accepted org admin. Multi-tenant scoping uses the
+   * caller's company_name so we don't page admins of other tenants.
+   */
+  async getOrgBudgetRecipients(callerUserId: string): Promise<string[]> {
+    const callerRow = await this.db
+      .select({ companyName: users.companyName })
+      .from(users)
+      .where(eq(users.id, callerUserId))
+      .limit(1);
+    const companyName = callerRow[0]?.companyName ?? null;
+    if (!companyName) return [];
+    const rows = await this.db
+      .select({ id: users.id })
+      .from(users)
+      .where(
+        and(
+          eq(users.role, 'admin'),
+          eq(users.companyName, companyName),
+        ),
+      );
+    return rows.map((r) => r.id);
+  }
+
+  private toView(row: typeof notifications.$inferSelect): NotificationView {
+    return {
+      id: row.id,
+      type: row.type as NotificationType,
+      title: row.title,
+      body: row.body,
+      data: (row.data ?? {}) as Record<string, unknown>,
+      status: row.status as NotificationStatus,
+      readAt: row.readAt ? row.readAt.toISOString() : null,
+      createdAt: row.createdAt.toISOString(),
+    };
+  }
+}

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -23,7 +23,8 @@ import { DATABASE, type Database } from '../database/database.module.js';
 export type NotificationType =
   | 'team_invite'
   | 'org_invite'
-  | 'budget_alert';
+  | 'budget_alert'
+  | 'budget_changed';
 
 export type NotificationStatus = 'pending' | 'acted' | 'dismissed';
 

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -25,7 +25,8 @@ export type NotificationType =
   | 'org_invite'
   | 'budget_alert'
   | 'budget_changed'
-  | 'team_renamed';
+  | 'team_renamed'
+  | 'team_role_changed';
 
 export type NotificationStatus = 'pending' | 'acted' | 'dismissed';
 

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import {
   notifications,
   teamMembers,
@@ -307,8 +307,9 @@ export class NotificationsService {
 
   /**
    * Resolve the set of users who should receive a team-budget
-   * alert: team owner + every accepted member with role='admin'.
-   * Used by the chat-transport budget gates.
+   * alert: team owner + every accepted member with role='admin'
+   * or role='manager' (the owner-equivalent set). Used by the
+   * chat-transport budget gates.
    */
   async getTeamBudgetRecipients(teamId: string): Promise<string[]> {
     const ownerRow = await this.db
@@ -323,7 +324,7 @@ export class NotificationsService {
       .where(
         and(
           eq(teamMembers.teamId, teamId),
-          eq(teamMembers.role, 'admin'),
+          inArray(teamMembers.role, ['admin', 'manager']),
           eq(teamMembers.status, 'accepted'),
         ),
       );

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -26,7 +26,14 @@ export type NotificationType =
   | 'budget_alert'
   | 'budget_changed'
   | 'team_renamed'
-  | 'team_role_changed';
+  | 'team_role_changed'
+  | 'team_member_added'
+  | 'team_member_removed'
+  | 'team_deleted'
+  | 'account_role_changed'
+  | 'account_budget_changed'
+  | 'member_cap_changed'
+  | 'file_ingestion_failed';
 
 export type NotificationStatus = 'pending' | 'acted' | 'dismissed';
 

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -24,7 +24,8 @@ export type NotificationType =
   | 'team_invite'
   | 'org_invite'
   | 'budget_alert'
-  | 'budget_changed';
+  | 'budget_changed'
+  | 'team_renamed';
 
 export type NotificationStatus = 'pending' | 'acted' | 'dismissed';
 
@@ -270,6 +271,38 @@ export class NotificationsService {
     }
     await this.markActed(id, userId);
     return { ok: true };
+  }
+
+  /**
+   * Resolve the set of users who should receive a team-wide
+   * informational notification (rename, generic announcements):
+   * team owner + every accepted member regardless of role.
+   * Distinct from `getTeamBudgetRecipients` which is narrower
+   * (owner + admin only) because budget signals are management-
+   * oriented, not member-oriented.
+   */
+  async getTeamMembers(teamId: string): Promise<string[]> {
+    const ownerRow = await this.db
+      .select({ ownerId: teams.ownerId })
+      .from(teams)
+      .where(eq(teams.id, teamId))
+      .limit(1);
+    const owner = ownerRow[0]?.ownerId;
+    const memberRows = await this.db
+      .select({ userId: teamMembers.userId })
+      .from(teamMembers)
+      .where(
+        and(
+          eq(teamMembers.teamId, teamId),
+          eq(teamMembers.status, 'accepted'),
+        ),
+      );
+    const set = new Set<string>();
+    if (owner) set.add(owner);
+    for (const r of memberRows) {
+      if (r.userId) set.add(r.userId);
+    }
+    return Array.from(set);
   }
 
   /**

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -30,6 +30,7 @@ import {
 import { DATABASE, type Database } from '../database/database.module.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
 import { KnowledgeIngestionService } from '../knowledge-core/knowledge-ingestion.service.js';
+import { sha256File } from '../knowledge-core/knowledge-core.service.js';
 
 type ProfileType = 'company' | 'personal';
 type InfraChoice = 'managed' | 'on-premise';
@@ -235,6 +236,7 @@ export class OnboardingService {
       fileType: string;
       storagePath: string;
       sizeBytes: number;
+      contentSha256: string;
     }> = [];
     for (const file of files) {
       const safeName = sanitizeFilename(file.originalname);
@@ -262,6 +264,11 @@ export class OnboardingService {
       // and the /knowledge-core UI treat onboarding uploads identically
       // to ones the user adds later via the dropzone.
       const ext = extname(safeName).replace('.', '').toUpperCase();
+      // Hash here (post-rename, before the DB insert) so the row goes
+      // in with content_sha256 populated. Lets the post-onboarding
+      // upload path detect re-uploads of the same bytes against
+      // onboarding-time files without a backfill pass.
+      const contentSha256 = await sha256File(absolutePath);
       writtenFiles.push({
         // Preserve the original display name (post-sanitize) so the
         // /account page and /knowledge-core list show something the
@@ -272,6 +279,7 @@ export class OnboardingService {
         // dev (Windows) and prod (Linux) without per-OS quirks.
         storagePath: pathPosix.join('uploads/knowledge-core', storedName),
         sizeBytes: file.size,
+        contentSha256,
       });
     }
 

--- a/apps/api/src/org-settings/org-settings.controller.ts
+++ b/apps/api/src/org-settings/org-settings.controller.ts
@@ -44,6 +44,6 @@ export class OrgSettingsController {
         'Only admins can change the company monthly budget.',
       );
     }
-    return this.orgSettings.update(body);
+    return this.orgSettings.update(body, caller.id);
   }
 }

--- a/apps/api/src/org-settings/org-settings.module.ts
+++ b/apps/api/src/org-settings/org-settings.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 import { OrgSettingsController } from './org-settings.controller.js';
 import { OrgSettingsService } from './org-settings.service.js';
 
 @Module({
+  imports: [NotificationsModule],
   controllers: [OrgSettingsController],
   providers: [OrgSettingsService],
   exports: [OrgSettingsService],

--- a/apps/api/src/org-settings/org-settings.service.spec.ts
+++ b/apps/api/src/org-settings/org-settings.service.spec.ts
@@ -21,7 +21,16 @@ function svc() {
       get: () => exploder,
     },
   );
-  return new OrgSettingsService(db as never);
+  return new OrgSettingsService(
+    db as never,
+    // NotificationsService stub — validation tests don't reach the
+    // alert fanout path, but the constructor requires the injection.
+    {
+      getOrgBudgetRecipients: async () => [] as string[],
+      createIfNotExists: async () => null,
+      create: async () => null,
+    } as never,
+  );
 }
 
 describe('OrgSettingsService.update validation', () => {

--- a/apps/api/src/org-settings/org-settings.service.ts
+++ b/apps/api/src/org-settings/org-settings.service.ts
@@ -1,7 +1,8 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
-import { asc, eq, sql } from 'drizzle-orm';
-import { orgSettings } from '@worken/database/schema';
+import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
+import { and, asc, eq, gte, sql } from 'drizzle-orm';
+import { observabilityEvents, orgSettings } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 
 // Postgres advisory lock key for the singleton seed. Constant on
 // purpose — every fetchOrSeed call grabs the same key, so concurrent
@@ -26,7 +27,12 @@ export interface OrgSettingsView {
 
 @Injectable()
 export class OrgSettingsService {
-  constructor(@Inject(DATABASE) private readonly db: Database) {}
+  private readonly logger = new Logger(OrgSettingsService.name);
+
+  constructor(
+    @Inject(DATABASE) private readonly db: Database,
+    private readonly notifications: NotificationsService,
+  ) {}
 
   /**
    * Singleton getter: returns the oldest row, lazy-seeding an empty
@@ -37,12 +43,18 @@ export class OrgSettingsService {
     return toView(await this.fetchOrSeed());
   }
 
-  async update(input: {
-    /** undefined → leave the saved value alone; null → clear the
-     *  target back to "no enforcement"; integer → save (0 suspends,
-     *  >0 enforces). */
-    monthlyBudgetCents?: number | null;
-  }): Promise<OrgSettingsView> {
+  async update(
+    input: {
+      /** undefined → leave the saved value alone; null → clear the
+       *  target back to "no enforcement"; integer → save (0 suspends,
+       *  >0 enforces). */
+      monthlyBudgetCents?: number | null;
+    },
+    /** Caller user id, used to resolve company-scoped admin
+     *  recipients for the budget-threshold notifications fired when
+     *  a lowered cap suddenly puts the company past 80% / 100%. */
+    callerUserId?: string,
+  ): Promise<OrgSettingsView> {
     // Validate before any DB call so the BadRequest path stays tight
     // and testable from a stub.
     const updates: Record<string, unknown> = { updatedAt: new Date() };
@@ -63,7 +75,102 @@ export class OrgSettingsService {
       .update(orgSettings)
       .set(updates)
       .where(eq(orgSettings.id, current.id));
+
+    // Proactive threshold check after admin-driven budget change.
+    // Same shape as TeamsService.updateBudget — fires when the new
+    // cap puts existing month-to-date spend at or past 80% / 100%
+    // without anyone making a fresh chat call.
+    if (
+      callerUserId &&
+      typeof input.monthlyBudgetCents === 'number' &&
+      input.monthlyBudgetCents > 0
+    ) {
+      await this.checkAndAlertOrgBudgetThresholds(
+        callerUserId,
+        input.monthlyBudgetCents,
+      );
+    }
+
     return this.getCurrent();
+  }
+
+  /**
+   * Mirror of TeamsService.checkAndAlertTeamBudgetThresholds for the
+   * org-wide budget: re-evaluates current-month spend against the
+   * freshly-saved cap and enqueues notifs for every company admin
+   * if the new cap puts the org past a threshold. Best-effort —
+   * a notification failure must not abort the budget save.
+   */
+  private async checkAndAlertOrgBudgetThresholds(
+    callerUserId: string,
+    budgetCents: number,
+  ): Promise<void> {
+    try {
+      const [agg] = await this.db
+        .select({
+          total: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)`,
+        })
+        .from(observabilityEvents)
+        .where(
+          and(
+            eq(observabilityEvents.success, true),
+            gte(observabilityEvents.createdAt, sql`date_trunc('month', now())`),
+          ),
+        );
+      const spentUsd = agg ? parseFloat(agg.total) : 0;
+      const spentCents = Math.round(spentUsd * 100);
+      const eightyPct = Math.floor(budgetCents * 0.8);
+
+      const now = new Date();
+      const periodKey = `${now.getUTCFullYear()}-${String(
+        now.getUTCMonth() + 1,
+      ).padStart(2, '0')}`;
+
+      const recipients =
+        await this.notifications.getOrgBudgetRecipients(callerUserId);
+      const fanout = async (
+        threshold: 80 | 100,
+        title: string,
+        body: string,
+      ) => {
+        await Promise.allSettled(
+          recipients.map((userId) =>
+            this.notifications.createIfNotExists({
+              userId,
+              type: 'budget_alert',
+              title,
+              body,
+              data: {
+                scope: 'org',
+                threshold,
+                budgetCents,
+                spentCents,
+                thresholdKey: `${periodKey}:org:${threshold}`,
+              },
+            }),
+          ),
+        );
+      };
+
+      if (spentCents >= budgetCents) {
+        await fanout(
+          100,
+          `Your company is over its monthly AI budget`,
+          `Spent ~$${(spentCents / 100).toFixed(2)} of $${(budgetCents / 100).toFixed(2)}. The new cap is already exceeded — chat is blocked until it's raised or next month resets.`,
+        );
+      } else if (spentCents >= eightyPct) {
+        await fanout(
+          80,
+          `Your company has used 80% of its monthly AI budget`,
+          `Spent ~$${(spentCents / 100).toFixed(2)} of $${(budgetCents / 100).toFixed(2)}.`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to evaluate org-budget threshold alerts: ${msg}`,
+      );
+    }
   }
 
   private async fetchOrSeed() {

--- a/apps/api/src/org-settings/org-settings.service.ts
+++ b/apps/api/src/org-settings/org-settings.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
 import { and, asc, eq, gte, sql } from 'drizzle-orm';
-import { observabilityEvents, orgSettings } from '@worken/database/schema';
+import { observabilityEvents, orgSettings, users } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { NotificationsService } from '../notifications/notifications.service.js';
 
@@ -91,7 +91,76 @@ export class OrgSettingsService {
       );
     }
 
+    // Info-only 'budget_changed' announcement for every company
+    // admin minus the caller. Independent of threshold alerts —
+    // every actual value change drops a row so the inbox doubles
+    // as a lightweight audit trail. Skipped when the cap is left
+    // alone or rewritten to the same value.
+    if (
+      callerUserId &&
+      input.monthlyBudgetCents !== undefined &&
+      input.monthlyBudgetCents !== current.monthlyBudgetCents
+    ) {
+      await this.announceOrgBudgetChange(
+        callerUserId,
+        current.monthlyBudgetCents,
+        input.monthlyBudgetCents,
+      );
+    }
+
     return this.getCurrent();
+  }
+
+  /**
+   * Fan out a 'budget_changed' info-only notification for the org
+   * budget. Recipients = every company admin minus the caller.
+   * Best-effort, never throws.
+   *
+   * `previousCents` / `nextCents` can be null when the cap toggles
+   * between "no target" and a concrete value — formatted as
+   * "(no target)" so the body still reads naturally.
+   */
+  private async announceOrgBudgetChange(
+    callerUserId: string,
+    previousCents: number | null,
+    nextCents: number | null,
+  ): Promise<void> {
+    try {
+      const recipients = (
+        await this.notifications.getOrgBudgetRecipients(callerUserId)
+      ).filter((id) => id !== callerUserId);
+      if (recipients.length === 0) return;
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'An admin';
+      const fmt = (c: number | null) =>
+        c === null ? '(no target)' : `$${(c / 100).toFixed(2)}`;
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'budget_changed',
+            title: `Company monthly AI budget was changed`,
+            body: `${fmt(previousCents)} → ${fmt(nextCents)}. Set by ${actorName}.`,
+            data: {
+              scope: 'org',
+              previousCents,
+              nextCents,
+              actorId: callerUserId,
+              actorName,
+            },
+          }),
+        ),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce org-budget change: ${msg}`,
+      );
+    }
   }
 
   /**

--- a/apps/api/src/org-settings/org-settings.service.ts
+++ b/apps/api/src/org-settings/org-settings.service.ts
@@ -113,8 +113,9 @@ export class OrgSettingsService {
 
   /**
    * Fan out a 'budget_changed' info-only notification for the org
-   * budget. Recipients = every company admin minus the caller.
-   * Best-effort, never throws.
+   * budget. Recipients = every company admin INCLUDING the caller,
+   * so the actor also gets a row in their own inbox as an audit
+   * trail of changes they made. Best-effort, never throws.
    *
    * `previousCents` / `nextCents` can be null when the cap toggles
    * between "no target" and a concrete value — formatted as
@@ -126,9 +127,8 @@ export class OrgSettingsService {
     nextCents: number | null,
   ): Promise<void> {
     try {
-      const recipients = (
-        await this.notifications.getOrgBudgetRecipients(callerUserId)
-      ).filter((id) => id !== callerUserId);
+      const recipients =
+        await this.notifications.getOrgBudgetRecipients(callerUserId);
       if (recipients.length === 0) return;
       const [actor] = await this.db
         .select({ name: users.name, email: users.email })

--- a/apps/api/src/projects/project-knowledge.service.ts
+++ b/apps/api/src/projects/project-knowledge.service.ts
@@ -242,6 +242,7 @@ export class ProjectKnowledgeService {
       folderId?: string;
       visibility?: string;
       teamIds?: string[];
+      projectIds?: string[];
     },
   ): Promise<{
     uploaded: Array<{ id: string; name: string; ingestionStatus: string }>;
@@ -265,6 +266,7 @@ export class ProjectKnowledgeService {
       files,
       options.visibility,
       options.teamIds,
+      options.projectIds,
     );
 
     // Auto-attach every successful upload to this project. The

--- a/apps/api/src/projects/project-knowledge.service.ts
+++ b/apps/api/src/projects/project-knowledge.service.ts
@@ -1,0 +1,418 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import {
+  knowledgeFiles,
+  knowledgeFileTeams,
+  knowledgeFolders,
+  projectKnowledgeFiles,
+  projects,
+  teamMembers,
+  teams,
+} from '@worken/database/schema';
+import { DATABASE, type Database } from '../database/database.module.js';
+import { KnowledgeCoreService } from '../knowledge-core/knowledge-core.service.js';
+
+/**
+ * Default KC folder that Manage Context uploads land in when the
+ * user doesn't pick a target. Auto-created on first upload per
+ * user — kept as a name string here (not an env / config) so the
+ * folder lives in the user's KC like any other folder.
+ */
+const DEFAULT_PROJECTS_FOLDER_NAME = 'Projects';
+
+/**
+ * Compact shape returned by the attach-list endpoint. Carries the
+ * info Manage Context needs to render a row (name, type, badges,
+ * status) without forcing a follow-up to /knowledge-core.
+ */
+export interface ProjectKnowledgeFileView {
+  fileId: string;
+  name: string;
+  fileType: string | null;
+  sizeBytes: number;
+  folderId: string;
+  folderName: string;
+  visibility: string;
+  ingestionStatus: string;
+  ingestionError: string | null;
+  teams: Array<{ id: string; name: string }>;
+  attachedAt: string;
+}
+
+@Injectable()
+export class ProjectKnowledgeService {
+  private readonly logger = new Logger(ProjectKnowledgeService.name);
+
+  constructor(
+    @Inject(DATABASE) private readonly db: Database,
+    private readonly knowledgeCore: KnowledgeCoreService,
+  ) {}
+
+  /**
+   * Project access gate shared by all the methods below. Mirrors
+   * the existing rule on chat: any team member can read a team
+   * project; personal projects are owner-only. Throws 404 on
+   * non-existent or denied to keep info leakage minimal.
+   */
+  private async assertProjectAccess(
+    projectId: string,
+    userId: string,
+  ): Promise<{ teamId: string | null; userId: string }> {
+    const [project] = await this.db
+      .select({ userId: projects.userId, teamId: projects.teamId })
+      .from(projects)
+      .where(eq(projects.id, projectId));
+    if (!project) {
+      throw new NotFoundException(`Project ${projectId} not found`);
+    }
+    if (project.teamId) {
+      const [membership] = await this.db
+        .select({ id: teamMembers.id })
+        .from(teamMembers)
+        .where(
+          and(
+            eq(teamMembers.teamId, project.teamId),
+            eq(teamMembers.userId, userId),
+            eq(teamMembers.status, 'accepted'),
+          ),
+        )
+        .limit(1);
+      const isOwner = project.userId === userId;
+      const [team] = await this.db
+        .select({ ownerId: teams.ownerId })
+        .from(teams)
+        .where(eq(teams.id, project.teamId))
+        .limit(1);
+      const isTeamOwner = team?.ownerId === userId;
+      if (!isOwner && !isTeamOwner && !membership) {
+        throw new NotFoundException(`Project ${projectId} not found`);
+      }
+    } else if (project.userId !== userId) {
+      throw new NotFoundException(`Project ${projectId} not found`);
+    }
+    return { teamId: project.teamId, userId: project.userId };
+  }
+
+  /**
+   * KC files currently attached to this project. Used by the Manage
+   * Context dialog to render the unified document list and by the
+   * chat layer to know which KC chunks to mix into RAG context.
+   */
+  async listAttached(
+    projectId: string,
+    callerId: string,
+  ): Promise<ProjectKnowledgeFileView[]> {
+    await this.assertProjectAccess(projectId, callerId);
+
+    const rows = await this.db
+      .select({
+        fileId: knowledgeFiles.id,
+        name: knowledgeFiles.name,
+        fileType: knowledgeFiles.fileType,
+        sizeBytes: knowledgeFiles.sizeBytes,
+        folderId: knowledgeFiles.folderId,
+        folderName: knowledgeFolders.name,
+        visibility: knowledgeFiles.visibility,
+        ingestionStatus: knowledgeFiles.ingestionStatus,
+        ingestionError: knowledgeFiles.ingestionError,
+        attachedAt: projectKnowledgeFiles.attachedAt,
+      })
+      .from(projectKnowledgeFiles)
+      .innerJoin(
+        knowledgeFiles,
+        eq(knowledgeFiles.id, projectKnowledgeFiles.fileId),
+      )
+      .innerJoin(
+        knowledgeFolders,
+        eq(knowledgeFolders.id, knowledgeFiles.folderId),
+      )
+      .where(eq(projectKnowledgeFiles.projectId, projectId))
+      .orderBy(desc(projectKnowledgeFiles.attachedAt));
+
+    // Hydrate team links per file (only meaningful when
+    // visibility='teams'; safe + empty otherwise).
+    const fileIds = rows.map((r) => r.fileId);
+    const teamLinks = await this.hydrateTeamLinks(fileIds);
+
+    return rows.map((r) => ({
+      ...r,
+      attachedAt: r.attachedAt.toISOString(),
+      teams: teamLinks.get(r.fileId) ?? [],
+    }));
+  }
+
+  /**
+   * Attach an existing set of KC files to the project. Validates
+   * each file is owned by the caller (preventing attach of
+   * someone else's KC file by id-guessing). Idempotent — the
+   * composite PK + ON CONFLICT DO NOTHING swallows duplicates.
+   */
+  async attach(
+    projectId: string,
+    fileIds: string[],
+    callerId: string,
+  ): Promise<{ attached: string[] }> {
+    await this.assertProjectAccess(projectId, callerId);
+    if (!Array.isArray(fileIds) || fileIds.length === 0) {
+      throw new BadRequestException('`fileIds` must be a non-empty array.');
+    }
+    const unique = Array.from(
+      new Set(fileIds.filter((s) => typeof s === 'string' && s.length > 0)),
+    );
+
+    // Caller must own each file. We don't allow attaching someone
+    // else's file via an id even if the caller can technically see
+    // it via team scope — they should re-upload (which goes
+    // through KC's own visibility flow) instead.
+    const owned = await this.db
+      .select({ id: knowledgeFiles.id })
+      .from(knowledgeFiles)
+      .where(
+        and(
+          eq(knowledgeFiles.uploadedById, callerId),
+          inArray(knowledgeFiles.id, unique),
+        ),
+      );
+    const ownedIds = new Set(owned.map((r) => r.id));
+    const denied = unique.filter((id) => !ownedIds.has(id));
+    if (denied.length > 0) {
+      throw new ForbiddenException(
+        'You can only attach knowledge files you uploaded.',
+      );
+    }
+
+    const rows = unique.map((fileId) => ({
+      projectId,
+      fileId,
+      attachedBy: callerId,
+    }));
+    await this.db
+      .insert(projectKnowledgeFiles)
+      .values(rows)
+      .onConflictDoNothing();
+
+    return { attached: unique };
+  }
+
+  /**
+   * Detach a single KC file from the project. The file itself
+   * stays in KC — only the link row is removed.
+   */
+  async detach(
+    projectId: string,
+    fileId: string,
+    callerId: string,
+  ): Promise<{ ok: true }> {
+    await this.assertProjectAccess(projectId, callerId);
+    await this.db
+      .delete(projectKnowledgeFiles)
+      .where(
+        and(
+          eq(projectKnowledgeFiles.projectId, projectId),
+          eq(projectKnowledgeFiles.fileId, fileId),
+        ),
+      );
+    return { ok: true };
+  }
+
+  /**
+   * Upload a file from the Manage Context dialog. Routes through
+   * KnowledgeCoreService.uploadFiles so dedupe + ingestion + team-
+   * visibility validation all match a plain KC upload. After the
+   * insert lands, the resulting file is attached to the project.
+   *
+   * `folderId` is optional — when omitted, we auto-create / reuse
+   * the caller's "Projects" folder so users who don't want to
+   * juggle KC mapping just get a sensible default. Visibility
+   * defaults are decided by the controller (smart default by
+   * project scope) and passed through here verbatim.
+   */
+  async uploadAndAttach(
+    projectId: string,
+    callerId: string,
+    files: Express.Multer.File[],
+    options: {
+      folderId?: string;
+      visibility?: string;
+      teamIds?: string[];
+    },
+  ): Promise<{
+    uploaded: Array<{ id: string; name: string; ingestionStatus: string }>;
+    duplicates: Array<{
+      name: string;
+      existing: { id: string | null; name: string; folderId: string; folderName: string };
+    }>;
+  }> {
+    await this.assertProjectAccess(projectId, callerId);
+    if (files.length === 0) {
+      throw new BadRequestException('Pick at least one file to upload.');
+    }
+
+    const folderId =
+      options.folderId ??
+      (await this.ensureDefaultProjectsFolder(callerId));
+
+    const result = await this.knowledgeCore.uploadFiles(
+      folderId,
+      callerId,
+      files,
+      options.visibility,
+      options.teamIds,
+    );
+
+    // Auto-attach every successful upload to this project. The
+    // dedupe path may flag duplicates against existing KC rows —
+    // those we also attach (`existing.id`) so the user sees them
+    // in Manage Context even if no new file was created.
+    const attachIds: string[] = [];
+    for (const row of result.uploaded) {
+      attachIds.push(row.id);
+    }
+    for (const dup of result.duplicates) {
+      if (dup.existing.id) attachIds.push(dup.existing.id);
+    }
+    if (attachIds.length > 0) {
+      await this.db
+        .insert(projectKnowledgeFiles)
+        .values(
+          Array.from(new Set(attachIds)).map((fileId) => ({
+            projectId,
+            fileId,
+            attachedBy: callerId,
+          })),
+        )
+        .onConflictDoNothing();
+    }
+
+    return {
+      uploaded: result.uploaded.map((u) => ({
+        id: u.id,
+        name: u.name,
+        ingestionStatus: u.ingestionStatus,
+      })),
+      duplicates: result.duplicates,
+    };
+  }
+
+  /**
+   * Look up — or lazily create — the caller's "Projects" KC folder
+   * used as the default upload destination from Manage Context.
+   * Per-user: each user gets their own "Projects" folder under
+   * their own KC; team projects don't share a folder by design
+   * (KC visibility is set per file, not per folder).
+   */
+  private async ensureDefaultProjectsFolder(userId: string): Promise<string> {
+    const [existing] = await this.db
+      .select({ id: knowledgeFolders.id })
+      .from(knowledgeFolders)
+      .where(
+        and(
+          eq(knowledgeFolders.ownerId, userId),
+          eq(knowledgeFolders.name, DEFAULT_PROJECTS_FOLDER_NAME),
+        ),
+      )
+      .limit(1);
+    if (existing) return existing.id;
+
+    const [created] = await this.db
+      .insert(knowledgeFolders)
+      .values({ ownerId: userId, name: DEFAULT_PROJECTS_FOLDER_NAME })
+      .returning({ id: knowledgeFolders.id });
+    return created.id;
+  }
+
+  /**
+   * Visibility "smart default" for the Manage Context upload UI.
+   * Used by the controller to pick a sensible default the user
+   * can still override:
+   *
+   *  - Team project → 'teams' with that project's team pre-
+   *    selected (only members of that team see the file in RAG).
+   *  - Personal project on a company-profile user → 'all' (every
+   *    company user can see it; matches the project's reach since
+   *    chat-time RAG already pulls company-scope KC).
+   *  - Personal project on a personal-profile user → 'all' too
+   *    (no scoping option to differentiate anyway).
+   *
+   * Returns a hint the FE renders as the initial picker state.
+   */
+  async getUploadDefaults(
+    projectId: string,
+    callerId: string,
+  ): Promise<{
+    folderId: string;
+    folderName: string;
+    visibility: 'all' | 'teams';
+    teamIds: string[];
+  }> {
+    const access = await this.assertProjectAccess(projectId, callerId);
+
+    // Folder default → caller's "Projects" folder (lazy-created).
+    const folderId = await this.ensureDefaultProjectsFolder(callerId);
+
+    if (access.teamId) {
+      return {
+        folderId,
+        folderName: DEFAULT_PROJECTS_FOLDER_NAME,
+        visibility: 'teams',
+        teamIds: [access.teamId],
+      };
+    }
+    return {
+      folderId,
+      folderName: DEFAULT_PROJECTS_FOLDER_NAME,
+      visibility: 'all',
+      teamIds: [],
+    };
+  }
+
+  /**
+   * Resolve per-file team-link maps for a batch of file ids. One
+   * round-trip regardless of list size; mirrors the same helper in
+   * KnowledgeCoreService (kept private here to avoid leaking
+   * internal join shape). Empty maps for files not in 'teams' mode.
+   */
+  private async hydrateTeamLinks(
+    fileIds: string[],
+  ): Promise<Map<string, Array<{ id: string; name: string }>>> {
+    const out = new Map<string, Array<{ id: string; name: string }>>();
+    if (fileIds.length === 0) return out;
+    const links = await this.db
+      .select({
+        fileId: knowledgeFileTeams.fileId,
+        teamId: teams.id,
+        teamName: teams.name,
+      })
+      .from(knowledgeFileTeams)
+      .innerJoin(teams, eq(teams.id, knowledgeFileTeams.teamId))
+      .where(inArray(knowledgeFileTeams.fileId, fileIds));
+    for (const link of links) {
+      const arr = out.get(link.fileId) ?? [];
+      arr.push({ id: link.teamId, name: link.teamName });
+      out.set(link.fileId, arr);
+    }
+    return out;
+  }
+
+  /**
+   * Lookup helper used by the chat-time RAG path: list KC file ids
+   * currently attached to a project. Wrapped in a tiny method (vs
+   * the public `listAttached`) so the chat code stays narrow and
+   * doesn't ask for visibility / folder data it doesn't need.
+   */
+  async getAttachedFileIds(projectId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ fileId: projectKnowledgeFiles.fileId })
+      .from(projectKnowledgeFiles)
+      .where(eq(projectKnowledgeFiles.projectId, projectId));
+    return rows.map((r) => r.fileId);
+  }
+}
+

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -1,12 +1,31 @@
-import { Body, Controller, Delete, Get, Param, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  UploadedFiles,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import * as path from 'node:path';
+import { randomUUID } from 'crypto';
 import { ProjectsService } from './projects.service.js';
 import type { CreateProjectDto } from './projects.service.js';
+import { ProjectKnowledgeService } from './project-knowledge.service.js';
 import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
 
 @Controller('projects')
 export class ProjectsController {
-  constructor(private readonly projectsService: ProjectsService) {}
+  constructor(
+    private readonly projectsService: ProjectsService,
+    private readonly projectKnowledge: ProjectKnowledgeService,
+  ) {}
 
   @Get()
   findAll(
@@ -32,5 +51,113 @@ export class ProjectsController {
   @Delete(':id')
   remove(@Param('id') id: string, @CurrentUser() user: AuthenticatedUser) {
     return this.projectsService.remove(id, user.id);
+  }
+
+  /* ─── Project ↔ Knowledge Core links ──────────────────────────── */
+
+  @Get(':id/knowledge-files')
+  listKnowledgeFiles(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.projectKnowledge.listAttached(id, user.id);
+  }
+
+  /**
+   * Smart-default hint for the Manage Context upload dialog. The
+   * FE pre-fills its picker state from this — folder defaults to
+   * the caller's "Projects" KC folder; visibility tracks the
+   * project's scope (team project → 'teams' with team pre-
+   * selected; personal → 'all'). User can override before submit.
+   */
+  @Get(':id/knowledge-files/upload-defaults')
+  uploadDefaults(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.projectKnowledge.getUploadDefaults(id, user.id);
+  }
+
+  @Post(':id/knowledge-files')
+  attachKnowledgeFiles(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() body: { fileIds: string[] },
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.projectKnowledge.attach(id, body?.fileIds ?? [], user.id);
+  }
+
+  @Delete(':id/knowledge-files/:fileId')
+  detachKnowledgeFile(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Param('fileId', new ParseUUIDPipe()) fileId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.projectKnowledge.detach(id, fileId, user.id);
+  }
+
+  /**
+   * Upload one or more files from the Manage Context dialog. Body
+   * is multipart: `files[]` + optional `folderId`, `visibility`,
+   * `teamIds[]`. Routes through KnowledgeCoreService (dedupe +
+   * ingestion + visibility validation) and auto-attaches the
+   * resulting rows to the project.
+   *
+   * Same multer config as the KC upload — disk storage in
+   * uploads/knowledge-core, 50 MB limit, same MIME / ext
+   * allowlist. Inlined here vs sharing because Nest decorators
+   * don't compose across modules cleanly.
+   */
+  @Post(':id/knowledge-files/upload')
+  @UseInterceptors(
+    FilesInterceptor('files', 20, {
+      storage: diskStorage({
+        destination: (_req, _file, cb) =>
+          cb(null, path.join(process.cwd(), 'uploads', 'knowledge-core')),
+        filename: (_req, file, cb) => {
+          const unique = randomUUID();
+          const safe = file.originalname
+            .replace(/[^a-zA-Z0-9_.-]/g, '_')
+            .slice(0, 200);
+          cb(null, `${unique}-${safe}`);
+        },
+      }),
+      limits: { fileSize: 50 * 1024 * 1024 },
+      fileFilter: (_req, file, cb) => {
+        const allowedExt = /\.(pdf|docx|xlsx?|png|jpe?g)$/i;
+        const allowedMime =
+          /^(application\/(pdf|vnd\.openxmlformats|vnd\.ms-excel|octet-stream)|image\/(png|jpe?g))/i;
+        if (
+          !allowedExt.test(file.originalname) ||
+          !allowedMime.test(file.mimetype)
+        ) {
+          cb(new Error(`Unsupported file type: ${file.originalname}`), false);
+          return;
+        }
+        cb(null, true);
+      },
+    }),
+  )
+  uploadKnowledgeFile(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body()
+    body: {
+      folderId?: string;
+      visibility?: string;
+      teamIds?: string | string[];
+    },
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    const teamIds = Array.isArray(body?.teamIds)
+      ? body.teamIds
+      : body?.teamIds
+        ? [body.teamIds]
+        : [];
+    return this.projectKnowledge.uploadAndAttach(id, user.id, files, {
+      folderId: body?.folderId,
+      visibility: body?.visibility,
+      teamIds,
+    });
   }
 }

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -161,6 +161,7 @@ export class ProjectsController {
       folderId?: string;
       visibility?: string;
       teamIds?: string | string[];
+      projectIds?: string | string[];
     },
     @CurrentUser() user: AuthenticatedUser,
   ) {
@@ -169,10 +170,16 @@ export class ProjectsController {
       : body?.teamIds
         ? [body.teamIds]
         : [];
+    const projectIds = Array.isArray(body?.projectIds)
+      ? body.projectIds
+      : body?.projectIds
+        ? [body.projectIds]
+        : [];
     return this.projectKnowledge.uploadAndAttach(id, user.id, files, {
       folderId: body?.folderId,
       visibility: body?.visibility,
       teamIds,
+      projectIds,
     });
   }
 }

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -12,6 +13,7 @@ import {
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'crypto';
 import { ProjectsService } from './projects.service.js';
@@ -19,6 +21,15 @@ import type { CreateProjectDto } from './projects.service.js';
 import { ProjectKnowledgeService } from './project-knowledge.service.js';
 import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
+
+// Shared upload dir with the Knowledge Core controller. Same path,
+// same on-disk shape — uploads from Manage Context land alongside
+// regular KC uploads so the storage_path saved on the row keeps
+// resolving from `uploads/knowledge-core/<uuid>-<name>`. Created
+// once at module load so the first request doesn't race the
+// directory creation.
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads', 'knowledge-core');
+fs.mkdirSync(UPLOAD_DIR, { recursive: true });
 
 @Controller('projects')
 export class ProjectsController {
@@ -112,8 +123,7 @@ export class ProjectsController {
   @UseInterceptors(
     FilesInterceptor('files', 20, {
       storage: diskStorage({
-        destination: (_req, _file, cb) =>
-          cb(null, path.join(process.cwd(), 'uploads', 'knowledge-core')),
+        destination: UPLOAD_DIR,
         filename: (_req, file, cb) => {
           const unique = randomUUID();
           const safe = file.originalname
@@ -131,7 +141,12 @@ export class ProjectsController {
           !allowedExt.test(file.originalname) ||
           !allowedMime.test(file.mimetype)
         ) {
-          cb(new Error(`Unsupported file type: ${file.originalname}`), false);
+          cb(
+            new BadRequestException(
+              `Unsupported file type: ${file.originalname}`,
+            ),
+            false,
+          );
           return;
         }
         cb(null, true);

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
 import { ProjectsController } from './projects.controller.js';
 import { ProjectsService } from './projects.service.js';
+import { ProjectKnowledgeService } from './project-knowledge.service.js';
+import { KnowledgeCoreModule } from '../knowledge-core/knowledge-core.module.js';
 import { NotificationsModule } from '../notifications/notifications.module.js';
 import { TeamsModule } from '../teams/teams.module.js';
 
 @Module({
-  imports: [TeamsModule, NotificationsModule],
+  imports: [TeamsModule, NotificationsModule, KnowledgeCoreModule],
   controllers: [ProjectsController],
-  providers: [ProjectsService],
+  providers: [ProjectsService, ProjectKnowledgeService],
+  exports: [ProjectKnowledgeService],
 })
 export class ProjectsModule {}

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ProjectsController } from './projects.controller.js';
 import { ProjectsService } from './projects.service.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 import { TeamsModule } from '../teams/teams.module.js';
 
 @Module({
-  imports: [TeamsModule],
+  imports: [TeamsModule, NotificationsModule],
   controllers: [ProjectsController],
   providers: [ProjectsService],
 })

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -102,9 +102,9 @@ export class ProjectsService {
   async create(dto: CreateProjectDto, userId: string) {
     if (dto.teamId) {
       const role = await this.teamsService.getUserTeamRole(dto.teamId, userId);
-      if (role !== 'owner' && role !== 'editor') {
+      if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
         throw new ForbiddenException(
-          'Only team owners and editors can create team projects',
+          'Only team owners, admins, or editors can create team projects',
         );
       }
     } else {

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -102,9 +102,14 @@ export class ProjectsService {
   async create(dto: CreateProjectDto, userId: string) {
     if (dto.teamId) {
       const role = await this.teamsService.getUserTeamRole(dto.teamId, userId);
-      if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
+      if (
+        role !== 'owner' &&
+        role !== 'admin' &&
+        role !== 'manager' &&
+        role !== 'editor'
+      ) {
         throw new ForbiddenException(
-          'Only team owners, admins, or editors can create team projects',
+          'Only team owners, admins, managers, or editors can create team projects',
         );
       }
     } else {

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -7,6 +7,7 @@ import {
 import { and, desc, eq, isNull, inArray, or } from 'drizzle-orm';
 import { projects, teams, users } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 import { TeamsService } from '../teams/teams.service.js';
 
 export interface CreateProjectDto {
@@ -21,6 +22,7 @@ export class ProjectsService {
   constructor(
     @Inject(DATABASE) private readonly db: Database,
     private readonly teamsService: TeamsService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   private selectWithTeamName() {
@@ -134,6 +136,19 @@ export class ProjectsService {
         teamId: dto.teamId ?? null,
       })
       .returning();
+
+    // Team transparency: tell every other team member a new project
+    // landed in their workspace. Personal projects have no audience
+    // to ping. Best-effort.
+    if (project.teamId) {
+      await this.announceTeamProjectCreated(
+        project.id,
+        project.name,
+        project.teamId,
+        userId,
+      );
+    }
+
     return project;
   }
 
@@ -151,7 +166,121 @@ export class ProjectsService {
       throw new ForbiddenException('Only the project owner can delete it');
     }
 
+    // Snapshot team scope + name BEFORE the delete so we can resolve
+    // recipients and render the title even after the row is gone.
+    const teamId = project.teamId;
+    const projectName = project.name;
+
     await this.db.delete(projects).where(eq(projects.id, id));
+
+    if (teamId) {
+      await this.announceTeamProjectDeleted(
+        id,
+        projectName,
+        teamId,
+        userId,
+      );
+    }
     return { success: true };
+  }
+
+  /**
+   * Notify every team member (minus the creator) that a new
+   * team-scoped project exists. Best-effort, never throws.
+   */
+  private async announceTeamProjectCreated(
+    projectId: string,
+    projectName: string,
+    teamId: string,
+    creatorUserId: string,
+  ): Promise<void> {
+    try {
+      const [team] = await this.db
+        .select({ name: teams.name })
+        .from(teams)
+        .where(eq(teams.id, teamId))
+        .limit(1);
+      if (!team) return;
+      const [creator] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, creatorUserId))
+        .limit(1);
+      const creatorName =
+        creator?.name || creator?.email || 'A team member';
+      const recipients = (
+        await this.notifications.getTeamMembers(teamId)
+      ).filter((id) => id !== creatorUserId);
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'project_created',
+            title: `${creatorName} created project "${projectName}" in "${team.name}"`,
+            body: null,
+            data: {
+              projectId,
+              projectName,
+              teamId,
+              teamName: team.name,
+              actorId: creatorUserId,
+              actorName: creatorName,
+            },
+          }),
+        ),
+      );
+    } catch {
+      // swallow — never abort the project insert
+    }
+  }
+
+  /**
+   * Notify every team member (minus the deleter) that a project is
+   * gone. Best-effort.
+   */
+  private async announceTeamProjectDeleted(
+    projectId: string,
+    projectName: string,
+    teamId: string,
+    deleterUserId: string,
+  ): Promise<void> {
+    try {
+      const [team] = await this.db
+        .select({ name: teams.name })
+        .from(teams)
+        .where(eq(teams.id, teamId))
+        .limit(1);
+      const teamName = team?.name ?? 'team';
+      const [deleter] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, deleterUserId))
+        .limit(1);
+      const actorName =
+        deleter?.name || deleter?.email || 'A team member';
+      const recipients = (
+        await this.notifications.getTeamMembers(teamId)
+      ).filter((id) => id !== deleterUserId);
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'project_deleted',
+            title: `Project "${projectName}" was deleted from "${teamName}"`,
+            body: `Deleted by ${actorName}.`,
+            data: {
+              projectId,
+              projectName,
+              teamId,
+              teamName,
+              actorId: deleterUserId,
+              actorName,
+            },
+          }),
+        ),
+      );
+    } catch {
+      // swallow
+    }
   }
 }

--- a/apps/api/src/teams/teams.module.ts
+++ b/apps/api/src/teams/teams.module.ts
@@ -1,11 +1,20 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TeamsController } from './teams.controller.js';
 import { TeamsService } from './teams.service.js';
 import { MailModule } from '../mail/mail.module.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 
 @Module({
-  imports: [MailModule, OpenRouterModule],
+  // forwardRef breaks the TeamsModule <-> NotificationsModule cycle —
+  // teams enqueues `team_invite` notifications, notifications calls
+  // back into TeamsService for accept(). Nest resolves the lazy ref
+  // at runtime once both modules are registered.
+  imports: [
+    MailModule,
+    OpenRouterModule,
+    forwardRef(() => NotificationsModule),
+  ],
   controllers: [TeamsController],
   providers: [TeamsService],
   exports: [TeamsService],

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -1149,7 +1149,74 @@ export class TeamsService {
       throw new NotFoundException('Member not found');
     }
 
+    // Tell the affected user their role moved. Skip:
+    //   - rows still on a pending invite (target.userId is null —
+    //     they don't have an account / inbox yet, the email-link
+    //     flow will surface their final role when they accept)
+    //   - self-edits (caller demoting themselves) since they
+    //     pressed Save and already know
+    //   - no-op patches (role unchanged) — would be confusing
+    if (
+      target?.userId &&
+      target.userId !== userId &&
+      target.role !== role
+    ) {
+      await this.announceRoleChange(
+        target.userId,
+        teamId,
+        team.name,
+        target.role,
+        role,
+        userId,
+      );
+    }
+
     return updated;
+  }
+
+  /**
+   * Notify a single team member that their role on a given team
+   * changed. Best-effort — alert failures must not unwind the role
+   * patch above. Used by updateMemberRole; not generalised to
+   * batch since role updates are one row at a time.
+   */
+  private async announceRoleChange(
+    targetUserId: string,
+    teamId: string,
+    teamName: string,
+    previousRole: string,
+    nextRole: string,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'A team manager';
+      const niceRole = (r: string) =>
+        r.charAt(0).toUpperCase() + r.slice(1).toLowerCase();
+      await this.notifications.create({
+        userId: targetUserId,
+        type: 'team_role_changed',
+        title: `Your role in "${teamName}" was changed to ${niceRole(nextRole)}`,
+        body: `${niceRole(previousRole)} → ${niceRole(nextRole)}. Set by ${actorName}.`,
+        data: {
+          teamId,
+          teamName,
+          previousRole,
+          nextRole,
+          actorId: callerUserId,
+          actorName,
+        },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce role change for user ${targetUserId} on team ${teamId}: ${msg}`,
+      );
+    }
   }
 
   async removeMember(teamId: string, memberId: string, userId: string) {

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -282,6 +282,7 @@ export class TeamsService {
     // the block. Owner can raise the budget later to enable.
 
     const budgetCents = Math.round(budgetUsd * 100);
+    const previousBudgetCents = team.monthlyBudgetCents;
     await this.db
       .update(teams)
       .set({ monthlyBudgetCents: budgetCents })
@@ -301,7 +302,74 @@ export class TeamsService {
       );
     }
 
+    // Info-only "budget changed" announcement for owner + admins
+    // (minus the caller — they pressed Save, no need to notify them
+    // about their own action). Independent of threshold alerts:
+    // every actual value change drops a row so the inbox doubles as
+    // a lightweight audit trail. Skipped when the new value equals
+    // the old (no-op patch).
+    if (previousBudgetCents !== budgetCents) {
+      await this.announceTeamBudgetChange(
+        teamId,
+        team.name,
+        previousBudgetCents,
+        budgetCents,
+        userId,
+      );
+    }
+
     return { monthlyBudgetCents: budgetCents };
+  }
+
+  /**
+   * Fan out a 'budget_changed' info-only notification when the team
+   * budget actually moves. Recipients = team owner + admins minus
+   * the caller. Best-effort, never throws.
+   */
+  private async announceTeamBudgetChange(
+    teamId: string,
+    teamName: string,
+    previousCents: number,
+    nextCents: number,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const recipients = (
+        await this.notifications.getTeamBudgetRecipients(teamId)
+      ).filter((id) => id !== callerUserId);
+      if (recipients.length === 0) return;
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'An admin';
+      const fmt = (c: number) => `$${(c / 100).toFixed(2)}`;
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'budget_changed',
+            title: `Team "${teamName}"'s monthly budget was changed`,
+            body: `${fmt(previousCents)} → ${fmt(nextCents)}. Set by ${actorName}.`,
+            data: {
+              scope: 'team',
+              teamId,
+              teamName,
+              previousCents,
+              nextCents,
+              actorId: callerUserId,
+              actorName,
+            },
+          }),
+        ),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce team-budget change for ${teamId}: ${msg}`,
+      );
+    }
   }
 
   /**

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -57,7 +57,11 @@ export class TeamsService {
     // editors of the parent can create children.
     if (parentTeamId) {
       const parentRole = await this.getUserTeamRole(parentTeamId, userId);
-      if (parentRole !== 'owner' && parentRole !== 'editor') {
+      if (
+        parentRole !== 'owner' &&
+        parentRole !== 'admin' &&
+        parentRole !== 'editor'
+      ) {
         throw new ForbiddenException(
           'Only team owners or editors can add subteams',
         );
@@ -137,9 +141,13 @@ export class TeamsService {
       throw new NotFoundException('Team not found');
     }
     const updateCallerRole = await this.getUserTeamRole(teamId, userId);
-    if (updateCallerRole !== 'owner' && updateCallerRole !== 'editor') {
+    if (
+      updateCallerRole !== 'owner' &&
+      updateCallerRole !== 'admin' &&
+      updateCallerRole !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners or editors can update the team',
+        'Only team owners, admins, or editors can update the team',
       );
     }
 
@@ -169,9 +177,13 @@ export class TeamsService {
 
     if (!team) throw new NotFoundException('Team not found');
     const deleteCallerRole = await this.getUserTeamRole(teamId, userId);
-    if (deleteCallerRole !== 'owner' && deleteCallerRole !== 'editor') {
+    if (
+      deleteCallerRole !== 'owner' &&
+      deleteCallerRole !== 'admin' &&
+      deleteCallerRole !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners or editors can delete the team',
+        'Only team owners, admins, or editors can delete the team',
       );
     }
 
@@ -208,8 +220,11 @@ export class TeamsService {
     if (!team) {
       throw new NotFoundException('Team not found');
     }
-    if (team.ownerId !== userId) {
-      throw new ForbiddenException('Only the team owner can update the budget');
+    const budgetCallerRole = await this.getUserTeamRole(teamId, userId);
+    if (!this.hasOwnerRights(budgetCallerRole)) {
+      throw new ForbiddenException(
+        'Only the team owner or a team admin can update the budget',
+      );
     }
 
     // Suspend semantic: budgetUsd === 0 means "block this team from
@@ -366,9 +381,11 @@ export class TeamsService {
         members: membersMap.get(t.id) ?? [],
         spentCents: usage?.spentCents ?? 0,
         projectedCents: usage?.projectedCents ?? 0,
-        // Matches the backend gate for edit/delete/invite/etc: owner or
-        // advanced member. Everyone else sees read-only controls.
-        canManage: isOwner || myRole === 'editor',
+        // Matches the backend gate for edit/delete/invite/etc: owner,
+        // admin, or editor member. Everyone else sees read-only
+        // controls.
+        canManage:
+          isOwner || myRole === 'admin' || myRole === 'editor',
       };
     });
   }
@@ -449,14 +466,26 @@ export class TeamsService {
       throw new NotFoundException('Team not found');
     }
     const callerRole = await this.getUserTeamRole(teamId, userId);
-    if (callerRole !== 'owner' && callerRole !== 'editor') {
+    if (
+      callerRole !== 'owner' &&
+      callerRole !== 'admin' &&
+      callerRole !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners or editors can invite users',
+        'Only team owners, admins, or editors can invite users',
       );
     }
 
-    if (role !== 'editor' && role !== 'viewer') {
-      throw new BadRequestException('Role must be editor or viewer');
+    if (role !== 'admin' && role !== 'editor' && role !== 'viewer') {
+      throw new BadRequestException('Role must be admin, editor, or viewer');
+    }
+    // Promoting an invitee straight to 'admin' is an owner-level
+    // action — editors can invite editors / viewers but can't seed
+    // someone with their own privilege ceiling.
+    if (role === 'admin' && !this.hasOwnerRights(callerRole)) {
+      throw new ForbiddenException(
+        'Only the team owner or a team admin can invite someone as admin',
+      );
     }
 
     if (
@@ -653,8 +682,11 @@ export class TeamsService {
       .from(teams)
       .where(eq(teams.id, teamId));
     if (!team) throw new NotFoundException('Team not found');
-    if (team.ownerId !== userId) {
-      throw new ForbiddenException('Only the team owner can list invitations');
+    const listCallerRole = await this.getUserTeamRole(teamId, userId);
+    if (!this.hasOwnerRights(listCallerRole)) {
+      throw new ForbiddenException(
+        'Only the team owner or a team admin can list invitations',
+      );
     }
 
     const rows = await this.db
@@ -701,8 +733,11 @@ export class TeamsService {
       .where(eq(teamMembers.id, memberId));
 
     if (!row) throw new NotFoundException('Invitation not found');
-    if (row.ownerId !== userId) {
-      throw new ForbiddenException('Only the team owner can revoke invitations');
+    const revokeCallerRole = await this.getUserTeamRole(row.teamId, userId);
+    if (!this.hasOwnerRights(revokeCallerRole)) {
+      throw new ForbiddenException(
+        'Only the team owner or a team admin can revoke invitations',
+      );
     }
     if (row.status === 'accepted') {
       throw new BadRequestException(
@@ -737,16 +772,57 @@ export class TeamsService {
     if (!team) {
       throw new NotFoundException('Team not found');
     }
-    // Owners and editors can update roles; viewers/non-members can't.
+    // Owners, admins, and editors can update roles; viewers / non-
+    // members can't. Promoting someone to / from 'admin' is owner-
+    // level only, enforced below.
     const callerRole = await this.getUserTeamRole(teamId, userId);
-    if (callerRole !== 'owner' && callerRole !== 'editor') {
+    if (
+      callerRole !== 'owner' &&
+      callerRole !== 'admin' &&
+      callerRole !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners or editors can update member roles',
+        'Only team owners, admins, or editors can update member roles',
       );
     }
 
-    if (role !== 'editor' && role !== 'viewer') {
-      throw new BadRequestException('Role must be editor or viewer');
+    if (role !== 'admin' && role !== 'editor' && role !== 'viewer') {
+      throw new BadRequestException('Role must be admin, editor, or viewer');
+    }
+    if (role === 'admin' && !this.hasOwnerRights(callerRole)) {
+      throw new ForbiddenException(
+        'Only the team owner or a team admin can promote someone to admin',
+      );
+    }
+
+    // Always look up the target so we can apply the owner-row guard
+    // below — and so the demote-admin gate has the role to inspect.
+    // Cheap: one indexed PK probe.
+    const [target] = await this.db
+      .select({ userId: teamMembers.userId, role: teamMembers.role })
+      .from(teamMembers)
+      .where(
+        and(
+          eq(teamMembers.id, memberId),
+          eq(teamMembers.teamId, teamId),
+        ),
+      );
+
+    // Owner row is pinned to `team.ownerId`; demoting it would leave
+    // a team with a member row whose role contradicts `teams.owner_id`.
+    // Mirror the removeMember guard so any caller, owner included,
+    // has to transfer ownership before fiddling with this row.
+    if (target?.userId && target.userId === team.ownerId) {
+      throw new BadRequestException(
+        'Cannot change the team owner\'s role. Transfer ownership first.',
+      );
+    }
+
+    // Symmetric guard: demoting an existing admin is also owner-level.
+    if (target?.role === 'admin' && !this.hasOwnerRights(callerRole)) {
+      throw new ForbiddenException(
+        'Only the team owner or a team admin can change another admin\'s role',
+      );
     }
 
     const [updated] = await this.db
@@ -772,9 +848,13 @@ export class TeamsService {
       throw new NotFoundException('Team not found');
     }
     const removeCallerRole = await this.getUserTeamRole(teamId, userId);
-    if (removeCallerRole !== 'owner' && removeCallerRole !== 'editor') {
+    if (
+      removeCallerRole !== 'owner' &&
+      removeCallerRole !== 'admin' &&
+      removeCallerRole !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners or editors can remove members',
+        'Only team owners, admins, or editors can remove members',
       );
     }
 
@@ -786,6 +866,15 @@ export class TeamsService {
 
     if (!member) {
       throw new NotFoundException('Member not found');
+    }
+
+    // Mirror of the demote-admin guard in updateMemberRole: an editor
+    // can't kick an admin out, since admins are owner-equivalent and
+    // editors aren't.
+    if (member.role === 'admin' && !this.hasOwnerRights(removeCallerRole)) {
+      throw new ForbiddenException(
+        'Only the team owner or a team admin can remove another admin',
+      );
     }
 
     if (member.userId === userId) {
@@ -810,7 +899,7 @@ export class TeamsService {
   async getUserTeamRole(
     teamId: string,
     userId: string,
-  ): Promise<'owner' | 'editor' | 'viewer' | null> {
+  ): Promise<'owner' | 'admin' | 'editor' | 'viewer' | null> {
     const [team] = await this.db
       .select()
       .from(teams)
@@ -831,14 +920,35 @@ export class TeamsService {
       );
 
     if (!member) return null;
-    const roleMap: Record<string, 'owner' | 'editor' | 'viewer'> = {
+    // `admin` is the new owner-equivalent member role; legacy
+    // `advanced` / `basic` remain mapped for back-compat with older
+    // rows that haven't been migrated.
+    const roleMap: Record<
+      string,
+      'owner' | 'admin' | 'editor' | 'viewer'
+    > = {
       owner: 'owner',
+      admin: 'admin',
       advanced: 'editor',
       editor: 'editor',
       basic: 'viewer',
       viewer: 'viewer',
     };
     return roleMap[member.role] ?? 'viewer';
+  }
+
+  /**
+   * Owner-level rights: real team owner OR member with role='admin'.
+   * Used for paths previously gated by `team.ownerId !== userId` —
+   * budget, invitations, role promotions. Admin is meant to mirror
+   * owner permissions exactly except they can't be the literal owner
+   * (i.e. they can't be removed as the team's owner — there is only
+   * one of those at any time).
+   */
+  private hasOwnerRights(
+    role: 'owner' | 'admin' | 'editor' | 'viewer' | null,
+  ): boolean {
+    return role === 'owner' || role === 'admin';
   }
 
   async getUserTeamIds(userId: string): Promise<string[]> {
@@ -1373,9 +1483,9 @@ export class TeamsService {
     },
   ): Promise<IntegrationView> {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'editor') {
+    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
       throw new ForbiddenException(
-        'Only team owners or editors can manage team integrations',
+        'Only team owners, admins, or editors can manage team integrations',
       );
     }
     const isCustom = input.providerId === 'custom';
@@ -1513,9 +1623,9 @@ export class TeamsService {
     },
   ): Promise<IntegrationView> {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'editor') {
+    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
       throw new ForbiddenException(
-        'Only team owners or editors can manage team integrations',
+        'Only team owners, admins, or editors can manage team integrations',
       );
     }
     const [row] = await this.db
@@ -1599,9 +1709,9 @@ export class TeamsService {
     integrationId: string,
   ): Promise<{ success: true }> {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'editor') {
+    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
       throw new ForbiddenException(
-        'Only team owners or editors can manage team integrations',
+        'Only team owners, admins, or editors can manage team integrations',
       );
     }
     const [row] = await this.db
@@ -1652,9 +1762,9 @@ export class TeamsService {
     callerId: string,
   ) {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'editor') {
+    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
       throw new ForbiddenException(
-        'Only team owners or editors can set member caps',
+        'Only team owners, admins, or editors can set member caps',
       );
     }
     if (

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -242,6 +242,48 @@ export class TeamsService {
     }
   }
 
+  /**
+   * Fan out a 'team_deleted' notification to a pre-resolved list
+   * of former members. Caller is expected to snapshot the recipient
+   * list BEFORE deleting the team_members rows, since they're gone
+   * after the cascade. Best-effort, never throws.
+   */
+  private async announceTeamDeleted(
+    teamName: string,
+    callerUserId: string,
+    recipients: string[],
+  ): Promise<void> {
+    if (recipients.length === 0) return;
+    try {
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'A team manager';
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'team_deleted',
+            title: `Team "${teamName}" was deleted`,
+            body: `Deleted by ${actorName}.`,
+            data: {
+              teamName,
+              actorId: callerUserId,
+              actorName,
+            },
+          }),
+        ),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce team deletion for "${teamName}": ${msg}`,
+      );
+    }
+  }
+
   async deleteTeam(teamId: string, userId: string) {
     const [team] = await this.db
       .select()
@@ -261,12 +303,24 @@ export class TeamsService {
       );
     }
 
+    // Snapshot the member set BEFORE the cascade — once teamMembers
+    // rows are gone we can't resolve recipients anymore. Excludes
+    // the caller (they pressed Delete).
+    const recipientsToNotify = (
+      await this.notifications.getTeamMembers(teamId)
+    ).filter((id) => id !== userId);
+
     // Remove all members first (cascade should handle this, but be explicit)
     await this.db
       .delete(teamMembers)
       .where(eq(teamMembers.teamId, teamId));
 
     await this.db.delete(teams).where(eq(teams.id, teamId));
+
+    // Tell every former member their team is gone so a stale UI
+    // refetch doesn't read as "membership disappeared, must be a
+    // bug". Best-effort.
+    await this.announceTeamDeleted(team.name, userId, recipientsToNotify);
 
     return { success: true };
   }
@@ -1278,7 +1332,93 @@ export class TeamsService {
       .delete(teamMembers)
       .where(and(eq(teamMembers.id, memberId), eq(teamMembers.teamId, teamId)));
 
+    // Announce the removal. Affected user (the one we just kicked)
+    // gets a direct notif; remaining team members get a heads-up
+    // so they're not surprised when a familiar name disappears.
+    // Skip pending invites (no account-having user to notify) and
+    // self-removal (already blocked above anyway).
+    if (member.userId && member.userId !== userId) {
+      await this.announceMemberRemoved(
+        member.userId,
+        teamId,
+        team.name,
+        userId,
+      );
+    }
+
     return { success: true };
+  }
+
+  /**
+   * Notify the removed user (direct, "you were removed") and the
+   * remaining team members (broadcast, "X was removed from team")
+   * after a successful membership delete. Best-effort, never throws.
+   */
+  private async announceMemberRemoved(
+    removedUserId: string,
+    teamId: string,
+    teamName: string,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'A team manager';
+      const [removed] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, removedUserId))
+        .limit(1);
+      const removedName = removed?.name || removed?.email || 'A team member';
+
+      // 1) Direct notif to the removed user.
+      await this.notifications.create({
+        userId: removedUserId,
+        type: 'team_member_removed',
+        title: `You were removed from "${teamName}"`,
+        body: `Removed by ${actorName}.`,
+        data: {
+          teamId,
+          teamName,
+          actorId: callerUserId,
+          actorName,
+          self: true,
+        },
+      });
+
+      // 2) Broadcast to remaining team members (minus the actor +
+      //    the just-removed user). One row per recipient.
+      const recipients = (
+        await this.notifications.getTeamMembers(teamId)
+      ).filter((id) => id !== callerUserId && id !== removedUserId);
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'team_member_removed',
+            title: `${removedName} was removed from "${teamName}"`,
+            body: `Removed by ${actorName}.`,
+            data: {
+              teamId,
+              teamName,
+              removedUserId,
+              removedName,
+              actorId: callerUserId,
+              actorName,
+              self: false,
+            },
+          }),
+        ),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce removal of ${removedUserId} from team ${teamId}: ${msg}`,
+      );
+    }
   }
 
   async getUserTeamRole(
@@ -1486,7 +1626,62 @@ export class TeamsService {
       .where(eq(teamMembers.id, member.id))
       .returning();
 
+    // Announce the new join to every other existing member so the
+    // team sees who joined. The accepter themselves doesn't need
+    // a notif — they pressed Accept and already know.
+    await this.announceMemberAdded(userId, member.teamId);
+
     return updated;
+  }
+
+  /**
+   * Fan out a 'team_member_added' notification to every existing
+   * accepted team member except the joiner. Resolves the joiner's
+   * display name in one round-trip so the title reads naturally.
+   * Best-effort, never throws.
+   */
+  private async announceMemberAdded(
+    joinerUserId: string,
+    teamId: string,
+  ): Promise<void> {
+    try {
+      const [team] = await this.db
+        .select({ name: teams.name })
+        .from(teams)
+        .where(eq(teams.id, teamId))
+        .limit(1);
+      if (!team) return;
+      const [joiner] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, joinerUserId))
+        .limit(1);
+      const joinerName = joiner?.name || joiner?.email || 'A new member';
+      const recipients = (
+        await this.notifications.getTeamMembers(teamId)
+      ).filter((id) => id !== joinerUserId);
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'team_member_added',
+            title: `${joinerName} joined "${team.name}"`,
+            body: null,
+            data: {
+              teamId,
+              teamName: team.name,
+              joinerUserId,
+              joinerName,
+            },
+          }),
+        ),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce member added for ${joinerUserId} on team ${teamId}: ${msg}`,
+      );
+    }
   }
 
   async findSubteams(parentTeamId: string) {
@@ -2186,6 +2381,21 @@ export class TeamsService {
         'monthlyCapCents must be null or a non-negative integer (cents).',
       );
     }
+    // Snapshot target's previous cap + user id so the notification
+    // can render "$X → $Y" and we know who to ping.
+    const [target] = await this.db
+      .select({
+        userId: teamMembers.userId,
+        monthlyCapCents: teamMembers.monthlyCapCents,
+      })
+      .from(teamMembers)
+      .where(
+        and(
+          eq(teamMembers.id, memberId),
+          eq(teamMembers.teamId, teamId),
+        ),
+      );
+
     const [updated] = await this.db
       .update(teamMembers)
       .set({ monthlyCapCents })
@@ -2202,7 +2412,73 @@ export class TeamsService {
     if (!updated) {
       throw new NotFoundException('Member not found');
     }
+
+    // Notify the affected user about their new cap. Skip:
+    //   - Pending invites (no account)
+    //   - Self-edits (caller adjusted their own cap)
+    //   - No-op (same value)
+    if (
+      target?.userId &&
+      target.userId !== callerId &&
+      target.monthlyCapCents !== monthlyCapCents
+    ) {
+      await this.announceMemberCapChange(
+        target.userId,
+        teamId,
+        target.monthlyCapCents,
+        monthlyCapCents,
+        callerId,
+      );
+    }
+
     return updated;
+  }
+
+  /**
+   * Notify the affected user when an admin moves their per-member
+   * monthly cap on a team. Best-effort, never throws.
+   */
+  private async announceMemberCapChange(
+    targetUserId: string,
+    teamId: string,
+    previousCents: number | null,
+    nextCents: number | null,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const [team] = await this.db
+        .select({ name: teams.name })
+        .from(teams)
+        .where(eq(teams.id, teamId))
+        .limit(1);
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'A team manager';
+      const fmt = (c: number | null) =>
+        c == null ? 'No cap' : `$${(c / 100).toFixed(2)}/mo`;
+      await this.notifications.create({
+        userId: targetUserId,
+        type: 'member_cap_changed',
+        title: `Your cap on "${team?.name ?? 'team'}" was set to ${fmt(nextCents)}`,
+        body: `${fmt(previousCents)} → ${fmt(nextCents)}. Set by ${actorName}.`,
+        data: {
+          teamId,
+          teamName: team?.name ?? null,
+          previousCents,
+          nextCents,
+          actorId: callerUserId,
+          actorName,
+        },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce member cap change for ${targetUserId} on team ${teamId}: ${msg}`,
+      );
+    }
   }
 
   /**

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  forwardRef,
   ForbiddenException,
   Inject,
   Injectable,
@@ -26,6 +27,7 @@ import {
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { MailService } from '../mail/mail.service.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
 import { OpenRouterProvisioningService } from '../openrouter/openrouter-provisioning.service.js';
 import {
@@ -43,6 +45,10 @@ export class TeamsService {
     private readonly mailService: MailService,
     private readonly provisioningService: OpenRouterProvisioningService,
     private readonly encryptionService: EncryptionService,
+    // forwardRef matches the module-level cycle break — see
+    // TeamsModule for the matching forwardRef on NotificationsModule.
+    @Inject(forwardRef(() => NotificationsService))
+    private readonly notifications: NotificationsService,
   ) {}
 
   async create(
@@ -281,7 +287,109 @@ export class TeamsService {
       .set({ monthlyBudgetCents: budgetCents })
       .where(eq(teams.id, teamId));
 
+    // Proactive threshold check after admin-driven budget change.
+    // Mirrors the chat-transport gate's logic but triggers off the
+    // ADMIN ACTION instead of a chat call — handles the case where
+    // lowering the cap suddenly puts the team past 80% / 100%
+    // without anyone making a call. Fire-and-forget; alert failures
+    // never abort the budget update.
+    if (budgetCents > 0) {
+      await this.checkAndAlertTeamBudgetThresholds(
+        teamId,
+        team.name,
+        budgetCents,
+      );
+    }
+
     return { monthlyBudgetCents: budgetCents };
+  }
+
+  /**
+   * After a team-budget patch lands, compute the team's current-month
+   * spend and enqueue 80% / 100% notifications if the NEW cap puts
+   * the team at or past those thresholds. Idempotent via the
+   * thresholdKey carried in `data` — re-running for the same
+   * (team, threshold, month) is a no-op.
+   *
+   * Kept private + best-effort: any failure here logs but never
+   * throws, so a flaky notification path can't break the budget
+   * update itself.
+   */
+  private async checkAndAlertTeamBudgetThresholds(
+    teamId: string,
+    teamName: string,
+    budgetCents: number,
+  ): Promise<void> {
+    try {
+      const [agg] = await this.db
+        .select({
+          total: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)`,
+        })
+        .from(observabilityEvents)
+        .where(
+          and(
+            eq(observabilityEvents.teamId, teamId),
+            eq(observabilityEvents.success, true),
+            gte(observabilityEvents.createdAt, sql`date_trunc('month', now())`),
+          ),
+        );
+      const spentUsd = agg ? parseFloat(agg.total) : 0;
+      const spentCents = Math.round(spentUsd * 100);
+      const eightyPct = Math.floor(budgetCents * 0.8);
+
+      const now = new Date();
+      const periodKey = `${now.getUTCFullYear()}-${String(
+        now.getUTCMonth() + 1,
+      ).padStart(2, '0')}`;
+
+      const recipients = await this.notifications.getTeamBudgetRecipients(
+        teamId,
+      );
+      const fanout = async (
+        threshold: 80 | 100,
+        title: string,
+        body: string,
+      ) => {
+        await Promise.allSettled(
+          recipients.map((userId) =>
+            this.notifications.createIfNotExists({
+              userId,
+              type: 'budget_alert',
+              title,
+              body,
+              data: {
+                scope: 'team',
+                teamId,
+                teamName,
+                threshold,
+                budgetCents,
+                spentCents,
+                thresholdKey: `${periodKey}:team:${teamId}:${threshold}`,
+              },
+            }),
+          ),
+        );
+      };
+
+      if (spentCents >= budgetCents) {
+        await fanout(
+          100,
+          `Team "${teamName}" is over its monthly budget`,
+          `Spent ~$${(spentCents / 100).toFixed(2)} of $${(budgetCents / 100).toFixed(2)}. The new cap is already exceeded — chat is blocked until you raise it or next month resets.`,
+        );
+      } else if (spentCents >= eightyPct) {
+        await fanout(
+          80,
+          `Team "${teamName}" has used 80% of its monthly budget`,
+          `Spent ~$${(spentCents / 100).toFixed(2)} of $${(budgetCents / 100).toFixed(2)}.`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to evaluate budget-threshold alerts for team ${teamId}: ${msg}`,
+      );
+    }
   }
 
   async findAllForUser(userId: string) {
@@ -578,6 +686,26 @@ export class TeamsService {
         this.logger.error(`Failed to resend invitation email: ${msg}`);
       }
 
+      // In-app companion to the email, only for invitees who already
+      // have an account (new users can't see the inbox until they
+      // sign up — they get the email link instead).
+      if (existingUser) {
+        await this.notifications.create({
+          userId: existingUser.id,
+          type: 'team_invite',
+          title: `You're invited to ${team.name}`,
+          body: `${inviterName} invited you as ${role}.`,
+          data: {
+            teamId,
+            teamName: team.name,
+            inviterName,
+            role,
+            invitationToken: token,
+            memberId: refreshed.id,
+          },
+        });
+      }
+
       return { ...refreshed, resent: true };
     }
 
@@ -671,6 +799,26 @@ export class TeamsService {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.error(`Failed to send invitation email: ${msg}`);
+    }
+
+    // Mirror the email with an in-app notification, but only for
+    // invitees who already have an account — new-user invitees
+    // can't see the bell yet, they get the email link only.
+    if (existingUser) {
+      await this.notifications.create({
+        userId: existingUser.id,
+        type: 'team_invite',
+        title: `You're invited to ${team.name}`,
+        body: `${inviterName} invited you as ${role}.`,
+        data: {
+          teamId,
+          teamName: team.name,
+          inviterName,
+          role,
+          invitationToken: token,
+          memberId: member.id,
+        },
+      });
     }
 
     return { ...member, resent: false };

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -66,10 +66,11 @@ export class TeamsService {
       if (
         parentRole !== 'owner' &&
         parentRole !== 'admin' &&
+        parentRole !== 'manager' &&
         parentRole !== 'editor'
       ) {
         throw new ForbiddenException(
-          'Only team owners or editors can add subteams',
+          'Only team owners, admins, managers, or editors can add subteams',
         );
       }
     }
@@ -150,10 +151,11 @@ export class TeamsService {
     if (
       updateCallerRole !== 'owner' &&
       updateCallerRole !== 'admin' &&
+      updateCallerRole !== 'manager' &&
       updateCallerRole !== 'editor'
     ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can update the team',
+        'Only team owners, admins, managers, or editors can update the team',
       );
     }
 
@@ -251,10 +253,11 @@ export class TeamsService {
     if (
       deleteCallerRole !== 'owner' &&
       deleteCallerRole !== 'admin' &&
+      deleteCallerRole !== 'manager' &&
       deleteCallerRole !== 'editor'
     ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can delete the team',
+        'Only team owners, admins, managers, or editors can delete the team',
       );
     }
 
@@ -622,11 +625,14 @@ export class TeamsService {
         members: membersMap.get(t.id) ?? [],
         spentCents: usage?.spentCents ?? 0,
         projectedCents: usage?.projectedCents ?? 0,
-        // Matches the backend gate for edit/delete/invite/etc: owner,
-        // admin, or editor member. Everyone else sees read-only
-        // controls.
+        // Matches the backend gate for edit/delete/invite/etc:
+        // owner, admin, manager, or editor member. Everyone else
+        // sees read-only controls.
         canManage:
-          isOwner || myRole === 'admin' || myRole === 'editor',
+          isOwner ||
+          myRole === 'admin' ||
+          myRole === 'manager' ||
+          myRole === 'editor',
       };
     });
   }
@@ -710,22 +716,33 @@ export class TeamsService {
     if (
       callerRole !== 'owner' &&
       callerRole !== 'admin' &&
+      callerRole !== 'manager' &&
       callerRole !== 'editor'
     ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can invite users',
+        'Only team owners, admins, managers, or editors can invite users',
       );
     }
 
-    if (role !== 'admin' && role !== 'editor' && role !== 'viewer') {
-      throw new BadRequestException('Role must be admin, editor, or viewer');
+    if (
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor' &&
+      role !== 'viewer'
+    ) {
+      throw new BadRequestException(
+        'Role must be admin, manager, editor, or viewer',
+      );
     }
-    // Promoting an invitee straight to 'admin' is an owner-level
-    // action — editors can invite editors / viewers but can't seed
-    // someone with their own privilege ceiling.
-    if (role === 'admin' && !this.hasOwnerRights(callerRole)) {
+    // Promoting an invitee straight to 'admin' / 'manager' is an
+    // owner-level action — editors can invite editors / viewers but
+    // can't seed someone with their own privilege ceiling.
+    if (
+      (role === 'admin' || role === 'manager') &&
+      !this.hasOwnerRights(callerRole)
+    ) {
       throw new ForbiddenException(
-        'Only the team owner or a team admin can invite someone as admin',
+        'Only the team owner, admin, or manager can invite someone as admin or manager',
       );
     }
 
@@ -1053,32 +1070,43 @@ export class TeamsService {
     if (!team) {
       throw new NotFoundException('Team not found');
     }
-    // Owners, admins, and editors can update roles; viewers / non-
-    // members can't. Promoting someone to / from 'admin' is owner-
-    // level only, enforced below.
+    // Owners, admins, managers, and editors can update roles;
+    // viewers / non-members can't. Promoting someone to / from
+    // 'admin' or 'manager' is owner-level only, enforced below.
     const callerRole = await this.getUserTeamRole(teamId, userId);
     if (
       callerRole !== 'owner' &&
       callerRole !== 'admin' &&
+      callerRole !== 'manager' &&
       callerRole !== 'editor'
     ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can update member roles',
+        'Only team owners, admins, managers, or editors can update member roles',
       );
     }
 
-    if (role !== 'admin' && role !== 'editor' && role !== 'viewer') {
-      throw new BadRequestException('Role must be admin, editor, or viewer');
+    if (
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor' &&
+      role !== 'viewer'
+    ) {
+      throw new BadRequestException(
+        'Role must be admin, manager, editor, or viewer',
+      );
     }
-    if (role === 'admin' && !this.hasOwnerRights(callerRole)) {
+    if (
+      (role === 'admin' || role === 'manager') &&
+      !this.hasOwnerRights(callerRole)
+    ) {
       throw new ForbiddenException(
-        'Only the team owner or a team admin can promote someone to admin',
+        'Only the team owner, admin, or manager can promote someone to admin or manager',
       );
     }
 
     // Always look up the target so we can apply the owner-row guard
-    // below — and so the demote-admin gate has the role to inspect.
-    // Cheap: one indexed PK probe.
+    // below — and so the demote-admin/manager gate has the role to
+    // inspect. Cheap: one indexed PK probe.
     const [target] = await this.db
       .select({ userId: teamMembers.userId, role: teamMembers.role })
       .from(teamMembers)
@@ -1099,10 +1127,15 @@ export class TeamsService {
       );
     }
 
-    // Symmetric guard: demoting an existing admin is also owner-level.
-    if (target?.role === 'admin' && !this.hasOwnerRights(callerRole)) {
+    // Symmetric guard: demoting an existing admin / manager is also
+    // owner-level — keeps editors from kicking admins/managers down
+    // a tier.
+    if (
+      (target?.role === 'admin' || target?.role === 'manager') &&
+      !this.hasOwnerRights(callerRole)
+    ) {
       throw new ForbiddenException(
-        'Only the team owner or a team admin can change another admin\'s role',
+        'Only the team owner, admin, or manager can change another admin or manager\'s role',
       );
     }
 
@@ -1132,10 +1165,11 @@ export class TeamsService {
     if (
       removeCallerRole !== 'owner' &&
       removeCallerRole !== 'admin' &&
+      removeCallerRole !== 'manager' &&
       removeCallerRole !== 'editor'
     ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can remove members',
+        'Only team owners, admins, managers, or editors can remove members',
       );
     }
 
@@ -1149,12 +1183,15 @@ export class TeamsService {
       throw new NotFoundException('Member not found');
     }
 
-    // Mirror of the demote-admin guard in updateMemberRole: an editor
-    // can't kick an admin out, since admins are owner-equivalent and
-    // editors aren't.
-    if (member.role === 'admin' && !this.hasOwnerRights(removeCallerRole)) {
+    // Mirror of the demote-admin/manager guard in updateMemberRole:
+    // an editor can't kick an admin or manager out, since both are
+    // owner-equivalent.
+    if (
+      (member.role === 'admin' || member.role === 'manager') &&
+      !this.hasOwnerRights(removeCallerRole)
+    ) {
       throw new ForbiddenException(
-        'Only the team owner or a team admin can remove another admin',
+        'Only the team owner, admin, or manager can remove another admin or manager',
       );
     }
 
@@ -1180,7 +1217,7 @@ export class TeamsService {
   async getUserTeamRole(
     teamId: string,
     userId: string,
-  ): Promise<'owner' | 'admin' | 'editor' | 'viewer' | null> {
+  ): Promise<'owner' | 'admin' | 'manager' | 'editor' | 'viewer' | null> {
     const [team] = await this.db
       .select()
       .from(teams)
@@ -1201,15 +1238,18 @@ export class TeamsService {
       );
 
     if (!member) return null;
-    // `admin` is the new owner-equivalent member role; legacy
-    // `advanced` / `basic` remain mapped for back-compat with older
+    // `admin` and `manager` are both owner-equivalent member roles —
+    // `manager` was added so admins can delegate operational tasks
+    // without conflating with the higher "admin" connotation in copy.
+    // Legacy `advanced` / `basic` map for back-compat with older
     // rows that haven't been migrated.
     const roleMap: Record<
       string,
-      'owner' | 'admin' | 'editor' | 'viewer'
+      'owner' | 'admin' | 'manager' | 'editor' | 'viewer'
     > = {
       owner: 'owner',
       admin: 'admin',
+      manager: 'manager',
       advanced: 'editor',
       editor: 'editor',
       basic: 'viewer',
@@ -1219,17 +1259,18 @@ export class TeamsService {
   }
 
   /**
-   * Owner-level rights: real team owner OR member with role='admin'.
+   * Owner-level rights: real team owner OR member with role='admin'
+   * or role='manager' (both treated as owner-equivalent per product
+   * decision — manager is a label distinction, not a rights one).
    * Used for paths previously gated by `team.ownerId !== userId` —
-   * budget, invitations, role promotions. Admin is meant to mirror
-   * owner permissions exactly except they can't be the literal owner
-   * (i.e. they can't be removed as the team's owner — there is only
-   * one of those at any time).
+   * budget, invitations, role promotions. None of these roles can
+   * be the literal team owner row; that one is pinned to
+   * `teams.owner_id` and must be transferred to change.
    */
   private hasOwnerRights(
-    role: 'owner' | 'admin' | 'editor' | 'viewer' | null,
+    role: 'owner' | 'admin' | 'manager' | 'editor' | 'viewer' | null,
   ): boolean {
-    return role === 'owner' || role === 'admin';
+    return role === 'owner' || role === 'admin' || role === 'manager';
   }
 
   async getUserTeamIds(userId: string): Promise<string[]> {
@@ -1764,9 +1805,14 @@ export class TeamsService {
     },
   ): Promise<IntegrationView> {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
+    if (
+      role !== 'owner' &&
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can manage team integrations',
+        'Only team owners, admins, managers, or editors can manage team integrations',
       );
     }
     const isCustom = input.providerId === 'custom';
@@ -1904,9 +1950,14 @@ export class TeamsService {
     },
   ): Promise<IntegrationView> {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
+    if (
+      role !== 'owner' &&
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can manage team integrations',
+        'Only team owners, admins, managers, or editors can manage team integrations',
       );
     }
     const [row] = await this.db
@@ -1990,9 +2041,14 @@ export class TeamsService {
     integrationId: string,
   ): Promise<{ success: true }> {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
+    if (
+      role !== 'owner' &&
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can manage team integrations',
+        'Only team owners, admins, managers, or editors can manage team integrations',
       );
     }
     const [row] = await this.db
@@ -2043,9 +2099,14 @@ export class TeamsService {
     callerId: string,
   ) {
     const role = await this.getUserTeamRole(teamId, callerId);
-    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
+    if (
+      role !== 'owner' &&
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor'
+    ) {
       throw new ForbiddenException(
-        'Only team owners, admins, or editors can set member caps',
+        'Only team owners, admins, managers, or editors can set member caps',
       );
     }
     if (

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -172,7 +172,72 @@ export class TeamsService {
       .where(eq(teams.id, teamId))
       .returning();
 
+    // Info-only rename announcement to every accepted member +
+    // owner, minus the caller. Fires only when the name actually
+    // changed (typing `name` into the patch with the same value
+    // shouldn't ping the team). Best-effort — alert failures must
+    // not abort the team update.
+    if (
+      data.name !== undefined &&
+      data.name !== team.name &&
+      data.name.trim().length > 0
+    ) {
+      await this.announceTeamRename(
+        teamId,
+        team.name,
+        data.name,
+        userId,
+      );
+    }
+
     return updated;
+  }
+
+  /**
+   * Fan out a 'team_renamed' info-only notification to every
+   * accepted member + owner of the team, minus the caller who
+   * made the change. Best-effort, never throws.
+   */
+  private async announceTeamRename(
+    teamId: string,
+    previousName: string,
+    nextName: string,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const recipients = (
+        await this.notifications.getTeamMembers(teamId)
+      ).filter((id) => id !== callerUserId);
+      if (recipients.length === 0) return;
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'A team manager';
+      await Promise.allSettled(
+        recipients.map((userId) =>
+          this.notifications.create({
+            userId,
+            type: 'team_renamed',
+            title: `Team "${previousName}" was renamed to "${nextName}"`,
+            body: `Renamed by ${actorName}.`,
+            data: {
+              teamId,
+              previousName,
+              nextName,
+              actorId: callerUserId,
+              actorName,
+            },
+          }),
+        ),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to announce team rename for ${teamId}: ${msg}`,
+      );
+    }
   }
 
   async deleteTeam(teamId: string, userId: string) {

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -48,6 +48,7 @@ describe('UsersController auth gates', () => {
       {} as never, // teamsService — unused by the gated endpoints
       {} as never, // mailService
       {} as never, // observabilityService
+      {} as never, // notificationsService — unused by these gates
     );
   }
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -235,7 +235,65 @@ export class UsersController {
         'Only admins can change another user\'s monthly budget. Company-profile basic users wait for admin approval; everyone else can self-update.',
       );
     }
-    return this.usersService.updateBudget(id, body.budgetUsd);
+    // Snapshot previous budget so the notif can render "$X → $Y".
+    const [prev] = await this.db
+      .select({ monthlyBudgetCents: users.monthlyBudgetCents })
+      .from(users)
+      .where(eq(users.id, id));
+    const result = await this.usersService.updateBudget(id, body.budgetUsd);
+    // Only fire when admin updates someone else's budget. Self-
+    // updates are silent — the user pressed Save, no reason to
+    // ping their own inbox.
+    if (
+      caller.id !== id &&
+      prev &&
+      prev.monthlyBudgetCents !== result.monthlyBudgetCents
+    ) {
+      await this.notifyAccountBudgetChange(
+        id,
+        prev.monthlyBudgetCents,
+        result.monthlyBudgetCents,
+        caller.id,
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Drop a 'account_budget_changed' notification for the affected
+   * user after an admin-driven budget patch. Resolves the actor's
+   * display name in one round-trip. Best-effort.
+   */
+  private async notifyAccountBudgetChange(
+    targetUserId: string,
+    previousCents: number | null,
+    nextCents: number | null,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'An admin';
+      const fmt = (c: number | null) =>
+        c == null ? '$0.00' : `$${(c / 100).toFixed(2)}`;
+      await this.notifications.create({
+        userId: targetUserId,
+        type: 'account_budget_changed',
+        title: `Your monthly AI budget was set to ${fmt(nextCents)}`,
+        body: `${fmt(previousCents)} → ${fmt(nextCents)}. Set by ${actorName}.`,
+        data: {
+          previousCents,
+          nextCents,
+          actorId: callerUserId,
+          actorName,
+        },
+      });
+    } catch {
+      // swallow — notif failures must not unwind the budget update
+    }
   }
 
   @Patch(':id/role')
@@ -264,7 +322,53 @@ export class UsersController {
         'You cannot change your own role. Ask another admin to do it.',
       );
     }
-    return this.usersService.updateRole(id, body.role);
+    const [prev] = await this.db
+      .select({ role: users.role })
+      .from(users)
+      .where(eq(users.id, id));
+    const result = await this.usersService.updateRole(id, body.role);
+    if (prev && prev.role !== result.role) {
+      await this.notifyAccountRoleChange(id, prev.role, result.role, caller.id);
+    }
+    return result;
+  }
+
+  /**
+   * Drop a 'account_role_changed' notification for the affected
+   * user after an admin-driven org-role patch. Cheap one-row
+   * insert; best-effort so a notif failure doesn't unwind the
+   * role update.
+   */
+  private async notifyAccountRoleChange(
+    targetUserId: string,
+    previousRole: string,
+    nextRole: string,
+    callerUserId: string,
+  ): Promise<void> {
+    try {
+      const [actor] = await this.db
+        .select({ name: users.name, email: users.email })
+        .from(users)
+        .where(eq(users.id, callerUserId))
+        .limit(1);
+      const actorName = actor?.name || actor?.email || 'An admin';
+      const nice = (r: string) =>
+        r.charAt(0).toUpperCase() + r.slice(1).toLowerCase();
+      await this.notifications.create({
+        userId: targetUserId,
+        type: 'account_role_changed',
+        title: `Your organization role was changed to ${nice(nextRole)}`,
+        body: `${nice(previousRole)} → ${nice(nextRole)}. Set by ${actorName}.`,
+        data: {
+          previousRole,
+          nextRole,
+          actorId: callerUserId,
+          actorName,
+        },
+      });
+    } catch {
+      // swallow — notif failures never abort the role patch
+    }
   }
 
   @Delete(':id')

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -241,14 +241,11 @@ export class UsersController {
       .from(users)
       .where(eq(users.id, id));
     const result = await this.usersService.updateBudget(id, body.budgetUsd);
-    // Only fire when admin updates someone else's budget. Self-
-    // updates are silent — the user pressed Save, no reason to
-    // ping their own inbox.
-    if (
-      caller.id !== id &&
-      prev &&
-      prev.monthlyBudgetCents !== result.monthlyBudgetCents
-    ) {
+    // Fire on every actual value change — including self-updates,
+    // so the inbox doubles as an audit trail of who set what when.
+    // The actor / target relationship is preserved in the notif body
+    // ("Set by <actorName>") so a self-update reads naturally too.
+    if (prev && prev.monthlyBudgetCents !== result.monthlyBudgetCents) {
       await this.notifyAccountBudgetChange(
         id,
         prev.monthlyBudgetCents,

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -20,6 +20,7 @@ import { eq } from 'drizzle-orm';
 import { users } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { MailService } from '../mail/mail.service.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 import { ObservabilityService } from '../observability/observability.service.js';
 
 @Controller('users')
@@ -30,6 +31,7 @@ export class UsersController {
     private readonly teamsService: TeamsService,
     private readonly mailService: MailService,
     private readonly observabilityService: ObservabilityService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   @Get()
@@ -167,6 +169,22 @@ export class UsersController {
       if (Object.keys(patch).length > 0) {
         await this.db.update(users).set(patch).where(eq(users.id, existing.id));
       }
+      // Existing user re-invited / role updated — surface it in
+      // their inbox so they know what changed. Info-only; no
+      // Accept/Decline since the role flip already happened.
+      await this.notifications.create({
+        userId: existing.id,
+        type: 'org_invite',
+        title: `${inviterName} updated your access to ${
+          inviterCompany ?? 'the workspace'
+        }`,
+        body: `Your role is now ${body.role}.`,
+        data: {
+          role: body.role,
+          companyName: inviterCompany ?? null,
+          inviterName,
+        },
+      });
       return { status: 'updated', email, role: body.role };
     }
 

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller.js';
 import { UsersService } from './users.service.js';
 import { MailModule } from '../mail/mail.module.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 import { OpenRouterModule } from '../openrouter/openrouter.module.js';
 import { TeamsModule } from '../teams/teams.module.js';
 
 @Module({
-  imports: [MailModule, OpenRouterModule, TeamsModule],
+  imports: [MailModule, NotificationsModule, OpenRouterModule, TeamsModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException,
   ServiceUnavailableException,
 } from '@nestjs/common';
-import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import { and, eq, gte, inArray, isNull, or, sql } from 'drizzle-orm';
 import {
   users,
   teamMembers,
@@ -20,10 +20,12 @@ import {
   knowledgeFolders,
   knowledgeFiles,
   modelConfigs,
+  observabilityEvents,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
 import { OpenRouterProvisioningService } from '../openrouter/openrouter-provisioning.service.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 
 @Injectable()
 export class UsersService {
@@ -33,6 +35,7 @@ export class UsersService {
     @Inject(DATABASE) private readonly db: Database,
     private readonly provisioningService: OpenRouterProvisioningService,
     private readonly encryptionService: EncryptionService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   /**
@@ -355,7 +358,94 @@ export class UsersService {
       .set({ monthlyBudgetCents: budgetCents })
       .where(eq(users.id, userId));
 
+    // Mirror teams.service.checkAndAlertTeamBudgetThresholds — when
+    // the new personal cap puts the user at / past 80% or 100% of
+    // month-to-date spend, drop a budget_alert in their inbox. Fire-
+    // and-forget so a flaky notification path can't block the save.
+    void this.checkAndAlertUserBudgetThresholds(userId, budgetCents);
+
     return { monthlyBudgetCents: budgetCents };
+  }
+
+  /**
+   * After a personal-budget patch lands, sum the user's month-to-date
+   * spend (observability_events) and fire 80% / 100% budget_alert
+   * notifications if the new cap already lands them past those
+   * thresholds. Idempotent via the thresholdKey in `data` — re-running
+   * for the same (user, threshold, month) is a no-op thanks to
+   * NotificationsService.createIfNotExists.
+   *
+   * Recipient = the affected user; they're the one whose chat is
+   * about to be blocked. Best-effort: any failure logs but never
+   * throws.
+   */
+  private async checkAndAlertUserBudgetThresholds(
+    userId: string,
+    budgetCents: number,
+  ): Promise<void> {
+    if (budgetCents <= 0) return;
+    try {
+      const [agg] = await this.db
+        .select({
+          total: sql<string>`coalesce(sum(${observabilityEvents.costUsd}), 0)`,
+        })
+        .from(observabilityEvents)
+        .where(
+          and(
+            eq(observabilityEvents.userId, userId),
+            eq(observabilityEvents.success, true),
+            gte(observabilityEvents.createdAt, sql`date_trunc('month', now())`),
+          ),
+        );
+      const spentUsd = agg ? parseFloat(agg.total) : 0;
+      const spentCents = Math.round(spentUsd * 100);
+      const eightyPct = Math.floor(budgetCents * 0.8);
+
+      const now = new Date();
+      const periodKey = `${now.getUTCFullYear()}-${String(
+        now.getUTCMonth() + 1,
+      ).padStart(2, '0')}`;
+
+      const fire = async (
+        threshold: 80 | 100,
+        title: string,
+        body: string,
+      ) => {
+        await this.notifications.createIfNotExists({
+          userId,
+          type: 'budget_alert',
+          title,
+          body,
+          data: {
+            scope: 'user',
+            userId,
+            threshold,
+            budgetCents,
+            spentCents,
+            thresholdKey: `${periodKey}:user:${userId}:${threshold}`,
+          },
+        });
+      };
+
+      if (spentCents >= budgetCents) {
+        await fire(
+          100,
+          `You are over your monthly AI budget`,
+          `Spent ~$${(spentCents / 100).toFixed(2)} of $${(budgetCents / 100).toFixed(2)}. The new cap is already exceeded — chat is blocked until it's raised or next month resets.`,
+        );
+      } else if (spentCents >= eightyPct) {
+        await fire(
+          80,
+          `You've used 80% of your monthly AI budget`,
+          `Spent ~$${(spentCents / 100).toFixed(2)} of $${(budgetCents / 100).toFixed(2)}.`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to evaluate budget-threshold alerts for user ${userId}: ${msg}`,
+      );
+    }
   }
 
   /**

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -270,6 +270,7 @@ export class UsersService {
         canManage:
           callerOwnedIds.has(m.teamId) ||
           callerRoleByTeam.get(m.teamId) === 'admin' ||
+          callerRoleByTeam.get(m.teamId) === 'manager' ||
           callerRoleByTeam.get(m.teamId) === 'editor',
       })),
       createdAt: user.createdAt,

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -269,6 +269,7 @@ export class UsersService {
         status: m.status,
         canManage:
           callerOwnedIds.has(m.teamId) ||
+          callerRoleByTeam.get(m.teamId) === 'admin' ||
           callerRoleByTeam.get(m.teamId) === 'editor',
       })),
       createdAt: user.createdAt,

--- a/apps/web/src/app/(app)/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(app)/(dashboard)/layout.tsx
@@ -1,14 +1,10 @@
-import { Footer } from "@/components/layout";
-
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <>
-      {children}
-      <Footer />
-    </>
-  );
+  // Footer used to live here, but it now ships from the global app
+  // layout so every authed page gets the same bottom row instead of
+  // just the dashboard.
+  return <>{children}</>;
 }

--- a/apps/web/src/app/(app)/(dashboard)/page.tsx
+++ b/apps/web/src/app/(app)/(dashboard)/page.tsx
@@ -8,9 +8,6 @@ import {
   MoreVertical,
   Trash2,
   ArrowRight,
-  Clock,
-  DollarSign,
-  TrendingUp,
   Calendar,
   Loader2,
   FileText,
@@ -41,7 +38,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AddDocumentDialog } from "@/components/add-document-dialog";
 import { useAuth } from "@/components/providers";
-import { fetchProjects, deleteProject, type Project } from "@/lib/api";
+import {
+  fetchProjects,
+  deleteProject,
+  fetchArenaRuns,
+  type Project,
+  type ArenaRunSummary,
+} from "@/lib/api";
 import { useAvailableModels } from "@/lib/hooks/use-available-models";
 
 function formatDate(dateStr: string) {
@@ -50,6 +53,44 @@ function formatDate(dateStr: string) {
     day: "numeric",
     year: "numeric",
   });
+}
+
+/**
+ * Relative time string for arena history cards. Falls back to a
+ * formatted date once the row is older than a week.
+ */
+function relativeShort(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "Just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day === 1) return "Yesterday";
+  if (day < 7) return `${day}d ago`;
+  return formatDate(iso);
+}
+
+/**
+ * 2-character avatar derived from a model identifier. Matches the
+ * hardcoded "G4 / C3 / L3" style of the original mock: take the
+ * model family (after the slash) and grab the first letter + first
+ * digit if present, else the first two letters.
+ *
+ * Examples:
+ *  - "anthropic/claude-3-opus" → "C3"
+ *  - "openai/gpt-4o"           → "G4"
+ *  - "meta-llama/llama-3-70b"  → "L3"
+ *  - "mistralai/mistral-large" → "MI"
+ */
+function modelAvatar(modelId: string): string {
+  const tail = modelId.split("/").pop() ?? modelId;
+  const compact = tail.replace(/[^a-zA-Z0-9]/g, "");
+  const firstLetter = compact.match(/[a-zA-Z]/)?.[0] ?? "?";
+  const firstDigit = compact.match(/\d/)?.[0];
+  if (firstDigit) return (firstLetter + firstDigit).toUpperCase();
+  return compact.slice(0, 2).toUpperCase() || "??";
 }
 
 function ProjectCard({ project }: { project: Project }) {
@@ -195,6 +236,15 @@ export default function WorkenDashboard() {
   const canCreateProject = user?.canCreateProject;
   const allLoading = activeTab === "all" ? (teamLoading || personalLoading) : isLoading;
 
+  // Recent arena runs power the comparisons section below. Capped
+  // to a small batch — the dashboard only renders the top 3 cards,
+  // and the full history lives on /compare-models.
+  const { data: arenaRuns = [], isLoading: arenaRunsLoading } = useQuery({
+    queryKey: ["arena-runs"],
+    queryFn: fetchArenaRuns,
+  });
+  const recentRuns = arenaRuns.slice(0, 3);
+
   return (
     <div className="space-y-6 pt-4">
       {/* All tab: two-column layout */}
@@ -317,91 +367,124 @@ export default function WorkenDashboard() {
       )}
 
       {/* Comparisons Section */}
-      <div className="border-t border-border-2 pt-8">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold tracking-tight text-text-1">
-            Recent Model Comparisons
-          </h2>
+      <RecentComparisons runs={recentRuns} loading={arenaRunsLoading} />
+    </div>
+  );
+}
+
+/**
+ * Recent model-arena history strip. Renders up to three of the
+ * user's last comparison runs as cards with model avatars +
+ * question excerpt + relative time. Cards link straight back to
+ * /compare-models — once that page supports a `?run=<id>` query
+ * param this can deep-link directly to a loaded run.
+ *
+ * Loading + empty states match the rest of the dashboard so the
+ * section doesn't visually pop when there's no data yet.
+ */
+function RecentComparisons({
+  runs,
+  loading,
+}: {
+  runs: ArenaRunSummary[];
+  loading: boolean;
+}) {
+  return (
+    <div className="border-t border-border-2 pt-8">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold tracking-tight text-text-1">
+          Recent Model Comparisons
+        </h2>
+        <Link
+          href="/compare-models"
+          className="flex items-center gap-1 text-sm font-medium text-primary-6 hover:text-primary-7"
+        >
+          View all
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center rounded-xl border border-border-2 bg-bg-white py-10 shadow-sm">
+          <Loader2 className="h-5 w-5 animate-spin text-text-3" />
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-border-2 bg-bg-white py-10 text-center shadow-sm">
+          <p className="text-sm text-text-3">
+            No comparisons yet. Run one in the Arena to compare
+            models side-by-side.
+          </p>
           <Link
-            href="#"
-            className="flex items-center gap-1 text-sm font-medium text-primary-6 hover:text-primary-7"
+            href="/compare-models"
+            className="inline-flex items-center gap-1 text-sm font-medium text-primary-6 hover:text-primary-7"
           >
-            View all
+            Open Arena
             <ArrowRight className="h-3.5 w-3.5" />
           </Link>
         </div>
-
+      ) : (
         <div className="overflow-hidden rounded-xl border border-border-2 bg-bg-white shadow-sm">
-          <div className="grid grid-cols-1 divide-y divide-border-2 md:grid-cols-3 md:divide-x md:divide-y-0">
-            {/* Comparison Item 1 */}
-            <div className="group cursor-pointer p-4 transition-colors hover:bg-bg-1">
-              <div className="mb-2 flex items-center gap-2">
-                <div className="flex -space-x-1.5">
-                  <div className="z-10 flex h-6 w-6 items-center justify-center rounded-full border border-border-2 bg-bg-white text-[8px] font-bold text-text-1 shadow-sm">
-                    G4
-                  </div>
-                  <div className="flex h-6 w-6 items-center justify-center rounded-full border border-border-2 bg-bg-white text-[8px] font-bold text-text-1 shadow-sm">
-                    C3
-                  </div>
+          {/* Stretch one card to full width when there's just 1 run,
+              two columns at 2 runs, three at 3+. Keeps the grid
+              visually balanced regardless of count. */}
+          <div
+            className={`grid grid-cols-1 divide-y divide-border-2 md:divide-x md:divide-y-0 ${
+              runs.length === 1
+                ? "md:grid-cols-1"
+                : runs.length === 2
+                  ? "md:grid-cols-2"
+                  : "md:grid-cols-3"
+            }`}
+          >
+            {runs.map((run) => (
+              <Link
+                key={run.id}
+                href="/compare-models"
+                className="group block cursor-pointer p-4 transition-colors hover:bg-bg-1"
+              >
+                <div className="mb-2 flex items-center gap-2">
+                  {run.models.length > 0 && (
+                    <div className="flex -space-x-1.5">
+                      {run.models.slice(0, 3).map((m, idx) => (
+                        <div
+                          key={m}
+                          title={m}
+                          style={{ zIndex: 10 - idx }}
+                          className="relative flex h-6 w-6 items-center justify-center rounded-full border border-border-2 bg-bg-white text-[8px] font-bold text-text-1 shadow-sm"
+                        >
+                          {modelAvatar(m)}
+                        </div>
+                      ))}
+                      {run.models.length > 3 && (
+                        <div
+                          title={run.models.slice(3).join(", ")}
+                          className="relative flex h-6 w-6 items-center justify-center rounded-full border border-border-2 bg-bg-1 text-[8px] font-bold text-text-2 shadow-sm"
+                        >
+                          +{run.models.length - 3}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  <span className="text-xs font-medium text-text-2">
+                    {run.models.length === 1
+                      ? "1 model"
+                      : `${run.models.length} models`}
+                  </span>
                 </div>
-                <span className="text-xs font-medium text-text-2">
-                  vs. Baseline
-                </span>
-              </div>
-              <h4 className="text-sm font-medium text-text-1 transition-colors group-hover:text-primary-6">
-                Legal Contract Summary
-              </h4>
-              <div className="mt-3 flex items-center gap-4 text-xs text-text-2">
-                <span className="flex items-center gap-1">
-                  <Clock className="h-3 w-3" /> 0.4s faster
-                </span>
-                <span className="flex items-center gap-1">
-                  <DollarSign className="h-3 w-3" /> $0.02 saved
-                </span>
-              </div>
-            </div>
-
-            {/* Comparison Item 2 */}
-            <div className="group cursor-pointer p-4 transition-colors hover:bg-bg-1">
-              <div className="mb-2 flex items-center gap-2">
-                <div className="flex -space-x-1.5">
-                  <div className="z-10 flex h-6 w-6 items-center justify-center rounded-full border border-border-2 bg-bg-white text-[8px] font-bold text-text-1 shadow-sm">
-                    L3
-                  </div>
-                  <div className="flex h-6 w-6 items-center justify-center rounded-full border border-border-2 bg-bg-white text-[8px] font-bold text-text-1 shadow-sm">
-                    M
-                  </div>
+                <h4 className="line-clamp-2 text-sm font-medium text-text-1 transition-colors group-hover:text-primary-6">
+                  {run.question}
+                </h4>
+                <div className="mt-3 flex items-center gap-4 text-xs text-text-2">
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3 w-3" />
+                    {relativeShort(run.createdAt)}
+                  </span>
                 </div>
-              </div>
-              <h4 className="text-sm font-medium text-text-1 transition-colors group-hover:text-primary-6">
-                Python Code Gen Accuracy
-              </h4>
-              <div className="mt-3 flex items-center gap-4 text-xs text-text-2">
-                <span className="flex items-center gap-1 text-success-7">
-                  <TrendingUp className="h-3 w-3" /> 12% better
-                </span>
-              </div>
-            </div>
-
-            {/* Comparison Item 3 */}
-            <div className="group cursor-pointer p-4 transition-colors hover:bg-bg-1">
-              <div className="mb-2 flex items-center gap-2">
-                <span className="text-xs font-medium text-text-3">
-                  Benchmark Test
-                </span>
-              </div>
-              <h4 className="text-sm font-medium text-text-1 transition-colors group-hover:text-primary-6">
-                Customer Sentiment Analysis
-              </h4>
-              <div className="mt-3 flex items-center gap-4 text-xs text-text-2">
-                <span className="flex items-center gap-1">
-                  <Calendar className="h-3 w-3" /> Yesterday
-                </span>
-              </div>
-            </div>
+              </Link>
+            ))}
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/(app)/(dashboard)/page.tsx
+++ b/apps/web/src/app/(app)/(dashboard)/page.tsx
@@ -439,7 +439,7 @@ function RecentComparisons({
             {runs.map((run) => (
               <Link
                 key={run.id}
-                href="/compare-models"
+                href={`/compare-models?run=${run.id}`}
                 className="group block cursor-pointer p-4 transition-colors hover:bg-bg-1"
               >
                 <div className="mb-2 flex items-center gap-2">

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -144,6 +144,9 @@ function scoreBadgeTone(score: number): string {
 }
 
 const MIN_MODELS = 2;
+// Where the picked-model set is mirrored so revisits restore the
+// last selection instead of resetting to the catalog's first two.
+const ARENA_MODELS_STORAGE_KEY = "arena.selectedModels";
 
 function slotLabel(index: number): string {
   // A, B, C, ... AA after Z. Plenty for our purposes.
@@ -154,16 +157,64 @@ function slotLabel(index: number): string {
 export default function CompareModelsPage() {
   const { models: availableModels, isLoading: modelsLoading, getLabel: getModelLabel } =
     useUserModels();
-  const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  // Persist the picked model set across navigation / reload via
+  // localStorage. Server-render returns [] (no window), then the
+  // first client effect rehydrates from storage if anything was
+  // saved. Stale IDs (admin disabled the model since last visit)
+  // are filtered out once the catalog loads.
+  const [selectedModels, setSelectedModels] = useState<string[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = window.localStorage.getItem(ARENA_MODELS_STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed)
+        ? parsed.filter((x): x is string => typeof x === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  });
 
-  // Seed the comparison with the first two enabled models once the catalog
-  // loads. Done in an effect so the initial render doesn't depend on async
-  // data and so we don't clobber the user's later picks.
+  // Drop any persisted IDs that are no longer in the catalog. Only
+  // depends on availableModels so it runs exactly when the catalog
+  // changes (avoids a feedback loop with the setter below).
+  useEffect(() => {
+    if (availableModels.length === 0) return;
+    const validIds = new Set(availableModels.map((m) => m.id));
+    setSelectedModels((prev) => {
+      const cleaned = prev.filter((id) => validIds.has(id));
+      return cleaned.length === prev.length ? prev : cleaned;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [availableModels]);
+
+  // Seed the comparison with the first two enabled models once the
+  // catalog loads AND nothing was restored from localStorage. The
+  // seed runs as a separate effect so the restore-or-seed paths
+  // share the same MIN_MODELS contract without duplicating logic.
   useEffect(() => {
     if (selectedModels.length === 0 && availableModels.length >= MIN_MODELS) {
       setSelectedModels([availableModels[0].id, availableModels[1].id]);
     }
   }, [availableModels, selectedModels.length]);
+
+  // Mirror every change back to localStorage so the next mount
+  // (re-navigation, refresh) restores the same selection. Skip the
+  // empty state — that's the unseeded initial render and would
+  // overwrite a still-good prior selection with [].
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (selectedModels.length === 0) return;
+    try {
+      window.localStorage.setItem(
+        ARENA_MODELS_STORAGE_KEY,
+        JSON.stringify(selectedModels),
+      );
+    } catch {
+      // Quota / privacy mode — non-fatal, just lose persistence.
+    }
+  }, [selectedModels]);
   const [question, setQuestion] = useState("");
   const [expectedOutput, setExpectedOutput] = useState("");
   const [responses, setResponses] = useState<Record<string, string | null>>({});

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -33,6 +33,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -561,6 +562,74 @@ export default function CompareModelsPage() {
     return () => window.removeEventListener("compare-models:new", handler);
   }, [newComparison]);
 
+  /**
+   * Hydrate the composer + panels from a saved arena run. Called
+   * from the history rail and from the `?run=<id>` deep-link
+   * effect below so the same path runs whether the user clicked
+   * History or arrived from the dashboard. Pops the rail open so
+   * the loaded run is visible in context.
+   */
+  const loadHistoryRun = useCallback(
+    (runId: string) => {
+      fetchArenaRun(runId)
+        .then((run) => {
+          setQuestion(run.question);
+          setExpectedOutput(run.expectedOutput);
+          setSelectedModels(run.models);
+          setDisabledModels(new Set());
+          setSubmittedQuestion(run.question);
+          setLoadedRunCreatedAt(run.createdAt);
+          const nextResponses: Record<string, string | null> = {};
+          const nextEvaluations: Record<string, ModelEvaluation | null> = {};
+          const nextStatuses: Record<string, ModelStatus> = {};
+          for (const id of run.models) {
+            nextResponses[id] =
+              run.responses.find((r) => r.model === id)?.response.content ??
+              null;
+            nextEvaluations[id] =
+              run.comparison.find((c) => c.name === id) ?? null;
+            // Historical runs were already completed — mark every
+            // panel done so the body renders content (not the
+            // "Waiting…" placeholder) on load.
+            nextStatuses[id] = "done";
+          }
+          setResponses(nextResponses);
+          setEvaluations(nextEvaluations);
+          setModelStatuses(nextStatuses);
+          setEvaluatorStatus(run.comparison.length > 0 ? "done" : "idle");
+          setEvaluatorError(null);
+          // Surface the loaded run in the history rail so users see
+          // it highlighted alongside the other entries.
+          setRailOpen(true);
+          setHistoryExpanded(true);
+        })
+        .catch((err) => {
+          const message =
+            err instanceof Error ? err.message : "Couldn't load run.";
+          toast.error(message);
+        });
+    },
+    [],
+  );
+
+  // Deep-link support: clicking a card on the dashboard opens
+  // /compare-models?run=<id> — auto-load that run, then scrub the
+  // param so a refresh doesn't re-trigger and so the URL reads as
+  // the canonical /compare-models again.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  useEffect(() => {
+    const runId = searchParams.get("run");
+    if (!runId) return;
+    loadHistoryRun(runId);
+    router.replace(pathname, { scroll: false });
+    // We deliberately omit `loadHistoryRun` etc from deps — the
+    // effect should fire once per URL change, not on render-time
+    // reference churn. router/pathname are stable per route.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
   async function copyText(text: string, label = "response") {
     try {
       await navigator.clipboard.writeText(text);
@@ -768,43 +837,7 @@ export default function CompareModelsPage() {
             setHistoryExpanded={setHistoryExpanded}
             history={history}
             onDeleteHistory={(runId) => setDeleteRunId(runId)}
-            onLoadHistory={(runId) => {
-              fetchArenaRun(runId)
-                .then((run) => {
-                  setQuestion(run.question);
-                  setExpectedOutput(run.expectedOutput);
-                  setSelectedModels(run.models);
-                  setDisabledModels(new Set());
-                  setSubmittedQuestion(run.question);
-                  setLoadedRunCreatedAt(run.createdAt);
-                  const nextResponses: Record<string, string | null> = {};
-                  const nextEvaluations: Record<string, ModelEvaluation | null> = {};
-                  const nextStatuses: Record<string, ModelStatus> = {};
-                  for (const id of run.models) {
-                    nextResponses[id] =
-                      run.responses.find((r) => r.model === id)?.response.content ??
-                      null;
-                    nextEvaluations[id] =
-                      run.comparison.find((c) => c.name === id) ?? null;
-                    // Historical runs were already completed — mark
-                    // every panel done so the body renders content
-                    // (not the "Waiting…" placeholder) on load.
-                    nextStatuses[id] = "done";
-                  }
-                  setResponses(nextResponses);
-                  setEvaluations(nextEvaluations);
-                  setModelStatuses(nextStatuses);
-                  setEvaluatorStatus(
-                    run.comparison.length > 0 ? "done" : "idle",
-                  );
-                  setEvaluatorError(null);
-                })
-                .catch((err) => {
-                  const message =
-                    err instanceof Error ? err.message : "Couldn't load run.";
-                  toast.error(message);
-                });
-            }}
+            onLoadHistory={loadHistoryRun}
             onClose={() => setRailOpen(false)}
             onAddModel={() => setAddModelOpen(true)}
           />

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -50,6 +50,7 @@ import {
 import {
   fetchKnowledgeFolder,
   fetchKnowledgeFolders,
+  fetchTeams,
   uploadKnowledgeFiles,
   updateKnowledgeFileVisibility,
   updateKnowledgeFilesVisibilityBulk,
@@ -148,7 +149,13 @@ function IngestionStatusBadge({
  * IngestionStatusBadge: the two pages don't share a components
  * file for this domain yet.
  */
-function VisibilityBadge({ visibility }: { visibility: KnowledgeFileVisibility }) {
+function VisibilityBadge({
+  visibility,
+  teams = [],
+}: {
+  visibility: KnowledgeFileVisibility;
+  teams?: { id: string; name: string }[];
+}) {
   if (visibility === "admins") {
     return (
       <span
@@ -157,6 +164,24 @@ function VisibilityBadge({ visibility }: { visibility: KnowledgeFileVisibility }
       >
         <Shield className="h-3 w-3" strokeWidth={2} />
         Admins only
+      </span>
+    );
+  }
+  if (visibility === "teams") {
+    // Team list as a comma-joined hover tooltip; the pill itself
+    // stays compact so the row keeps a single-line layout.
+    const names = teams.map((t) => t.name).join(", ");
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-primary-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-7"
+        title={
+          names.length > 0
+            ? `Only members of these teams can see this file in chat / arena: ${names}.`
+            : "Visibility is set to specific teams, but no team is linked yet — no one can see this file."
+        }
+      >
+        <Users className="h-3 w-3" strokeWidth={2} />
+        {teams.length > 0 ? `Teams (${teams.length})` : "Teams"}
       </span>
     );
   }
@@ -208,10 +233,12 @@ export default function FolderDetailPage({
     mutationFn: ({
       files,
       visibility,
+      teamIds,
     }: {
       files: File[];
       visibility: KnowledgeFileVisibility;
-    }) => uploadKnowledgeFiles(folderId, files, visibility),
+      teamIds: string[];
+    }) => uploadKnowledgeFiles(folderId, files, visibility, teamIds),
     onSuccess: ({ uploaded, duplicates }) => {
       queryClient.invalidateQueries({
         queryKey: ["knowledge-folder", folderId],
@@ -238,7 +265,8 @@ export default function FolderDetailPage({
         );
       }
     },
-    onError: () => toast.error("Failed to upload files."),
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to upload files."),
   });
 
   // Single-file re-train. Mirror of the root /knowledge-core page;
@@ -326,10 +354,19 @@ export default function FolderDetailPage({
 
   const [stagedFiles, setStagedFiles] = useState<File[]>([]);
   // Per-batch visibility staging. Same lifecycle as on the root
-  // /knowledge-core page: admin-only select, reset to 'all' after
-  // each confirmed upload so the choice doesn't leak across batches.
+  // /knowledge-core page: select is open to all users, reset to
+  // 'all' after each confirmed upload so the choice doesn't leak
+  // across batches. Team IDs reset alongside visibility.
   const [stagedVisibility, setStagedVisibility] =
     useState<KnowledgeFileVisibility>("all");
+  const [stagedTeamIds, setStagedTeamIds] = useState<string[]>([]);
+
+  // Same user-teams list the root page renders. Cached by react-query
+  // key 'teams' so navigating between KC pages reuses one fetch.
+  const { data: userTeams = [] } = useQuery({
+    queryKey: ["teams"],
+    queryFn: fetchTeams,
+  });
 
   // Multi-select state for the bulk action bar. Set<string> over
   // the current folder's file ids; resets when the user navigates
@@ -455,14 +492,19 @@ export default function FolderDetailPage({
   };
 
   const confirmUpload = () => {
-    if (stagedFiles.length > 0) {
-      uploadMutation.mutate({
-        files: stagedFiles,
-        visibility: stagedVisibility,
-      });
+    if (stagedFiles.length === 0) return;
+    if (stagedVisibility === "teams" && stagedTeamIds.length === 0) {
+      toast.error("Pick at least one team for Teams visibility.");
+      return;
     }
+    uploadMutation.mutate({
+      files: stagedFiles,
+      visibility: stagedVisibility,
+      teamIds: stagedTeamIds,
+    });
     setStagedFiles([]);
     setStagedVisibility("all");
+    setStagedTeamIds([]);
   };
 
   const removeStagedFile = (idx: number) =>
@@ -702,7 +744,7 @@ export default function FolderDetailPage({
                         status={f.ingestionStatus}
                         error={f.ingestionError}
                       />
-                      <VisibilityBadge visibility={f.visibility} />
+                      <VisibilityBadge visibility={f.visibility} teams={f.teams} />
                     </div>
                   </td>
                   <td className="px-5 py-4">
@@ -840,7 +882,7 @@ export default function FolderDetailPage({
                     status={f.ingestionStatus}
                     error={f.ingestionError}
                   />
-                  <VisibilityBadge visibility={f.visibility} />
+                  <VisibilityBadge visibility={f.visibility} teams={f.teams} />
                 </div>
                 <span className="text-[12px] text-text-3">
                   {formatBytes(f.sizeBytes)} •{" "}
@@ -1012,42 +1054,90 @@ export default function FolderDetailPage({
             ))}
           </div>
 
-          {/* Admin-only visibility select — same UX as the root
-              /knowledge-core upload dialog. Hidden for non-admins so
-              their uploads quietly ship as 'all' (BE forces this
-              regardless). */}
-          {isAdmin && (
-            <div className="flex flex-col gap-1.5 pt-1">
-              <label className="text-[12px] font-medium text-text-1">
-                Visibility
-              </label>
-              <Select
-                value={stagedVisibility}
-                onValueChange={(v) =>
-                  setStagedVisibility(v as KnowledgeFileVisibility)
-                }
-                disabled={uploadMutation.isPending}
-              >
-                <SelectTrigger className="h-10 w-full cursor-pointer">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Everyone in the company</SelectItem>
+          {/* Visibility picker — same UX as the root /knowledge-core
+              upload dialog. Open to all users; 'admins' is filtered
+              out for non-admin callers (BE rejects it too). Team
+              checkbox panel below appears when 'teams' is active. */}
+          <div className="flex flex-col gap-1.5 pt-1">
+            <label className="text-[12px] font-medium text-text-1">
+              Visibility
+            </label>
+            <Select
+              value={stagedVisibility}
+              onValueChange={(v) =>
+                setStagedVisibility(v as KnowledgeFileVisibility)
+              }
+              disabled={uploadMutation.isPending}
+            >
+              <SelectTrigger className="h-10 w-full cursor-pointer">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Everyone in the company</SelectItem>
+                {isAdmin && (
                   <SelectItem value="admins">Admins only</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-[11px] text-text-3">
-                {stagedVisibility === "admins"
-                  ? "Only admins will see these files in chat / arena. You can change this later from the file's action menu."
+                )}
+                <SelectItem value="teams">Specific teams…</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-[11px] text-text-3">
+              {stagedVisibility === "admins"
+                ? "Only admins will see these files in chat / arena. You can change this later from the file's action menu."
+                : stagedVisibility === "teams"
+                  ? "Only members of the teams you pick below will see these files in chat / arena."
                   : "Every user in the company can see these files in chat / arena."}
-              </p>
+            </p>
+          </div>
+
+          {stagedVisibility === "teams" && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-[12px] font-medium text-text-1">
+                Teams with access
+              </label>
+              {userTeams.length === 0 ? (
+                <p className="text-[11px] text-text-3">
+                  You aren&rsquo;t a member of any team yet — create or
+                  join a team first to use this visibility option.
+                </p>
+              ) : (
+                <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
+                  {userTeams.map((t) => {
+                    const checked = stagedTeamIds.includes(t.id);
+                    return (
+                      <label
+                        key={t.id}
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={uploadMutation.isPending}
+                          onChange={() => {
+                            setStagedTeamIds((prev) =>
+                              checked
+                                ? prev.filter((id) => id !== t.id)
+                                : [...prev, t.id],
+                            );
+                          }}
+                          className="h-3.5 w-3.5 cursor-pointer accent-primary-6"
+                        />
+                        <span className="truncate">{t.name}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           )}
 
           <DialogFooter className="gap-2">
             <Button
               variant="outline"
-              onClick={() => setStagedFiles([])}
+              onClick={() => {
+                setStagedFiles([]);
+                setStagedVisibility("all");
+                setStagedTeamIds([]);
+              }}
               disabled={uploadMutation.isPending}
               className="cursor-pointer"
             >

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -14,6 +14,7 @@ import {
   Search,
   Shield,
   Trash2,
+  Unplug,
   Upload,
   Users,
   X,
@@ -55,6 +56,7 @@ import {
   updateKnowledgeFileVisibility,
   updateKnowledgeFilesVisibilityBulk,
   reingestKnowledgeFile,
+  untrainKnowledgeFile,
   moveKnowledgeFile,
   deleteKnowledgeFile,
   type KnowledgeFileVisibility,
@@ -113,7 +115,7 @@ function IngestionStatusBadge({
   status,
   error,
 }: {
-  status: "pending" | "processing" | "done" | "failed";
+  status: "pending" | "processing" | "done" | "failed" | "untrained";
   error?: string | null;
 }) {
   if (status === "done") {
@@ -132,6 +134,17 @@ function IngestionStatusBadge({
       >
         <AlertTriangle className="h-3 w-3" strokeWidth={2} />
         Skipped
+      </span>
+    );
+  }
+  if (status === "untrained") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-bg-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-3"
+        title="Embeddings removed — Retrain to make this file searchable again."
+      >
+        <Unplug className="h-3 w-3" strokeWidth={2} />
+        Untrained
       </span>
     );
   }
@@ -283,6 +296,23 @@ export default function FolderDetailPage({
     },
     onError: (err: Error) =>
       toast.error(err.message || "Failed to re-train this file."),
+  });
+
+  // Inverse of Retrain — drops the file's embeddings so chat RAG
+  // ignores it, but keeps the row + disk copy. See the root page's
+  // mutation comment for the BE-side semantics.
+  const untrainMutation = useMutation({
+    mutationFn: (fileId: string) => untrainKnowledgeFile(fileId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["knowledge-folder", folderId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
+      queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
+      toast.success("File untrained — embeddings removed.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to untrain this file."),
   });
 
   // Admin-only PATCH to flip visibility post-upload. BE rejects
@@ -803,6 +833,17 @@ export default function FolderDetailPage({
                           <RotateCw className="mr-2 h-3.5 w-3.5" />
                           Retrain
                         </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => untrainMutation.mutate(f.id)}
+                          disabled={
+                            f.ingestionStatus === "processing" ||
+                            f.ingestionStatus === "untrained" ||
+                            untrainMutation.isPending
+                          }
+                        >
+                          <Unplug className="mr-2 h-3.5 w-3.5" />
+                          Untrain
+                        </DropdownMenuItem>
                         {isAdmin && (
                           <DropdownMenuItem
                             onSelect={() =>
@@ -918,6 +959,17 @@ export default function FolderDetailPage({
                   >
                     <RotateCw className="mr-2 h-3.5 w-3.5" />
                     Retrain
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => untrainMutation.mutate(f.id)}
+                    disabled={
+                      f.ingestionStatus === "processing" ||
+                      f.ingestionStatus === "untrained" ||
+                      untrainMutation.isPending
+                    }
+                  >
+                    <Unplug className="mr-2 h-3.5 w-3.5" />
+                    Untrain
                   </DropdownMenuItem>
                   {isAdmin && (
                     <DropdownMenuItem

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -915,15 +915,16 @@ export default function FolderDetailPage({
                             )}
                           </DropdownMenuItem>
                         )}
-                        {isAdmin && (
-                          <DropdownMenuItem
-                            onSelect={() => setEditingVisibilityFileId(f.id)}
-                            disabled={f.ingestionStatus === "processing"}
-                          >
-                            <Settings2 className="mr-2 h-3.5 w-3.5" />
-                            Change visibility…
-                          </DropdownMenuItem>
-                        )}
+                        {/* Open to file owners too; folder detail
+                            requires folder ownership to load, so the
+                            caller is always the uploader (or admin). */}
+                        <DropdownMenuItem
+                          onSelect={() => setEditingVisibilityFileId(f.id)}
+                          disabled={f.ingestionStatus === "processing"}
+                        >
+                          <Settings2 className="mr-2 h-3.5 w-3.5" />
+                          Change visibility…
+                        </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           onSelect={() => handleDelete(f.id)}
@@ -1055,15 +1056,13 @@ export default function FolderDetailPage({
                       )}
                     </DropdownMenuItem>
                   )}
-                  {isAdmin && (
-                    <DropdownMenuItem
-                      onSelect={() => setEditingVisibilityFileId(f.id)}
-                      disabled={f.ingestionStatus === "processing"}
-                    >
-                      <Settings2 className="mr-2 h-3.5 w-3.5" />
-                      Change visibility…
-                    </DropdownMenuItem>
-                  )}
+                  <DropdownMenuItem
+                    onSelect={() => setEditingVisibilityFileId(f.id)}
+                    disabled={f.ingestionStatus === "processing"}
+                  >
+                    <Settings2 className="mr-2 h-3.5 w-3.5" />
+                    Change visibility…
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     onSelect={() => handleDelete(f.id)}

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -51,6 +51,7 @@ import {
 import {
   fetchKnowledgeFolder,
   fetchKnowledgeFolders,
+  fetchProjects,
   fetchTeams,
   uploadKnowledgeFiles,
   updateKnowledgeFileVisibility,
@@ -165,9 +166,11 @@ function IngestionStatusBadge({
 function VisibilityBadge({
   visibility,
   teams = [],
+  projects = [],
 }: {
   visibility: KnowledgeFileVisibility;
   teams?: { id: string; name: string }[];
+  projects?: { id: string; name: string }[];
 }) {
   if (visibility === "admins") {
     return (
@@ -195,6 +198,22 @@ function VisibilityBadge({
       >
         <Users className="h-3 w-3" strokeWidth={2} />
         {teams.length > 0 ? `Teams (${teams.length})` : "Teams"}
+      </span>
+    );
+  }
+  if (visibility === "project") {
+    const names = projects.map((p) => p.name).join(", ");
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-primary-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-7"
+        title={
+          names.length > 0
+            ? `Surfaced only in the chat of these projects: ${names}.`
+            : "Visibility is set to specific projects, but none is linked yet — no one can see this file."
+        }
+      >
+        <Folder className="h-3 w-3" strokeWidth={2} />
+        {projects.length > 0 ? `Projects (${projects.length})` : "Project"}
       </span>
     );
   }
@@ -247,11 +266,14 @@ export default function FolderDetailPage({
       files,
       visibility,
       teamIds,
+      projectIds,
     }: {
       files: File[];
       visibility: KnowledgeFileVisibility;
       teamIds: string[];
-    }) => uploadKnowledgeFiles(folderId, files, visibility, teamIds),
+      projectIds: string[];
+    }) =>
+      uploadKnowledgeFiles(folderId, files, visibility, teamIds, projectIds),
     onSuccess: ({ uploaded, duplicates }) => {
       queryClient.invalidateQueries({
         queryKey: ["knowledge-folder", folderId],
@@ -386,16 +408,21 @@ export default function FolderDetailPage({
   // Per-batch visibility staging. Same lifecycle as on the root
   // /knowledge-core page: select is open to all users, reset to
   // 'all' after each confirmed upload so the choice doesn't leak
-  // across batches. Team IDs reset alongside visibility.
+  // across batches. Team / project IDs reset alongside visibility.
   const [stagedVisibility, setStagedVisibility] =
     useState<KnowledgeFileVisibility>("all");
   const [stagedTeamIds, setStagedTeamIds] = useState<string[]>([]);
+  const [stagedProjectIds, setStagedProjectIds] = useState<string[]>([]);
 
   // Same user-teams list the root page renders. Cached by react-query
   // key 'teams' so navigating between KC pages reuses one fetch.
   const { data: userTeams = [] } = useQuery({
     queryKey: ["teams"],
     queryFn: fetchTeams,
+  });
+  const { data: userProjects = [] } = useQuery({
+    queryKey: ["projects", "kc-upload"],
+    queryFn: () => fetchProjects("all"),
   });
 
   // Multi-select state for the bulk action bar. Set<string> over
@@ -527,14 +554,20 @@ export default function FolderDetailPage({
       toast.error("Pick at least one team for Teams visibility.");
       return;
     }
+    if (stagedVisibility === "project" && stagedProjectIds.length === 0) {
+      toast.error("Pick at least one project for Project visibility.");
+      return;
+    }
     uploadMutation.mutate({
       files: stagedFiles,
       visibility: stagedVisibility,
       teamIds: stagedTeamIds,
+      projectIds: stagedProjectIds,
     });
     setStagedFiles([]);
     setStagedVisibility("all");
     setStagedTeamIds([]);
+    setStagedProjectIds([]);
   };
 
   const removeStagedFile = (idx: number) =>
@@ -774,7 +807,11 @@ export default function FolderDetailPage({
                         status={f.ingestionStatus}
                         error={f.ingestionError}
                       />
-                      <VisibilityBadge visibility={f.visibility} teams={f.teams} />
+                      <VisibilityBadge
+                        visibility={f.visibility}
+                        teams={f.teams}
+                        projects={f.projects}
+                      />
                     </div>
                   </td>
                   <td className="px-5 py-4">
@@ -923,7 +960,11 @@ export default function FolderDetailPage({
                     status={f.ingestionStatus}
                     error={f.ingestionError}
                   />
-                  <VisibilityBadge visibility={f.visibility} teams={f.teams} />
+                  <VisibilityBadge
+                        visibility={f.visibility}
+                        teams={f.teams}
+                        projects={f.projects}
+                      />
                 </div>
                 <span className="text-[12px] text-text-3">
                   {formatBytes(f.sizeBytes)} •{" "}
@@ -1130,6 +1171,7 @@ export default function FolderDetailPage({
                   <SelectItem value="admins">Admins only</SelectItem>
                 )}
                 <SelectItem value="teams">Specific teams…</SelectItem>
+                <SelectItem value="project">Specific project…</SelectItem>
               </SelectContent>
             </Select>
             <p className="text-[11px] text-text-3">
@@ -1137,7 +1179,9 @@ export default function FolderDetailPage({
                 ? "Only admins will see these files in chat / arena. You can change this later from the file's action menu."
                 : stagedVisibility === "teams"
                   ? "Only members of the teams you pick below will see these files in chat / arena."
-                  : "Every user in the company can see these files in chat / arena."}
+                  : stagedVisibility === "project"
+                    ? "These files will only appear in the chat of the project(s) you pick below — never in the org-wide RAG."
+                    : "Every user in the company can see these files in chat / arena."}
             </p>
           </div>
 
@@ -1182,6 +1226,54 @@ export default function FolderDetailPage({
             </div>
           )}
 
+          {stagedVisibility === "project" && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-[12px] font-medium text-text-1">
+                Projects with access
+              </label>
+              {userProjects.length === 0 ? (
+                <p className="text-[11px] text-text-3">
+                  You don&rsquo;t have access to any projects yet — create
+                  one first to use this visibility option.
+                </p>
+              ) : (
+                <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
+                  {userProjects.map((p) => {
+                    const checked = stagedProjectIds.includes(p.id);
+                    return (
+                      <label
+                        key={p.id}
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={uploadMutation.isPending}
+                          onChange={() => {
+                            setStagedProjectIds((prev) =>
+                              checked
+                                ? prev.filter((id) => id !== p.id)
+                                : [...prev, p.id],
+                            );
+                          }}
+                          className="h-3.5 w-3.5 cursor-pointer accent-primary-6"
+                        />
+                        <span className="truncate">
+                          {p.name}
+                          {p.teamName ? (
+                            <span className="ml-1 text-text-3">
+                              · {p.teamName}
+                            </span>
+                          ) : null}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
           <DialogFooter className="gap-2">
             <Button
               variant="outline"
@@ -1189,6 +1281,7 @@ export default function FolderDetailPage({
                 setStagedFiles([]);
                 setStagedVisibility("all");
                 setStagedTeamIds([]);
+                setStagedProjectIds([]);
               }}
               disabled={uploadMutation.isPending}
               className="cursor-pointer"

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -212,13 +212,31 @@ export default function FolderDetailPage({
       files: File[];
       visibility: KnowledgeFileVisibility;
     }) => uploadKnowledgeFiles(folderId, files, visibility),
-    onSuccess: (uploaded) => {
+    onSuccess: ({ uploaded, duplicates }) => {
       queryClient.invalidateQueries({
         queryKey: ["knowledge-folder", folderId],
       });
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
-      toast.success(`Uploaded ${uploaded.length} file(s).`);
+      // Same three-outcome shape as the root KC page: mixed batches
+      // fire both toasts (one success for what got saved, one info
+      // for what was skipped) so the user always knows the exact
+      // result of their drop.
+      if (uploaded.length > 0) {
+        toast.success(`Uploaded ${uploaded.length} file(s).`);
+      }
+      if (duplicates.length > 0) {
+        toast.info(
+          duplicates.length === 1
+            ? `"${duplicates[0].name}" is already in your Knowledge Core.`
+            : `${duplicates.length} file(s) were already in your Knowledge Core.`,
+          {
+            description: duplicates
+              .map((d) => `"${d.name}" → "${d.existing.folderName}"`)
+              .join("\n"),
+          },
+        );
+      }
     },
     onError: () => toast.error("Failed to upload files."),
   });

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -12,6 +12,7 @@ import {
   MoreVertical,
   RotateCw,
   Search,
+  Settings2,
   Shield,
   Trash2,
   Unplug,
@@ -63,6 +64,7 @@ import {
   type KnowledgeFileVisibility,
 } from "@/lib/api";
 import { useAuth } from "@/components/providers";
+import { ChangeFileVisibilityDialog } from "@/components/change-file-visibility-dialog";
 
 const TYPE_STYLES: Record<string, string> = {
   PDF: "bg-danger-1 text-danger-6",
@@ -542,6 +544,15 @@ export default function FolderDetailPage({
   const deleteFileName =
     folder?.files.find((f) => f.id === deleteFileId)?.name ?? "";
 
+  // Same pattern as on the root /knowledge-core page — full
+  // visibility editor lives in a shared dialog, opened per file by
+  // the dropdown menu item.
+  const [editingVisibilityFileId, setEditingVisibilityFileId] = useState<
+    string | null
+  >(null);
+  const editingVisibilityFile =
+    folder?.files.find((f) => f.id === editingVisibilityFileId) ?? null;
+
   const handleBrowse = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
     if (files.length > 0) setStagedFiles(files);
@@ -904,6 +915,15 @@ export default function FolderDetailPage({
                             )}
                           </DropdownMenuItem>
                         )}
+                        {isAdmin && (
+                          <DropdownMenuItem
+                            onSelect={() => setEditingVisibilityFileId(f.id)}
+                            disabled={f.ingestionStatus === "processing"}
+                          >
+                            <Settings2 className="mr-2 h-3.5 w-3.5" />
+                            Change visibility…
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           onSelect={() => handleDelete(f.id)}
@@ -1033,6 +1053,15 @@ export default function FolderDetailPage({
                           Make admin-only
                         </>
                       )}
+                    </DropdownMenuItem>
+                  )}
+                  {isAdmin && (
+                    <DropdownMenuItem
+                      onSelect={() => setEditingVisibilityFileId(f.id)}
+                      disabled={f.ingestionStatus === "processing"}
+                    >
+                      <Settings2 className="mr-2 h-3.5 w-3.5" />
+                      Change visibility…
                     </DropdownMenuItem>
                   )}
                   <DropdownMenuSeparator />
@@ -1377,6 +1406,24 @@ export default function FolderDetailPage({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Full visibility editor — same shared dialog the root KC
+          page uses; opened per file via the dropdown menu. */}
+      <ChangeFileVisibilityDialog
+        file={editingVisibilityFile}
+        open={editingVisibilityFile !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingVisibilityFileId(null);
+        }}
+        isAdmin={isAdmin}
+        onSuccess={() => {
+          queryClient.invalidateQueries({
+            queryKey: ["knowledge-folder", folderId],
+          });
+          queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
+          queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -754,15 +754,17 @@ export default function KnowledgeCorePage() {
                       )}
                     </DropdownMenuItem>
                   )}
-                  {isAdmin && (
-                    <DropdownMenuItem
-                      onSelect={() => setEditingVisibilityFileId(file.id)}
-                      disabled={file.ingestionStatus === "processing"}
-                    >
-                      <Settings2 className="mr-2 h-3.5 w-3.5" />
-                      Change visibility…
-                    </DropdownMenuItem>
-                  )}
+                  {/* Open to file owners too — /knowledge-core lists
+                      only the caller's own folders, so anyone seeing
+                      this menu is the file's uploader (or admin).
+                      BE rejects 'admins' for non-admin owners. */}
+                  <DropdownMenuItem
+                    onSelect={() => setEditingVisibilityFileId(file.id)}
+                    disabled={file.ingestionStatus === "processing"}
+                  >
+                    <Settings2 className="mr-2 h-3.5 w-3.5" />
+                    Change visibility…
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     onSelect={() => setDeleteFileId(file.id)}

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -14,6 +14,7 @@ import {
   Search,
   Shield,
   Trash2,
+  Unplug,
   Upload,
   Users,
   X,
@@ -31,6 +32,7 @@ import {
   uploadKnowledgeFiles,
   updateKnowledgeFileVisibility,
   reingestKnowledgeFile,
+  untrainKnowledgeFile,
   moveKnowledgeFile,
   deleteKnowledgeFile,
   type KnowledgeFolder,
@@ -98,7 +100,7 @@ function IngestionStatusBadge({
   status,
   error,
 }: {
-  status: "pending" | "processing" | "done" | "failed";
+  status: "pending" | "processing" | "done" | "failed" | "untrained";
   error?: string | null;
 }) {
   if (status === "done") {
@@ -117,6 +119,17 @@ function IngestionStatusBadge({
       >
         <AlertTriangle className="h-3 w-3" strokeWidth={2} />
         Skipped
+      </span>
+    );
+  }
+  if (status === "untrained") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-bg-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-3"
+        title="Embeddings removed — Retrain to make this file searchable again."
+      >
+        <Unplug className="h-3 w-3" strokeWidth={2} />
+        Untrained
       </span>
     );
   }
@@ -292,6 +305,22 @@ export default function KnowledgeCorePage() {
     },
     onError: (err: Error) =>
       toast.error(err.message || "Failed to re-train this file."),
+  });
+
+  // Inverse of Retrain: drop the file's embeddings so chat RAG stops
+  // surfacing it, but keep the row + disk copy so Download / Retrain
+  // still work. BE gates on owner + mid-ingestion same way Retrain
+  // does, so we share the same disabled rule on the menu item.
+  const untrainMutation = useMutation({
+    mutationFn: (fileId: string) => untrainKnowledgeFile(fileId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
+      queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
+      queryClient.invalidateQueries({ queryKey: ["knowledge-folder"] });
+      toast.success("File untrained — embeddings removed.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to untrain this file."),
   });
 
   // Admin-only PATCH to flip a file's visibility between 'all' and
@@ -640,6 +669,17 @@ export default function KnowledgeCorePage() {
                   >
                     <RotateCw className="mr-2 h-3.5 w-3.5" />
                     Retrain
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => untrainMutation.mutate(file.id)}
+                    disabled={
+                      file.ingestionStatus === "processing" ||
+                      file.ingestionStatus === "untrained" ||
+                      untrainMutation.isPending
+                    }
+                  >
+                    <Unplug className="mr-2 h-3.5 w-3.5" />
+                    Untrain
                   </DropdownMenuItem>
                   {isAdmin && (
                     <DropdownMenuItem

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -12,6 +12,7 @@ import {
   Download,
   RotateCw,
   Search,
+  Settings2,
   Shield,
   Trash2,
   Unplug,
@@ -65,6 +66,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { ChangeFileVisibilityDialog } from "@/components/change-file-visibility-dialog";
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B";
@@ -372,6 +374,16 @@ export default function KnowledgeCorePage() {
   const [deleteFileId, setDeleteFileId] = useState<string | null>(null);
   const deleteFileName =
     recentFiles.find((f) => f.id === deleteFileId)?.name ?? "";
+
+  // Currently-edited file for the full visibility dialog. Stays
+  // separate from the inline binary toggle so admins can keep using
+  // the one-click admin-only flip for hot rows and reach for the
+  // dialog only when they need teams / project tiers.
+  const [editingVisibilityFileId, setEditingVisibilityFileId] = useState<
+    string | null
+  >(null);
+  const editingVisibilityFile =
+    recentFiles.find((f) => f.id === editingVisibilityFileId) ?? null;
 
   const handleDeleteFolder = (id: string) => {
     setDeleteFolderId(id);
@@ -740,6 +752,15 @@ export default function KnowledgeCorePage() {
                           Make admin-only
                         </>
                       )}
+                    </DropdownMenuItem>
+                  )}
+                  {isAdmin && (
+                    <DropdownMenuItem
+                      onSelect={() => setEditingVisibilityFileId(file.id)}
+                      disabled={file.ingestionStatus === "processing"}
+                    >
+                      <Settings2 className="mr-2 h-3.5 w-3.5" />
+                      Change visibility…
                     </DropdownMenuItem>
                   )}
                   <DropdownMenuSeparator />
@@ -1114,6 +1135,22 @@ export default function KnowledgeCorePage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Full visibility editor — covers all four tiers including
+          teams / project, beyond what the inline admin toggle does. */}
+      <ChangeFileVisibilityDialog
+        file={editingVisibilityFile}
+        open={editingVisibilityFile !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingVisibilityFileId(null);
+        }}
+        isAdmin={isAdmin}
+        onSuccess={() => {
+          queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
+          queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
+          queryClient.invalidateQueries({ queryKey: ["knowledge-folder"] });
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -334,13 +334,34 @@ export default function KnowledgeCorePage() {
     setUploading(true);
     try {
       const folderId = await getAllFilesFolderId();
-      await uploadKnowledgeFiles(folderId, stagedFiles, stagedVisibility);
+      const { uploaded, duplicates } = await uploadKnowledgeFiles(
+        folderId,
+        stagedFiles,
+        stagedVisibility,
+      );
       await Promise.all([
         queryClient.refetchQueries({ queryKey: ["knowledge-folders"] }),
         queryClient.refetchQueries({ queryKey: ["knowledge-recent"] }),
         queryClient.refetchQueries({ queryKey: ["knowledge-folder", folderId] }),
       ]);
-      toast.success(`Uploaded ${stagedFiles.length} file(s) to All Files.`);
+      // Three outcomes: all-new, mixed, all-duplicates. The mixed
+      // case fires both toasts so the user sees what was actually
+      // saved AND why a few were skipped.
+      if (uploaded.length > 0) {
+        toast.success(`Uploaded ${uploaded.length} file(s) to All Files.`);
+      }
+      if (duplicates.length > 0) {
+        toast.info(
+          duplicates.length === 1
+            ? `"${duplicates[0].name}" is already in your Knowledge Core.`
+            : `${duplicates.length} file(s) were already in your Knowledge Core.`,
+          {
+            description: duplicates
+              .map((d) => `"${d.name}" → "${d.existing.folderName}"`)
+              .join("\n"),
+          },
+        );
+      }
       setStagedFiles([]);
       setStagedVisibility("all");
     } catch {

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -25,6 +25,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   fetchKnowledgeFolders,
+  fetchProjects,
   fetchRecentKnowledgeFiles,
   fetchTeams,
   createKnowledgeFolder,
@@ -151,9 +152,11 @@ function IngestionStatusBadge({
 function VisibilityBadge({
   visibility,
   teams = [],
+  projects = [],
 }: {
   visibility: KnowledgeFileVisibility;
   teams?: { id: string; name: string }[];
+  projects?: { id: string; name: string }[];
 }) {
   if (visibility === "admins") {
     return (
@@ -179,6 +182,22 @@ function VisibilityBadge({
       >
         <Users className="h-3 w-3" strokeWidth={2} />
         {teams.length > 0 ? `Teams (${teams.length})` : "Teams"}
+      </span>
+    );
+  }
+  if (visibility === "project") {
+    const names = projects.map((p) => p.name).join(", ");
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-primary-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-7"
+        title={
+          names.length > 0
+            ? `Surfaced only in the chat of these projects: ${names}.`
+            : "Visibility is set to specific projects, but none is linked yet — no one can see this file."
+        }
+      >
+        <Folder className="h-3 w-3" strokeWidth={2} />
+        {projects.length > 0 ? `Projects (${projects.length})` : "Project"}
       </span>
     );
   }
@@ -380,10 +399,11 @@ export default function KnowledgeCorePage() {
   // across batches.
   const [stagedVisibility, setStagedVisibility] =
     useState<KnowledgeFileVisibility>("all");
-  // Selected team IDs for the 'teams' visibility option. Reset along
-  // with `stagedVisibility` so a previous batch's selection doesn't
-  // leak into the next one.
+  // Selected team / project IDs for 'teams' / 'project' visibility.
+  // Both reset alongside `stagedVisibility` so a previous batch's
+  // selection doesn't leak into the next one.
   const [stagedTeamIds, setStagedTeamIds] = useState<string[]>([]);
+  const [stagedProjectIds, setStagedProjectIds] = useState<string[]>([]);
 
   // Pull the user's team list once; only meaningful for company
   // profiles, but we render it lazily anyway (the picker only appears
@@ -392,14 +412,26 @@ export default function KnowledgeCorePage() {
     queryKey: ["teams"],
     queryFn: fetchTeams,
   });
+  // Same lazy pattern for projects — only the 'project' visibility
+  // branch reads this. fetchProjects('all') returns every project
+  // the caller can access (personal + team).
+  const { data: userProjects = [] } = useQuery({
+    queryKey: ["projects", "kc-upload"],
+    queryFn: () => fetchProjects("all"),
+  });
 
   const confirmUpload = async () => {
     if (stagedFiles.length === 0) return;
-    // Block submit when 'teams' is picked but no team is checked —
-    // the BE would reject this too, but a client-side guard keeps
-    // the dialog from collapsing on a 400 with stale staged files.
+    // Block submit when the chosen visibility requires a non-empty
+    // selection but the picker is empty — the BE rejects this too,
+    // but a client guard keeps the dialog from collapsing on a 400
+    // with stale staged files.
     if (stagedVisibility === "teams" && stagedTeamIds.length === 0) {
       toast.error("Pick at least one team for Teams visibility.");
+      return;
+    }
+    if (stagedVisibility === "project" && stagedProjectIds.length === 0) {
+      toast.error("Pick at least one project for Project visibility.");
       return;
     }
     setUploading(true);
@@ -410,6 +442,7 @@ export default function KnowledgeCorePage() {
         stagedFiles,
         stagedVisibility,
         stagedTeamIds,
+        stagedProjectIds,
       );
       await Promise.all([
         queryClient.refetchQueries({ queryKey: ["knowledge-folders"] }),
@@ -437,6 +470,7 @@ export default function KnowledgeCorePage() {
       setStagedFiles([]);
       setStagedVisibility("all");
       setStagedTeamIds([]);
+      setStagedProjectIds([]);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to upload files.");
     } finally {
@@ -621,7 +655,11 @@ export default function KnowledgeCorePage() {
                     status={file.ingestionStatus}
                     error={file.ingestionError}
                   />
-                  <VisibilityBadge visibility={file.visibility} teams={file.teams} />
+                  <VisibilityBadge
+                    visibility={file.visibility}
+                    teams={file.teams}
+                    projects={file.projects}
+                  />
                 </div>
                 <span className="truncate text-[13px] text-text-3">
                   {file.folderName} • {formatBytes(file.sizeBytes)} •
@@ -902,6 +940,7 @@ export default function KnowledgeCorePage() {
                   <SelectItem value="admins">Admins only</SelectItem>
                 )}
                 <SelectItem value="teams">Specific teams…</SelectItem>
+                <SelectItem value="project">Specific project…</SelectItem>
               </SelectContent>
             </Select>
             <p className="text-[11px] text-text-3">
@@ -909,7 +948,9 @@ export default function KnowledgeCorePage() {
                 ? "Only admins will see these files in chat / arena. You can change this later from the file's action menu."
                 : stagedVisibility === "teams"
                   ? "Only members of the teams you pick below will see these files in chat / arena."
-                  : "Every user in the company can see these files in chat / arena."}
+                  : stagedVisibility === "project"
+                    ? "These files will only appear in the chat of the project(s) you pick below — never in the org-wide RAG."
+                    : "Every user in the company can see these files in chat / arena."}
             </p>
           </div>
 
@@ -958,6 +999,59 @@ export default function KnowledgeCorePage() {
               )}
             </div>
           )}
+
+          {/* Project checkbox panel — shown only when
+              visibility='project'. Same shape as the teams panel.
+              Lists every project the caller can access (their own
+              + team projects). Empty state mirrors the teams case
+              so the dialog stays consistent. */}
+          {stagedVisibility === "project" && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-[12px] font-medium text-text-1">
+                Projects with access
+              </label>
+              {userProjects.length === 0 ? (
+                <p className="text-[11px] text-text-3">
+                  You don&rsquo;t have access to any projects yet — create
+                  one first to use this visibility option.
+                </p>
+              ) : (
+                <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
+                  {userProjects.map((p) => {
+                    const checked = stagedProjectIds.includes(p.id);
+                    return (
+                      <label
+                        key={p.id}
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={uploading}
+                          onChange={() => {
+                            setStagedProjectIds((prev) =>
+                              checked
+                                ? prev.filter((id) => id !== p.id)
+                                : [...prev, p.id],
+                            );
+                          }}
+                          className="h-3.5 w-3.5 cursor-pointer accent-primary-6"
+                        />
+                        <span className="truncate">
+                          {p.name}
+                          {p.teamName ? (
+                            <span className="ml-1 text-text-3">
+                              · {p.teamName}
+                            </span>
+                          ) : null}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
           <DialogFooter className="gap-2">
             <Button
               variant="outline"
@@ -965,6 +1059,7 @@ export default function KnowledgeCorePage() {
                 setStagedFiles([]);
                 setStagedVisibility("all");
                 setStagedTeamIds([]);
+                setStagedProjectIds([]);
               }}
               disabled={uploading}
               className="cursor-pointer"

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -25,6 +25,7 @@ import { toast } from "sonner";
 import {
   fetchKnowledgeFolders,
   fetchRecentKnowledgeFiles,
+  fetchTeams,
   createKnowledgeFolder,
   deleteKnowledgeFolder,
   uploadKnowledgeFiles,
@@ -134,7 +135,13 @@ function IngestionStatusBadge({
  * scream a designation that's the unremarkable default. Kept inline
  * (not a shared component) for the same reason as IngestionStatusBadge.
  */
-function VisibilityBadge({ visibility }: { visibility: KnowledgeFileVisibility }) {
+function VisibilityBadge({
+  visibility,
+  teams = [],
+}: {
+  visibility: KnowledgeFileVisibility;
+  teams?: { id: string; name: string }[];
+}) {
   if (visibility === "admins") {
     return (
       <span
@@ -143,6 +150,22 @@ function VisibilityBadge({ visibility }: { visibility: KnowledgeFileVisibility }
       >
         <Shield className="h-3 w-3" strokeWidth={2} />
         Admins only
+      </span>
+    );
+  }
+  if (visibility === "teams") {
+    const names = teams.map((t) => t.name).join(", ");
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-primary-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-7"
+        title={
+          names.length > 0
+            ? `Only members of these teams can see this file in chat / arena: ${names}.`
+            : "Visibility is set to specific teams, but no team is linked yet — no one can see this file."
+        }
+      >
+        <Users className="h-3 w-3" strokeWidth={2} />
+        {teams.length > 0 ? `Teams (${teams.length})` : "Teams"}
       </span>
     );
   }
@@ -328,9 +351,28 @@ export default function KnowledgeCorePage() {
   // across batches.
   const [stagedVisibility, setStagedVisibility] =
     useState<KnowledgeFileVisibility>("all");
+  // Selected team IDs for the 'teams' visibility option. Reset along
+  // with `stagedVisibility` so a previous batch's selection doesn't
+  // leak into the next one.
+  const [stagedTeamIds, setStagedTeamIds] = useState<string[]>([]);
+
+  // Pull the user's team list once; only meaningful for company
+  // profiles, but we render it lazily anyway (the picker only appears
+  // when 'teams' is the chosen visibility).
+  const { data: userTeams = [] } = useQuery({
+    queryKey: ["teams"],
+    queryFn: fetchTeams,
+  });
 
   const confirmUpload = async () => {
     if (stagedFiles.length === 0) return;
+    // Block submit when 'teams' is picked but no team is checked —
+    // the BE would reject this too, but a client-side guard keeps
+    // the dialog from collapsing on a 400 with stale staged files.
+    if (stagedVisibility === "teams" && stagedTeamIds.length === 0) {
+      toast.error("Pick at least one team for Teams visibility.");
+      return;
+    }
     setUploading(true);
     try {
       const folderId = await getAllFilesFolderId();
@@ -338,6 +380,7 @@ export default function KnowledgeCorePage() {
         folderId,
         stagedFiles,
         stagedVisibility,
+        stagedTeamIds,
       );
       await Promise.all([
         queryClient.refetchQueries({ queryKey: ["knowledge-folders"] }),
@@ -364,8 +407,9 @@ export default function KnowledgeCorePage() {
       }
       setStagedFiles([]);
       setStagedVisibility("all");
-    } catch {
-      toast.error("Failed to upload files.");
+      setStagedTeamIds([]);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to upload files.");
     } finally {
       setUploading(false);
     }
@@ -548,7 +592,7 @@ export default function KnowledgeCorePage() {
                     status={file.ingestionStatus}
                     error={file.ingestionError}
                   />
-                  <VisibilityBadge visibility={file.visibility} />
+                  <VisibilityBadge visibility={file.visibility} teams={file.teams} />
                 </div>
                 <span className="truncate text-[13px] text-text-3">
                   {file.folderName} • {formatBytes(file.sizeBytes)} •
@@ -794,41 +838,94 @@ export default function KnowledgeCorePage() {
             ))}
           </div>
 
-          {/* Admin-only visibility select. Hidden for non-admins so
-              the only thing they see is the upload list — their
-              uploads ship with the default 'all' visibility (BE
-              forces 'all' anyway for non-admin callers). */}
-          {isAdmin && (
-            <div className="flex flex-col gap-1.5 pt-1">
-              <label className="text-[12px] font-medium text-text-1">
-                Visibility
-              </label>
-              <Select
-                value={stagedVisibility}
-                onValueChange={(v) =>
-                  setStagedVisibility(v as KnowledgeFileVisibility)
-                }
-                disabled={uploading}
-              >
-                <SelectTrigger className="h-10 w-full cursor-pointer">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Everyone in the company</SelectItem>
+          {/* Visibility picker. All users see this now — 'all' and
+              'teams' are open to everyone, 'admins' is admin-only.
+              The team-checkbox panel appears below when 'teams' is
+              the active choice; nothing else changes the layout. */}
+          <div className="flex flex-col gap-1.5 pt-1">
+            <label className="text-[12px] font-medium text-text-1">
+              Visibility
+            </label>
+            <Select
+              value={stagedVisibility}
+              onValueChange={(v) =>
+                setStagedVisibility(v as KnowledgeFileVisibility)
+              }
+              disabled={uploading}
+            >
+              <SelectTrigger className="h-10 w-full cursor-pointer">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Everyone in the company</SelectItem>
+                {isAdmin && (
                   <SelectItem value="admins">Admins only</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-[11px] text-text-3">
-                {stagedVisibility === "admins"
-                  ? "Only admins will see these files in chat / arena. You can change this later from the file's action menu."
+                )}
+                <SelectItem value="teams">Specific teams…</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-[11px] text-text-3">
+              {stagedVisibility === "admins"
+                ? "Only admins will see these files in chat / arena. You can change this later from the file's action menu."
+                : stagedVisibility === "teams"
+                  ? "Only members of the teams you pick below will see these files in chat / arena."
                   : "Every user in the company can see these files in chat / arena."}
-              </p>
+            </p>
+          </div>
+
+          {/* Team checkbox panel — shown only when visibility='teams'.
+              Lists the user's teams (owned + accepted membership);
+              the BE rejects assignments to teams the user isn't in
+              for non-admins, so listing them here would just route
+              users to a 403. Empty state has its own copy. */}
+          {stagedVisibility === "teams" && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-[12px] font-medium text-text-1">
+                Teams with access
+              </label>
+              {userTeams.length === 0 ? (
+                <p className="text-[11px] text-text-3">
+                  You aren&rsquo;t a member of any team yet — create or
+                  join a team first to use this visibility option.
+                </p>
+              ) : (
+                <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
+                  {userTeams.map((t) => {
+                    const checked = stagedTeamIds.includes(t.id);
+                    return (
+                      <label
+                        key={t.id}
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={uploading}
+                          onChange={() => {
+                            setStagedTeamIds((prev) =>
+                              checked
+                                ? prev.filter((id) => id !== t.id)
+                                : [...prev, t.id],
+                            );
+                          }}
+                          className="h-3.5 w-3.5 cursor-pointer accent-primary-6"
+                        />
+                        <span className="truncate">{t.name}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           )}
           <DialogFooter className="gap-2">
             <Button
               variant="outline"
-              onClick={() => setStagedFiles([])}
+              onClick={() => {
+                setStagedFiles([]);
+                setStagedVisibility("all");
+                setStagedTeamIds([]);
+              }}
               disabled={uploading}
               className="cursor-pointer"
             >

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { Loader2 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { Sidebar, Appbar } from "@/components/layout";
+import { Sidebar, Appbar, Footer } from "@/components/layout";
 import { AuthProvider, useAuth } from "@/components/providers";
 import { SidebarProvider } from "@/hooks/use-sidebar";
 import { getRouteConfig } from "@/lib/route-config";
@@ -56,8 +56,14 @@ export default function AppLayout({
             <main className="flex min-w-0 flex-1 flex-col">
               <Appbar />
               <div className="min-h-0 flex-1 overflow-auto">
-                <div className="flex min-h-full flex-col px-6 pb-6">
+                {/* `min-h-full flex-col` + `mt-auto` on Footer makes
+                    the copyright row stick to the viewport bottom on
+                    short pages and yield naturally on long ones.
+                    Bottom padding lives on the Footer now, so we
+                    don't double-pad below the copyright line. */}
+                <div className="flex min-h-full flex-col px-6 pb-2">
                   {children}
+                  <Footer />
                 </div>
               </div>
             </main>

--- a/apps/web/src/app/(app)/notifications/page.tsx
+++ b/apps/web/src/app/(app)/notifications/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Bell,
+  CheckCheck,
+  CircleDollarSign,
+  Loader2,
+  Users,
+  X,
+} from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  acceptNotification,
+  declineNotification,
+  dismissNotification,
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  type Notification,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type Filter = "all" | "unread" | "actionable";
+
+function NotificationIcon({ type }: { type: Notification["type"] }) {
+  if (type === "team_invite" || type === "org_invite") {
+    return <Users className="h-4 w-4 text-primary-7" strokeWidth={2} />;
+  }
+  if (type === "budget_alert") {
+    return (
+      <CircleDollarSign className="h-4 w-4 text-warning-7" strokeWidth={2} />
+    );
+  }
+  return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;
+}
+
+function formatFull(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+/**
+ * Full-page notification history. Mirrors the popover with more
+ * room: filters across the top, full-width rows, no truncation on
+ * the list. Used when the user clicks "View all" in the sidebar
+ * popover.
+ */
+export default function NotificationsPage() {
+  const [filter, setFilter] = useState<Filter>("all");
+  const queryClient = useQueryClient();
+
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: ["notifications"],
+    queryFn: fetchNotifications,
+  });
+
+  const filtered = useMemo(() => {
+    if (filter === "unread") return items.filter((n) => n.readAt == null);
+    if (filter === "actionable")
+      return items.filter(
+        (n) => n.status === "pending" && n.type === "team_invite",
+      );
+    return items;
+  }, [items, filter]);
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["notifications"] });
+
+  const acceptMutation = useMutation({
+    mutationFn: (id: string) => acceptNotification(id),
+    onSuccess: () => {
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+      toast.success("Invitation accepted.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to accept."),
+  });
+  const declineMutation = useMutation({
+    mutationFn: (id: string) => declineNotification(id),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Invitation declined.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to decline."),
+  });
+  const dismissMutation = useMutation({
+    mutationFn: (id: string) => dismissNotification(id),
+    onSuccess: invalidate,
+  });
+  const markReadMutation = useMutation({
+    mutationFn: (id: string) => markNotificationRead(id),
+    onSuccess: invalidate,
+  });
+  const markAllMutation = useMutation({
+    mutationFn: () => markAllNotificationsRead(),
+    onSuccess: () => {
+      invalidate();
+      toast.success("All notifications marked as read.");
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <header className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-[24px] font-bold text-text-1">Notifications</h1>
+          <p className="text-[13px] text-text-3">
+            Team invitations, role changes, and budget alerts — all in one
+            place. Email keeps firing in parallel as a backup.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => markAllMutation.mutate()}
+          disabled={
+            markAllMutation.isPending ||
+            items.every((n) => n.readAt != null)
+          }
+          className="flex items-center gap-1.5 cursor-pointer rounded-md border border-border-3 px-3 py-1.5 text-[13px] text-text-1 hover:bg-bg-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <CheckCheck className="h-3.5 w-3.5" />
+          Mark all read
+        </button>
+      </header>
+
+      <div className="flex gap-2">
+        {(["all", "unread", "actionable"] as Filter[]).map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFilter(f)}
+            className={cn(
+              "cursor-pointer rounded-md border px-3 py-1 text-[13px]",
+              filter === f
+                ? "border-primary-6 bg-primary-1 text-primary-7"
+                : "border-border-3 bg-bg-white text-text-2 hover:bg-bg-1",
+            )}
+          >
+            {f === "all"
+              ? "All"
+              : f === "unread"
+                ? "Unread"
+                : "Needs action"}
+          </button>
+        ))}
+      </div>
+
+      <div className="rounded-lg border border-border-2 bg-bg-white">
+        {isLoading ? (
+          <div className="flex items-center justify-center px-4 py-12 text-text-3">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Loading…
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="px-4 py-12 text-center text-text-3">
+            {filter === "all"
+              ? "You're all caught up."
+              : filter === "unread"
+                ? "No unread notifications."
+                : "No invitations waiting on you."}
+          </div>
+        ) : (
+          <ul className="divide-y divide-border-2">
+            {filtered.map((n) => (
+              <li
+                key={n.id}
+                className={cn(
+                  "flex items-start gap-3 px-4 py-3",
+                  n.readAt == null && "bg-primary-1/40",
+                )}
+              >
+                <span className="mt-0.5">
+                  <NotificationIcon type={n.type} />
+                </span>
+                <div className="flex flex-1 flex-col gap-1 min-w-0">
+                  <p className="text-[14px] font-medium text-text-1">
+                    {n.title}
+                  </p>
+                  {n.body && (
+                    <p className="text-[13px] text-text-2">{n.body}</p>
+                  )}
+                  <span className="text-[11px] text-text-3">
+                    {formatFull(n.createdAt)}
+                  </span>
+                  {n.status === "pending" && n.type === "team_invite" && (
+                    <div className="mt-2 flex gap-2">
+                      <button
+                        type="button"
+                        disabled={acceptMutation.isPending}
+                        onClick={() => acceptMutation.mutate(n.id)}
+                        className="cursor-pointer rounded bg-primary-6 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-primary-7 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        disabled={declineMutation.isPending}
+                        onClick={() => declineMutation.mutate(n.id)}
+                        className="cursor-pointer rounded border border-border-3 px-3 py-1.5 text-[13px] font-medium text-text-1 hover:bg-bg-1 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        Decline
+                      </button>
+                    </div>
+                  )}
+                  {n.status === "acted" && (
+                    <span className="mt-1 text-[11px] text-text-3 italic">
+                      Resolved
+                    </span>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  {n.readAt == null && (
+                    <button
+                      type="button"
+                      title="Mark read"
+                      aria-label="Mark read"
+                      onClick={() => markReadMutation.mutate(n.id)}
+                      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-1 hover:text-text-1"
+                    >
+                      <CheckCheck className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    title="Dismiss"
+                    aria-label="Dismiss"
+                    onClick={() => dismissMutation.mutate(n.id)}
+                    className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-1 hover:text-text-1"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/notifications/page.tsx
+++ b/apps/web/src/app/(app)/notifications/page.tsx
@@ -6,7 +6,9 @@ import {
   CheckCheck,
   CircleDollarSign,
   FileWarning,
+  FolderOpen,
   Loader2,
+  Shield,
   Users,
   X,
 } from "lucide-react";
@@ -48,6 +50,12 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
     return (
       <FileWarning className="h-4 w-4 text-warning-7" strokeWidth={2} />
     );
+  }
+  if (type === "project_created" || type === "project_deleted") {
+    return <FolderOpen className="h-4 w-4 text-text-3" strokeWidth={2} />;
+  }
+  if (type === "guardrail_added") {
+    return <Shield className="h-4 w-4 text-text-3" strokeWidth={2} />;
   }
   if (
     type === "team_renamed" ||

--- a/apps/web/src/app/(app)/notifications/page.tsx
+++ b/apps/web/src/app/(app)/notifications/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import {
   acceptNotification,
   declineNotification,
@@ -110,65 +111,68 @@ export default function NotificationsPage() {
     },
   });
 
+  const allRead = items.every((n) => n.readAt != null);
+
   return (
-    <div className="flex flex-col gap-4 p-6">
-      <header className="flex items-center justify-between">
-        <div className="flex flex-col gap-1">
-          <h1 className="text-[24px] font-bold text-text-1">Notifications</h1>
-          <p className="text-[13px] text-text-3">
-            Team invitations, role changes, and budget alerts — all in one
-            place. Email keeps firing in parallel as a backup.
-          </p>
+    <div className="flex flex-col gap-4 pt-4">
+      {/* Filters + bulk action row. Filters wrap to a new line on
+          narrow screens; the action button keeps its right alignment
+          via flex-wrap + justify-between behaviour. Title comes from
+          the appbar, so no <h1> here. */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          {(["all", "unread", "actionable"] as Filter[]).map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setFilter(f)}
+              className={cn(
+                "cursor-pointer rounded-lg border px-3 py-1.5 text-[13px] transition-colors",
+                filter === f
+                  ? "border-primary-6 bg-primary-1 text-primary-7"
+                  : "border-border-3 bg-bg-white text-text-2 hover:bg-bg-1",
+              )}
+            >
+              {f === "all"
+                ? "All"
+                : f === "unread"
+                  ? "Unread"
+                  : "Needs action"}
+            </button>
+          ))}
         </div>
-        <button
-          type="button"
+        <Button
+          variant="outline"
+          size="sm"
           onClick={() => markAllMutation.mutate()}
-          disabled={
-            markAllMutation.isPending ||
-            items.every((n) => n.readAt != null)
-          }
-          className="flex items-center gap-1.5 cursor-pointer rounded-md border border-border-3 px-3 py-1.5 text-[13px] text-text-1 hover:bg-bg-1 disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={markAllMutation.isPending || allRead}
+          className="cursor-pointer gap-1.5 rounded-lg"
         >
           <CheckCheck className="h-3.5 w-3.5" />
-          Mark all read
-        </button>
-      </header>
-
-      <div className="flex gap-2">
-        {(["all", "unread", "actionable"] as Filter[]).map((f) => (
-          <button
-            key={f}
-            type="button"
-            onClick={() => setFilter(f)}
-            className={cn(
-              "cursor-pointer rounded-md border px-3 py-1 text-[13px]",
-              filter === f
-                ? "border-primary-6 bg-primary-1 text-primary-7"
-                : "border-border-3 bg-bg-white text-text-2 hover:bg-bg-1",
-            )}
-          >
-            {f === "all"
-              ? "All"
-              : f === "unread"
-                ? "Unread"
-                : "Needs action"}
-          </button>
-        ))}
+          <span className="hidden sm:inline">Mark all read</span>
+          <span className="sm:hidden">Read all</span>
+        </Button>
       </div>
 
-      <div className="rounded-lg border border-border-2 bg-bg-white">
+      {/* Main list card — matches the surface treatment used on
+          /guardrails, /knowledge-core, etc: rounded-[20px], white
+          background, no border (the shadow + radius do the lift). */}
+      <div className="overflow-hidden rounded-[20px] bg-bg-white shadow-[0_1px_3px_rgba(0,0,0,0.06)]">
         {isLoading ? (
-          <div className="flex items-center justify-center px-4 py-12 text-text-3">
+          <div className="flex items-center justify-center px-4 py-16 text-[13px] text-text-3">
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             Loading…
           </div>
         ) : filtered.length === 0 ? (
-          <div className="px-4 py-12 text-center text-text-3">
-            {filter === "all"
-              ? "You're all caught up."
-              : filter === "unread"
-                ? "No unread notifications."
-                : "No invitations waiting on you."}
+          <div className="flex flex-col items-center gap-2 px-4 py-16 text-center text-text-3">
+            <Bell className="h-6 w-6 text-text-3" />
+            <p className="text-[14px]">
+              {filter === "all"
+                ? "You're all caught up."
+                : filter === "unread"
+                  ? "No unread notifications."
+                  : "No invitations waiting on you."}
+            </p>
           </div>
         ) : (
           <ul className="divide-y divide-border-2">
@@ -176,45 +180,48 @@ export default function NotificationsPage() {
               <li
                 key={n.id}
                 className={cn(
-                  "flex items-start gap-3 px-4 py-3",
-                  n.readAt == null && "bg-primary-1/40",
+                  "flex items-start gap-3 px-4 py-3 sm:px-5 sm:py-4",
+                  n.readAt == null && "bg-primary-1/30",
                 )}
               >
-                <span className="mt-0.5">
+                <span className="mt-0.5 shrink-0">
                   <NotificationIcon type={n.type} />
                 </span>
-                <div className="flex flex-1 flex-col gap-1 min-w-0">
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
                   <p className="text-[14px] font-medium text-text-1">
                     {n.title}
                   </p>
                   {n.body && (
-                    <p className="text-[13px] text-text-2">{n.body}</p>
+                    <p className="text-[13px] text-text-2 whitespace-pre-line break-words">
+                      {n.body}
+                    </p>
                   )}
                   <span className="text-[11px] text-text-3">
                     {formatFull(n.createdAt)}
                   </span>
                   {n.status === "pending" && n.type === "team_invite" && (
-                    <div className="mt-2 flex gap-2">
-                      <button
-                        type="button"
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <Button
+                        size="sm"
                         disabled={acceptMutation.isPending}
                         onClick={() => acceptMutation.mutate(n.id)}
-                        className="cursor-pointer rounded bg-primary-6 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-primary-7 disabled:cursor-not-allowed disabled:opacity-60"
+                        className="cursor-pointer rounded-lg bg-primary-6 text-white hover:bg-primary-7"
                       >
                         Accept
-                      </button>
-                      <button
-                        type="button"
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
                         disabled={declineMutation.isPending}
                         onClick={() => declineMutation.mutate(n.id)}
-                        className="cursor-pointer rounded border border-border-3 px-3 py-1.5 text-[13px] font-medium text-text-1 hover:bg-bg-1 disabled:cursor-not-allowed disabled:opacity-60"
+                        className="cursor-pointer rounded-lg"
                       >
                         Decline
-                      </button>
+                      </Button>
                     </div>
                   )}
                   {n.status === "acted" && (
-                    <span className="mt-1 text-[11px] text-text-3 italic">
+                    <span className="mt-1 text-[11px] italic text-text-3">
                       Resolved
                     </span>
                   )}
@@ -226,7 +233,7 @@ export default function NotificationsPage() {
                       title="Mark read"
                       aria-label="Mark read"
                       onClick={() => markReadMutation.mutate(n.id)}
-                      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-1 hover:text-text-1"
+                      className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-text-3 hover:bg-bg-1 hover:text-text-1"
                     >
                       <CheckCheck className="h-3.5 w-3.5" />
                     </button>
@@ -236,7 +243,7 @@ export default function NotificationsPage() {
                     title="Dismiss"
                     aria-label="Dismiss"
                     onClick={() => dismissMutation.mutate(n.id)}
-                    className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-1 hover:text-text-1"
+                    className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-text-3 hover:bg-bg-1 hover:text-text-1"
                   >
                     <X className="h-3.5 w-3.5" />
                   </button>

--- a/apps/web/src/app/(app)/notifications/page.tsx
+++ b/apps/web/src/app/(app)/notifications/page.tsx
@@ -38,6 +38,9 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
     );
   }
+  if (type === "team_renamed") {
+    return <Users className="h-4 w-4 text-text-3" strokeWidth={2} />;
+  }
   return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;
 }
 

--- a/apps/web/src/app/(app)/notifications/page.tsx
+++ b/apps/web/src/app/(app)/notifications/page.tsx
@@ -33,6 +33,11 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-warning-7" strokeWidth={2} />
     );
   }
+  if (type === "budget_changed") {
+    return (
+      <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
+    );
+  }
   return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;
 }
 

--- a/apps/web/src/app/(app)/notifications/page.tsx
+++ b/apps/web/src/app/(app)/notifications/page.tsx
@@ -39,7 +39,7 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
     );
   }
-  if (type === "team_renamed") {
+  if (type === "team_renamed" || type === "team_role_changed") {
     return <Users className="h-4 w-4 text-text-3" strokeWidth={2} />;
   }
   return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;

--- a/apps/web/src/app/(app)/notifications/page.tsx
+++ b/apps/web/src/app/(app)/notifications/page.tsx
@@ -5,6 +5,7 @@ import {
   Bell,
   CheckCheck,
   CircleDollarSign,
+  FileWarning,
   Loader2,
   Users,
   X,
@@ -34,12 +35,28 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-warning-7" strokeWidth={2} />
     );
   }
-  if (type === "budget_changed") {
+  if (
+    type === "budget_changed" ||
+    type === "account_budget_changed" ||
+    type === "member_cap_changed"
+  ) {
     return (
       <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
     );
   }
-  if (type === "team_renamed" || type === "team_role_changed") {
+  if (type === "file_ingestion_failed") {
+    return (
+      <FileWarning className="h-4 w-4 text-warning-7" strokeWidth={2} />
+    );
+  }
+  if (
+    type === "team_renamed" ||
+    type === "team_role_changed" ||
+    type === "team_member_added" ||
+    type === "team_member_removed" ||
+    type === "team_deleted" ||
+    type === "account_role_changed"
+  ) {
     return <Users className="h-4 w-4 text-text-3" strokeWidth={2} />;
   }
   return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;

--- a/apps/web/src/app/(app)/projects/create/page.tsx
+++ b/apps/web/src/app/(app)/projects/create/page.tsx
@@ -30,6 +30,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   createProject,
   fetchTeams,
   // Kept for the (commented-out) "invite members on project create" flow.
@@ -277,7 +282,17 @@ export default function CreateProjectPage() {
                 }`}
               >
                 Personal
-                <Info className="h-[18px] w-[18px] opacity-60" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex items-center">
+                      <Info className="h-[18px] w-[18px] opacity-60" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs text-center">
+                    A private workspace only you can access. Spend
+                    counts against your personal monthly budget.
+                  </TooltipContent>
+                </Tooltip>
               </button>
               <button
                 onClick={() => setProjectType("team")}
@@ -288,7 +303,18 @@ export default function CreateProjectPage() {
                 }`}
               >
                 Team
-                <Info className="h-[18px] w-[18px] opacity-60" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex items-center">
+                      <Info className="h-[18px] w-[18px] opacity-60" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs text-center">
+                    A shared workspace for a team. Spend counts against
+                    the chosen team&rsquo;s monthly budget and members
+                    can collaborate on prompts and chatbots.
+                  </TooltipContent>
+                </Tooltip>
               </button>
             </div>
 

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -375,7 +375,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
       role,
     }: {
       memberId: string;
-      role: "admin" | "editor" | "viewer";
+      role: "admin" | "manager" | "editor" | "viewer";
     }) => updateMemberRole(id, memberId, role),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams", id] }),
     onError: (err: Error) =>
@@ -502,13 +502,16 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     (currentUser.id === team.ownerId ||
       myMembership?.role === "owner" ||
       myMembership?.role === "admin" ||
+      myMembership?.role === "manager" ||
       myMembership?.role === "editor");
-  // Owner-equivalent rights: owner or admin. Required to promote /
-  // demote 'admin' roles and (later) to surface budget / invitation
-  // controls scoped to the team.
+  // Owner-equivalent rights: owner, admin, or manager. Required to
+  // promote / demote 'admin' or 'manager' rows and (later) to
+  // surface budget / invitation controls scoped to the team.
   const hasOwnerRights =
     !!currentUser &&
-    (currentUser.id === team.ownerId || myMembership?.role === "admin");
+    (currentUser.id === team.ownerId ||
+      myMembership?.role === "admin" ||
+      myMembership?.role === "manager");
   // Back-compat alias used by the role Select.
   const canEditRoles = canManageTeam;
 
@@ -973,6 +976,11 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                                 Team Admin
                               </Badge>
                             )}
+                            {m.role === "manager" && (
+                              <Badge className="border-transparent bg-success-1 text-success-7 uppercase tracking-wide text-[10px] px-1.5 py-0">
+                                Team Manager
+                              </Badge>
+                            )}
                             {m.status === "pending" && <span className="rounded-lg bg-bg-2 px-2 py-0.5 text-[13px] text-text-3">Pending</span>}
                           </span>
                         </div>
@@ -988,22 +996,24 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                             value={m.role}
                             // Editors can flip editor↔viewer but the
                             // BE rejects them touching anything that
-                            // involves 'admin' (promoting to it or
-                            // demoting from it). Disable the whole
-                            // control when the target is currently
-                            // admin and the caller isn't owner-level,
-                            // so the editor sees a read-only "Admin"
-                            // chip instead of an option set that
-                            // would 403 on submit.
+                            // involves 'admin' or 'manager' (promo-
+                            // ting to / demoting from). Disable the
+                            // whole control when the target is one
+                            // of those tiers and the caller isn't
+                            // owner-level, so the editor sees a
+                            // read-only chip instead of an option
+                            // set that would 403 on submit.
                             disabled={
                               !canEditRoles ||
-                              (m.role === "admin" && !hasOwnerRights)
+                              ((m.role === "admin" || m.role === "manager") &&
+                                !hasOwnerRights)
                             }
                             onValueChange={(value) =>
                               roleMutation.mutate({
                                 memberId: m.id,
                                 role: value as
                                   | "admin"
+                                  | "manager"
                                   | "editor"
                                   | "viewer",
                               })
@@ -1013,13 +1023,17 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              {/* 'Admin' is only offered to owner-
-                                  level callers. Stays in the list when
-                                  the target is already admin so the
-                                  Select can display the current value
-                                  even for a read-only editor view. */}
+                              {/* Admin / Manager are only offered to
+                                  owner-level callers. Stays in the
+                                  list when the target is already in
+                                  that tier so the Select can display
+                                  the current value even for a read-
+                                  only editor view. */}
                               {(hasOwnerRights || m.role === "admin") && (
                                 <SelectItem value="admin">Admin</SelectItem>
+                              )}
+                              {(hasOwnerRights || m.role === "manager") && (
+                                <SelectItem value="manager">Manager</SelectItem>
                               )}
                               <SelectItem value="editor">Editor</SelectItem>
                               <SelectItem value="viewer">Viewer</SelectItem>

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -19,7 +19,12 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { DisabledReasonTooltip } from "@/components/ui/tooltip";
+import {
+  DisabledReasonTooltip,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAuth } from "@/components/providers";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -689,7 +694,23 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
           <div className="space-y-3">
             <div className="flex items-center gap-3">
               <p className="text-[18px] font-bold text-text-1">Projected</p>
-              <Info className="h-3.5 w-3.5 text-text-3" />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="What does Projected mean?"
+                    className="flex items-center justify-center text-text-3 hover:text-text-1"
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs text-center">
+                  Linear forecast of this team&rsquo;s total spend by
+                  month-end, extrapolated from the daily run-rate so
+                  far. Early in the month it can swing widely, then
+                  stabilizes.
+                </TooltipContent>
+              </Tooltip>
             </div>
             <div className="flex items-center gap-2.5 h-[56px]">
               <span className="text-[16px] text-text-1">{formatCurrency(projected)}</span>

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -370,8 +370,16 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams", id] }),
   });
   const roleMutation = useMutation({
-    mutationFn: ({ memberId, role }: { memberId: string; role: "editor" | "viewer" }) => updateMemberRole(id, memberId, role),
+    mutationFn: ({
+      memberId,
+      role,
+    }: {
+      memberId: string;
+      role: "admin" | "editor" | "viewer";
+    }) => updateMemberRole(id, memberId, role),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams", id] }),
+    onError: (err: Error) =>
+      toast.error(err.message || "Couldn't update member role."),
   });
   const removeMutation = useMutation({
     mutationFn: (memberId: string) => removeTeamMember(id, memberId),
@@ -491,7 +499,16 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
   );
   const canManageTeam =
     !!currentUser &&
-    (currentUser.id === team.ownerId || myMembership?.role === "owner" || myMembership?.role === "editor");
+    (currentUser.id === team.ownerId ||
+      myMembership?.role === "owner" ||
+      myMembership?.role === "admin" ||
+      myMembership?.role === "editor");
+  // Owner-equivalent rights: owner or admin. Required to promote /
+  // demote 'admin' roles and (later) to surface budget / invitation
+  // controls scoped to the team.
+  const hasOwnerRights =
+    !!currentUser &&
+    (currentUser.id === team.ownerId || myMembership?.role === "admin");
   // Back-compat alias used by the role Select.
   const canEditRoles = canManageTeam;
 
@@ -951,6 +968,11 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                                 Team Owner
                               </Badge>
                             )}
+                            {m.role === "admin" && (
+                              <Badge className="border-transparent bg-warning-1 text-warning-7 uppercase tracking-wide text-[10px] px-1.5 py-0">
+                                Team Admin
+                              </Badge>
+                            )}
                             {m.status === "pending" && <span className="rounded-lg bg-bg-2 px-2 py-0.5 text-[13px] text-text-3">Pending</span>}
                           </span>
                         </div>
@@ -964,11 +986,26 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                         ) : (
                           <Select
                             value={m.role}
-                            disabled={!canEditRoles}
+                            // Editors can flip editor↔viewer but the
+                            // BE rejects them touching anything that
+                            // involves 'admin' (promoting to it or
+                            // demoting from it). Disable the whole
+                            // control when the target is currently
+                            // admin and the caller isn't owner-level,
+                            // so the editor sees a read-only "Admin"
+                            // chip instead of an option set that
+                            // would 403 on submit.
+                            disabled={
+                              !canEditRoles ||
+                              (m.role === "admin" && !hasOwnerRights)
+                            }
                             onValueChange={(value) =>
                               roleMutation.mutate({
                                 memberId: m.id,
-                                role: value as "editor" | "viewer",
+                                role: value as
+                                  | "admin"
+                                  | "editor"
+                                  | "viewer",
                               })
                             }
                           >
@@ -976,6 +1013,14 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
+                              {/* 'Admin' is only offered to owner-
+                                  level callers. Stays in the list when
+                                  the target is already admin so the
+                                  Select can display the current value
+                                  even for a read-only editor view. */}
+                              {(hasOwnerRights || m.role === "admin") && (
+                                <SelectItem value="admin">Admin</SelectItem>
+                              )}
                               <SelectItem value="editor">Editor</SelectItem>
                               <SelectItem value="viewer">Viewer</SelectItem>
                             </SelectContent>

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -298,7 +298,7 @@ export default function UserDetailPage({
     }: {
       teamId: string;
       memberId: string;
-      role: "editor" | "viewer";
+      role: "admin" | "editor" | "viewer";
     }) => updateMemberRole(teamId, memberId, role),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users", id] });
@@ -709,7 +709,7 @@ export default function UserDetailPage({
                             teamRoleMutation.mutate({
                               teamId: t.id,
                               memberId: t.memberId,
-                              role: value as "editor" | "viewer",
+                              role: value as "admin" | "editor" | "viewer",
                             })
                           }
                         >
@@ -717,6 +717,13 @@ export default function UserDetailPage({
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
+                            {/* 'Admin' is gated by the BE — promoting
+                                to / from admin requires owner-level
+                                rights. Keep the option visible so the
+                                Select can render the current value
+                                even when read-only; the 403 surfaces
+                                as a toast for editors who try. */}
+                            <SelectItem value="admin">Admin</SelectItem>
                             <SelectItem value="editor">Editor</SelectItem>
                             <SelectItem value="viewer">Viewer</SelectItem>
                           </SelectContent>

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -642,7 +642,23 @@ export default function UserDetailPage({
           <div className="space-y-3">
             <div className="flex items-center gap-3">
               <p className="text-[18px] font-bold text-text-1">Projected</p>
-              <Info className="h-3.5 w-3.5 text-text-3" />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="What does Projected mean?"
+                    className="flex items-center justify-center text-text-3 hover:text-text-1"
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs text-center">
+                  Linear forecast of this user&rsquo;s total spend by
+                  month-end, extrapolated from the daily run-rate so
+                  far. Early in the month it can swing widely, then
+                  stabilizes.
+                </TooltipContent>
+              </Tooltip>
             </div>
             <div className="flex items-center gap-2.5 h-[56px]">
               <span className="text-[16px] text-text-1">{formatCurrency(projected)}</span>

--- a/apps/web/src/app/(app)/users/[id]/page.tsx
+++ b/apps/web/src/app/(app)/users/[id]/page.tsx
@@ -298,7 +298,7 @@ export default function UserDetailPage({
     }: {
       teamId: string;
       memberId: string;
-      role: "admin" | "editor" | "viewer";
+      role: "admin" | "manager" | "editor" | "viewer";
     }) => updateMemberRole(teamId, memberId, role),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users", id] });
@@ -709,7 +709,11 @@ export default function UserDetailPage({
                             teamRoleMutation.mutate({
                               teamId: t.id,
                               memberId: t.memberId,
-                              role: value as "admin" | "editor" | "viewer",
+                              role: value as
+                                | "admin"
+                                | "manager"
+                                | "editor"
+                                | "viewer",
                             })
                           }
                         >
@@ -717,13 +721,15 @@ export default function UserDetailPage({
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
-                            {/* 'Admin' is gated by the BE — promoting
-                                to / from admin requires owner-level
-                                rights. Keep the option visible so the
-                                Select can render the current value
-                                even when read-only; the 403 surfaces
-                                as a toast for editors who try. */}
+                            {/* 'Admin' and 'Manager' are gated by
+                                the BE — promoting to / from those
+                                tiers requires owner-level rights.
+                                Options stay visible so the Select
+                                renders the current value even when
+                                read-only; the 403 surfaces as a
+                                toast for editors who try. */}
                             <SelectItem value="admin">Admin</SelectItem>
+                            <SelectItem value="manager">Manager</SelectItem>
                             <SelectItem value="editor">Editor</SelectItem>
                             <SelectItem value="viewer">Viewer</SelectItem>
                           </SelectContent>

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -1,14 +1,25 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import {
   createDocument,
   fetchDocumentGroups,
   deleteDocumentGroup,
-  uploadDocumentFile,
+  fetchKnowledgeFolders,
+  fetchKnowledgeFolder,
+  fetchProjectKnowledgeFiles,
+  fetchProjectKnowledgeUploadDefaults,
+  fetchTeams,
+  attachKnowledgeFiles,
+  detachKnowledgeFile,
+  uploadProjectKnowledgeFiles,
   type DocumentGroup,
+  type ProjectKnowledgeFile,
+  type KnowledgeFileVisibility,
 } from "@/lib/api";
+import { useAuth } from "@/components/providers";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -17,6 +28,13 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -24,7 +42,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { FileText, Trash2, Loader2, Upload } from "lucide-react";
+import {
+  FileText,
+  Trash2,
+  Loader2,
+  Upload,
+  CheckCircle2,
+  AlertTriangle,
+  Link2,
+} from "lucide-react";
 
 interface AddDocumentDialogProps {
   projectId: string;
@@ -32,67 +58,284 @@ interface AddDocumentDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+/* ── Small visual helpers (kept local — not reused elsewhere) ──── */
+
+function VisibilityBadge({ visibility }: { visibility: string }) {
+  const tone =
+    visibility === "admins"
+      ? "bg-warning-1 text-warning-7"
+      : visibility === "teams"
+        ? "bg-primary-1 text-primary-7"
+        : "bg-bg-1 text-text-3";
+  const label =
+    visibility === "admins"
+      ? "Admins"
+      : visibility === "teams"
+        ? "Teams"
+        : "Everyone";
+  return (
+    <Badge className={`shrink-0 text-[10px] uppercase tracking-wide ${tone}`}>
+      {label}
+    </Badge>
+  );
+}
+
+function IngestionBadge({ status }: { status: string }) {
+  if (status === "done") {
+    return (
+      <span
+        title="Indexed for chat search"
+        className="inline-flex items-center gap-1 text-[11px] text-success-7"
+      >
+        <CheckCircle2 className="h-3 w-3" /> Indexed
+      </span>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <span
+        title="Couldn't be indexed"
+        className="inline-flex items-center gap-1 text-[11px] text-warning-7"
+      >
+        <AlertTriangle className="h-3 w-3" /> Skipped
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-[11px] text-text-3">
+      <Loader2 className="h-3 w-3 animate-spin" /> Indexing…
+    </span>
+  );
+}
+
+/* ── Dialog ───────────────────────────────────────────────────────── */
+
 export function AddDocumentDialog({
   projectId,
   open,
   onOpenChange,
 }: AddDocumentDialogProps) {
-  const [content, setContent] = useState("");
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
 
+  /* Paste-text state (legacy `documents` table) */
+  const [content, setContent] = useState("");
+
+  /* Upload tab state */
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [uploadFolderId, setUploadFolderId] = useState<string>("");
+  const [uploadVisibility, setUploadVisibility] =
+    useState<KnowledgeFileVisibility>("all");
+  const [uploadTeamIds, setUploadTeamIds] = useState<string[]>([]);
+  const [uploadDefaultsApplied, setUploadDefaultsApplied] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  /* Attach tab state */
+  const [attachSelectedIds, setAttachSelectedIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [attachFolderId, setAttachFolderId] = useState<string>("");
+  const [attachQuery, setAttachQuery] = useState("");
+
+  /* Delete-confirm shared by both lists */
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  /* ── Queries ──────────────────────────────────────────────────── */
+
+  // Legacy paste-text snippets (existing /documents data, plus
+  // anything still using the old upload path).
   const { data: groups, isLoading: groupsLoading } = useQuery({
     queryKey: ["documentGroups", projectId],
     queryFn: () => fetchDocumentGroups(projectId),
     enabled: open,
   });
 
+  // KC files attached to this project.
+  const { data: attachedFiles = [], isLoading: attachedLoading } = useQuery({
+    queryKey: ["project-knowledge-files", projectId],
+    queryFn: () => fetchProjectKnowledgeFiles(projectId),
+    enabled: open,
+  });
+
+  // Smart defaults the BE picks for the upload picker — folder +
+  // visibility + team set are all initialised from this so the
+  // user sees a reasonable preset on first open.
+  const { data: uploadDefaults } = useQuery({
+    queryKey: ["project-upload-defaults", projectId],
+    queryFn: () => fetchProjectKnowledgeUploadDefaults(projectId),
+    enabled: open,
+  });
+
+  // KC folders for the upload-folder picker AND the attach-tab
+  // folder filter.
+  const { data: kcFolders = [] } = useQuery({
+    queryKey: ["knowledge-folders"],
+    queryFn: fetchKnowledgeFolders,
+    enabled: open,
+  });
+
+  // User's teams — populates the team-checkbox panel when
+  // visibility='teams' is picked.
+  const { data: userTeams = [] } = useQuery({
+    queryKey: ["teams"],
+    queryFn: fetchTeams,
+    enabled: open && uploadVisibility === "teams",
+  });
+
+  // Files inside the selected folder on the Attach tab — fetched
+  // lazily so we don't pull every KC file in the workspace.
+  const { data: attachFolderDetail } = useQuery({
+    queryKey: ["knowledge-folder", attachFolderId],
+    queryFn: () => fetchKnowledgeFolder(attachFolderId),
+    enabled: open && !!attachFolderId,
+  });
+
+  /* ── Effects ──────────────────────────────────────────────────── */
+
+  // Apply smart defaults once when they first arrive. Reset the
+  // applied flag on dialog close so reopening pulls fresh state.
+  useEffect(() => {
+    if (!open) {
+      setUploadDefaultsApplied(false);
+      return;
+    }
+    if (uploadDefaults && !uploadDefaultsApplied) {
+      setUploadFolderId(uploadDefaults.folderId);
+      setUploadVisibility(uploadDefaults.visibility);
+      setUploadTeamIds(uploadDefaults.teamIds);
+      // Also default the attach-folder filter to "Projects" so the
+      // user sees something useful when they switch tabs.
+      setAttachFolderId(uploadDefaults.folderId);
+      setUploadDefaultsApplied(true);
+    }
+  }, [open, uploadDefaults, uploadDefaultsApplied]);
+
+  /* ── Mutations ────────────────────────────────────────────────── */
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["documentGroups", projectId],
+    });
+    queryClient.invalidateQueries({
+      queryKey: ["project-knowledge-files", projectId],
+    });
+    queryClient.invalidateQueries({ queryKey: ["documents", projectId] });
+  };
+
   const addMutation = useMutation({
     mutationFn: (text: string) => createDocument(projectId, text),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["documentGroups", projectId],
-      });
-      queryClient.invalidateQueries({ queryKey: ["documents", projectId] });
+      invalidate();
       setContent("");
+      toast.success("Text added to project context.");
     },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to add text."),
   });
 
   const uploadMutation = useMutation({
-    mutationFn: (file: File) => uploadDocumentFile(projectId, file),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["documentGroups", projectId],
-      });
-      queryClient.invalidateQueries({ queryKey: ["documents", projectId] });
-      setSelectedFile(null);
+    mutationFn: () =>
+      uploadProjectKnowledgeFiles(projectId, selectedFiles, {
+        folderId: uploadFolderId || undefined,
+        visibility: uploadVisibility,
+        teamIds: uploadVisibility === "teams" ? uploadTeamIds : undefined,
+      }),
+    onSuccess: (result) => {
+      invalidate();
+      // Also refresh KC views so the file shows up there too.
+      queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
+      queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
+      if (uploadFolderId) {
+        queryClient.invalidateQueries({
+          queryKey: ["knowledge-folder", uploadFolderId],
+        });
+      }
+      setSelectedFiles([]);
       if (fileInputRef.current) fileInputRef.current.value = "";
+      if (result.uploaded.length > 0) {
+        toast.success(
+          `Uploaded ${result.uploaded.length} file(s) and attached to project.`,
+        );
+      }
+      if (result.duplicates.length > 0) {
+        toast.info(
+          result.duplicates.length === 1
+            ? `"${result.duplicates[0].name}" is already in your Knowledge Core.`
+            : `${result.duplicates.length} file(s) already in your Knowledge Core.`,
+          {
+            description: result.duplicates
+              .map((d) => `"${d.name}" → "${d.existing.folderName}"`)
+              .join("\n"),
+          },
+        );
+      }
     },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to upload."),
+  });
+
+  const attachMutation = useMutation({
+    mutationFn: (fileIds: string[]) =>
+      attachKnowledgeFiles(projectId, fileIds),
+    onSuccess: () => {
+      invalidate();
+      setAttachSelectedIds(new Set());
+      toast.success("Attached to project.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to attach."),
+  });
+
+  const detachMutation = useMutation({
+    mutationFn: (fileId: string) => detachKnowledgeFile(projectId, fileId),
+    onSuccess: () => {
+      invalidate();
+      setConfirmDeleteId(null);
+      toast.success("Detached from project.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to detach."),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (groupId: string) => deleteDocumentGroup(projectId, groupId),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["documentGroups", projectId],
-      });
-      queryClient.invalidateQueries({ queryKey: ["documents", projectId] });
+      invalidate();
       setConfirmDeleteId(null);
+      toast.success("Removed from project.");
     },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to remove."),
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  /* ── Handlers ─────────────────────────────────────────────────── */
+
+  const handleAddText = (e: React.FormEvent) => {
     e.preventDefault();
     if (!content.trim()) return;
     addMutation.mutate(content.trim());
   };
 
   const handleUpload = () => {
-    if (!selectedFile) return;
-    uploadMutation.mutate(selectedFile);
+    if (selectedFiles.length === 0) return;
+    if (uploadVisibility === "teams" && uploadTeamIds.length === 0) {
+      toast.error("Pick at least one team for Teams visibility.");
+      return;
+    }
+    uploadMutation.mutate();
   };
+
+  const filteredAttachCandidates = useMemo(() => {
+    const all = attachFolderDetail?.files ?? [];
+    const attachedSet = new Set(attachedFiles.map((f) => f.fileId));
+    const q = attachQuery.trim().toLowerCase();
+    return all
+      .filter((f) => !attachedSet.has(f.id))
+      .filter((f) => (q ? f.name.toLowerCase().includes(q) : true));
+  }, [attachFolderDetail, attachedFiles, attachQuery]);
+
+  /* ── Render ──────────────────────────────────────────────────── */
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -100,8 +343,9 @@ export function AddDocumentDialog({
         <DialogHeader>
           <DialogTitle>Manage Context</DialogTitle>
           <DialogDescription>
-            View existing context documents or add new ones. Text is chunked and
-            embedded for semantic search in chat.
+            Project context for chat. Uploaded files live in your
+            Knowledge Core so visibility, indexing, and team sharing
+            are managed in one place.
           </DialogDescription>
         </DialogHeader>
 
@@ -113,16 +357,21 @@ export function AddDocumentDialog({
             <TabsTrigger value="upload" className="flex-1">
               Upload File
             </TabsTrigger>
+            <TabsTrigger value="attach" className="flex-1">
+              From Knowledge Core
+            </TabsTrigger>
           </TabsList>
 
-          {/* Paste Text tab */}
+          {/* Paste-text tab — unchanged: snippets stay project-
+              scoped in the `documents` table, they're not a "file"
+              that belongs in KC. */}
           <TabsContent value="paste">
-            <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+            <form onSubmit={handleAddText} className="space-y-4 pt-2">
               <div className="space-y-2">
-                <Label htmlFor="document-content">Add New Context</Label>
+                <Label htmlFor="document-content">Add new context</Label>
                 <Textarea
                   id="document-content"
-                  placeholder="Paste your document text here..."
+                  placeholder="Paste your document text here…"
                   value={content}
                   onChange={(e) => setContent(e.target.value)}
                   rows={6}
@@ -135,57 +384,246 @@ export function AddDocumentDialog({
                   type="submit"
                   disabled={addMutation.isPending || !content.trim()}
                 >
-                  {addMutation.isPending ? "Adding..." : "Add Context"}
+                  {addMutation.isPending ? "Adding…" : "Add Context"}
                 </Button>
               </DialogFooter>
             </form>
           </TabsContent>
 
-          {/* Upload File tab */}
+          {/* Upload tab — sends to KC + auto-attaches. */}
           <TabsContent value="upload">
             <div className="space-y-4 pt-2">
               <div className="space-y-2">
-                <Label>Upload PDF or DOCX</Label>
+                <Label>Files</Label>
                 <div
-                  className="flex cursor-pointer items-center gap-3 rounded-md border border-dashed border-slate-300 px-4 py-5 transition-colors hover:border-slate-400 hover:bg-slate-50"
+                  className="flex cursor-pointer items-center gap-3 rounded-md border border-dashed border-border-3 px-4 py-5 transition-colors hover:border-border-4 hover:bg-bg-1"
                   onClick={() => fileInputRef.current?.click()}
                 >
-                  <Upload className="h-5 w-5 shrink-0 text-slate-400" />
-                  <span className="text-sm text-slate-500">
-                    {selectedFile
-                      ? selectedFile.name
-                      : "Click to select a .pdf or .docx file"}
+                  <Upload className="h-5 w-5 shrink-0 text-text-3" />
+                  <span className="text-sm text-text-3">
+                    {selectedFiles.length === 0
+                      ? "Click to select files (.pdf, .docx, .xlsx, .png, .jpg)"
+                      : selectedFiles.length === 1
+                        ? selectedFiles[0].name
+                        : `${selectedFiles.length} files selected`}
                   </span>
                 </div>
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept=".pdf,.docx"
+                  multiple
+                  accept=".pdf,.docx,.xlsx,.xls,.png,.jpg,.jpeg"
                   className="hidden"
                   onChange={(e) =>
-                    setSelectedFile(e.target.files?.[0] ?? null)
+                    setSelectedFiles(Array.from(e.target.files ?? []))
                   }
                 />
-                {uploadMutation.isError && (
-                  <p className="text-sm text-red-500">
-                    {uploadMutation.error?.message ?? "Upload failed."}
-                  </p>
-                )}
               </div>
+
+              {/* Folder + visibility pickers. Defaults from BE so
+                  the user can press Upload without picking
+                  anything. */}
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Folder in Knowledge Core</Label>
+                  <Select
+                    value={uploadFolderId}
+                    onValueChange={setUploadFolderId}
+                  >
+                    <SelectTrigger className="h-10 cursor-pointer">
+                      <SelectValue placeholder="Select a folder" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {kcFolders.map((f) => (
+                        <SelectItem key={f.id} value={f.id}>
+                          {f.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {uploadDefaults &&
+                    uploadFolderId === uploadDefaults.folderId && (
+                      <p className="text-[11px] text-text-3">
+                        Default — auto-created if missing.
+                      </p>
+                    )}
+                </div>
+                <div className="space-y-2">
+                  <Label>Visibility</Label>
+                  <Select
+                    value={uploadVisibility}
+                    onValueChange={(v) =>
+                      setUploadVisibility(v as KnowledgeFileVisibility)
+                    }
+                  >
+                    <SelectTrigger className="h-10 cursor-pointer">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">
+                        Everyone in the company
+                      </SelectItem>
+                      {isAdmin && (
+                        <SelectItem value="admins">Admins only</SelectItem>
+                      )}
+                      <SelectItem value="teams">Specific teams…</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {uploadVisibility === "teams" && (
+                <div className="space-y-2">
+                  <Label>Teams with access</Label>
+                  {userTeams.length === 0 ? (
+                    <p className="text-[11px] text-text-3">
+                      You aren&rsquo;t a member of any team yet — create or
+                      join one first to use this visibility option.
+                    </p>
+                  ) : (
+                    <div className="flex max-h-32 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
+                      {userTeams.map((t) => {
+                        const checked = uploadTeamIds.includes(t.id);
+                        return (
+                          <label
+                            key={t.id}
+                            className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={() =>
+                                setUploadTeamIds((prev) =>
+                                  checked
+                                    ? prev.filter((id) => id !== t.id)
+                                    : [...prev, t.id],
+                                )
+                              }
+                              className="h-3.5 w-3.5 accent-primary-6"
+                            />
+                            <span className="truncate">{t.name}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              )}
+
               <DialogFooter>
                 <Button
                   type="button"
-                  disabled={uploadMutation.isPending || !selectedFile}
+                  disabled={
+                    uploadMutation.isPending || selectedFiles.length === 0
+                  }
                   onClick={handleUpload}
                 >
                   {uploadMutation.isPending ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Uploading...
+                      Uploading…
                     </>
                   ) : (
-                    "Upload File"
+                    "Upload to Knowledge Core"
                   )}
+                </Button>
+              </DialogFooter>
+            </div>
+          </TabsContent>
+
+          {/* Attach tab — pick existing KC files. */}
+          <TabsContent value="attach">
+            <div className="space-y-3 pt-2">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Folder</Label>
+                  <Select
+                    value={attachFolderId}
+                    onValueChange={setAttachFolderId}
+                  >
+                    <SelectTrigger className="h-10 cursor-pointer">
+                      <SelectValue placeholder="Pick a folder" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {kcFolders.map((f) => (
+                        <SelectItem key={f.id} value={f.id}>
+                          {f.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="attach-search">Search</Label>
+                  <input
+                    id="attach-search"
+                    type="text"
+                    placeholder="Filter files in this folder…"
+                    value={attachQuery}
+                    onChange={(e) => setAttachQuery(e.target.value)}
+                    className="h-10 w-full rounded-md border border-border-3 bg-transparent px-3 text-[14px] outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
+                  />
+                </div>
+              </div>
+
+              <div className="rounded border border-border-2">
+                <ScrollArea className="h-44">
+                  {!attachFolderId ? (
+                    <p className="py-6 text-center text-sm text-text-3">
+                      Pick a folder to see its files.
+                    </p>
+                  ) : filteredAttachCandidates.length === 0 ? (
+                    <p className="py-6 text-center text-sm text-text-3">
+                      No files available to attach.
+                    </p>
+                  ) : (
+                    <div className="divide-y divide-border-2">
+                      {filteredAttachCandidates.map((f) => {
+                        const checked = attachSelectedIds.has(f.id);
+                        return (
+                          <label
+                            key={f.id}
+                            className="flex cursor-pointer items-center gap-3 px-3 py-2 text-[13px] hover:bg-bg-1"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={() => {
+                                setAttachSelectedIds((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(f.id)) next.delete(f.id);
+                                  else next.add(f.id);
+                                  return next;
+                                });
+                              }}
+                              className="h-3.5 w-3.5 accent-primary-6"
+                            />
+                            <FileText className="h-3.5 w-3.5 shrink-0 text-text-3" />
+                            <span className="flex-1 truncate text-text-1">
+                              {f.name}
+                            </span>
+                            <VisibilityBadge visibility={f.visibility} />
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                </ScrollArea>
+              </div>
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  disabled={
+                    attachMutation.isPending || attachSelectedIds.size === 0
+                  }
+                  onClick={() =>
+                    attachMutation.mutate(Array.from(attachSelectedIds))
+                  }
+                >
+                  {attachMutation.isPending
+                    ? "Attaching…"
+                    : `Attach ${attachSelectedIds.size > 0 ? `(${attachSelectedIds.size})` : ""}`}
                 </Button>
               </DialogFooter>
             </div>
@@ -194,41 +632,56 @@ export function AddDocumentDialog({
 
         <Separator />
 
-        {/* Existing document groups */}
+        {/* Unified Documents list — paste-text snippets (legacy
+            `documents` rows) + attached KC files. Origin badge
+            distinguishes the two. */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">Documents</Label>
+          <Label className="text-sm font-medium">In this project</Label>
           <ScrollArea className="h-48">
-            {groupsLoading ? (
+            {groupsLoading || attachedLoading ? (
               <div className="flex items-center justify-center py-6">
-                <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+                <Loader2 className="h-4 w-4 animate-spin text-text-3" />
               </div>
-            ) : groups && groups.length > 0 ? (
+            ) : (groups?.length ?? 0) === 0 && attachedFiles.length === 0 ? (
+              <p className="py-4 text-center text-sm text-text-3">
+                No context yet. Paste text, upload a file, or attach one
+                from Knowledge Core.
+              </p>
+            ) : (
               <div className="space-y-1">
-                {groups.map((group: DocumentGroup) => (
+                {/* Attached KC files first — they're the richer
+                    surface and most users will reach for them. */}
+                {attachedFiles.map((f: ProjectKnowledgeFile) => (
                   <div
-                    key={group.groupId}
-                    className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2"
+                    key={f.fileId}
+                    className="flex items-center justify-between rounded-md border border-border-2 px-3 py-2"
                   >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <FileText className="h-4 w-4 shrink-0 text-slate-400" />
-                      <span className="truncate text-sm text-slate-700">
-                        {group.title}
+                    <div className="flex min-w-0 items-center gap-2">
+                      <FileText className="h-4 w-4 shrink-0 text-text-3" />
+                      <span className="truncate text-sm text-text-1">
+                        {f.name}
                       </span>
-                      <Badge variant="secondary" className="shrink-0 text-xs">
-                        {group.chunkCount}{" "}
-                        {group.chunkCount === 1 ? "chunk" : "chunks"}
+                      <Badge
+                        variant="secondary"
+                        className="shrink-0 text-[10px]"
+                        title={`In folder "${f.folderName}"`}
+                      >
+                        <Link2 className="mr-1 h-2.5 w-2.5" /> KC
                       </Badge>
+                      <VisibilityBadge visibility={f.visibility} />
+                      <IngestionBadge status={f.ingestionStatus} />
                     </div>
-                    {confirmDeleteId === group.groupId ? (
-                      <div className="flex items-center gap-1 shrink-0">
+                    {confirmDeleteId === f.fileId ? (
+                      <div className="flex shrink-0 items-center gap-1">
                         <Button
                           variant="destructive"
                           size="sm"
                           className="h-7 text-xs"
-                          disabled={deleteMutation.isPending}
-                          onClick={() => deleteMutation.mutate(group.groupId)}
+                          disabled={detachMutation.isPending}
+                          onClick={() => detachMutation.mutate(f.fileId)}
+                          title="Removes from project — the file stays in Knowledge Core"
                         >
-                          {deleteMutation.isPending ? "..." : "Confirm"}
+                          {detachMutation.isPending ? "…" : "Detach"}
                         </Button>
                         <Button
                           variant="ghost"
@@ -243,7 +696,62 @@ export function AddDocumentDialog({
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-7 w-7 shrink-0 text-slate-400 hover:text-red-500"
+                        className="h-7 w-7 shrink-0 text-text-3 hover:text-danger-6"
+                        onClick={() => setConfirmDeleteId(f.fileId)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+
+                {/* Then paste-text snippets. */}
+                {(groups ?? []).map((group: DocumentGroup) => (
+                  <div
+                    key={group.groupId}
+                    className="flex items-center justify-between rounded-md border border-border-2 px-3 py-2"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <FileText className="h-4 w-4 shrink-0 text-text-3" />
+                      <span className="truncate text-sm text-text-1">
+                        {group.title}
+                      </span>
+                      <Badge
+                        variant="secondary"
+                        className="shrink-0 text-[10px]"
+                      >
+                        Text
+                      </Badge>
+                      <Badge variant="secondary" className="shrink-0 text-xs">
+                        {group.chunkCount}{" "}
+                        {group.chunkCount === 1 ? "chunk" : "chunks"}
+                      </Badge>
+                    </div>
+                    {confirmDeleteId === group.groupId ? (
+                      <div className="flex shrink-0 items-center gap-1">
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          className="h-7 text-xs"
+                          disabled={deleteMutation.isPending}
+                          onClick={() => deleteMutation.mutate(group.groupId)}
+                        >
+                          {deleteMutation.isPending ? "…" : "Confirm"}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 text-xs"
+                          onClick={() => setConfirmDeleteId(null)}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 shrink-0 text-text-3 hover:text-danger-6"
                         onClick={() => setConfirmDeleteId(group.groupId)}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
@@ -252,10 +760,6 @@ export function AddDocumentDialog({
                   </div>
                 ))}
               </div>
-            ) : (
-              <p className="py-4 text-center text-sm text-slate-400">
-                No documents added yet.
-              </p>
             )}
           </ScrollArea>
         </div>

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -11,15 +11,12 @@ import {
   fetchKnowledgeFolder,
   fetchProjectKnowledgeFiles,
   fetchProjectKnowledgeUploadDefaults,
-  fetchTeams,
   attachKnowledgeFiles,
   detachKnowledgeFile,
   uploadProjectKnowledgeFiles,
   type DocumentGroup,
   type ProjectKnowledgeFile,
-  type KnowledgeFileVisibility,
 } from "@/lib/api";
-import { useAuth } from "@/components/providers";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -65,7 +62,7 @@ function VisibilityBadge({ visibility }: { visibility: string }) {
   const tone =
     visibility === "admins"
       ? "bg-warning-1 text-warning-7"
-      : visibility === "teams"
+      : visibility === "teams" || visibility === "project"
         ? "bg-primary-1 text-primary-7"
         : "bg-bg-1 text-text-3";
   const label =
@@ -73,7 +70,9 @@ function VisibilityBadge({ visibility }: { visibility: string }) {
       ? "Admins"
       : visibility === "teams"
         ? "Teams"
-        : "Everyone";
+        : visibility === "project"
+          ? "Project"
+          : "Everyone";
   return (
     <Badge className={`shrink-0 text-[10px] uppercase tracking-wide ${tone}`}>
       {label}
@@ -127,18 +126,16 @@ export function AddDocumentDialog({
   onOpenChange,
 }: AddDocumentDialogProps) {
   const queryClient = useQueryClient();
-  const { user } = useAuth();
-  const isAdmin = user?.role === "admin";
 
   /* Paste-text state (legacy `documents` table) */
   const [content, setContent] = useState("");
 
-  /* Upload tab state */
+  /* Upload tab state — Manage Context uploads are project-scoped by
+     design (visibility='project' pinned to this project). No
+     visibility / teams selector here; that lives on /knowledge-core
+     for files meant to be reused across projects. */
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [uploadFolderId, setUploadFolderId] = useState<string>("");
-  const [uploadVisibility, setUploadVisibility] =
-    useState<KnowledgeFileVisibility>("all");
-  const [uploadTeamIds, setUploadTeamIds] = useState<string[]>([]);
   const [uploadDefaultsApplied, setUploadDefaultsApplied] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -186,14 +183,6 @@ export function AddDocumentDialog({
     enabled: open,
   });
 
-  // User's teams — populates the team-checkbox panel when
-  // visibility='teams' is picked.
-  const { data: userTeams = [] } = useQuery({
-    queryKey: ["teams"],
-    queryFn: fetchTeams,
-    enabled: open && uploadVisibility === "teams",
-  });
-
   // Files inside the selected folder on the Attach tab — fetched
   // lazily so we don't pull every KC file in the workspace.
   const { data: attachFolderDetail } = useQuery({
@@ -213,8 +202,6 @@ export function AddDocumentDialog({
     }
     if (uploadDefaults && !uploadDefaultsApplied) {
       setUploadFolderId(uploadDefaults.folderId);
-      setUploadVisibility(uploadDefaults.visibility);
-      setUploadTeamIds(uploadDefaults.teamIds);
       // Also default the attach-folder filter to "Projects" so the
       // user sees something useful when they switch tabs.
       setAttachFolderId(uploadDefaults.folderId);
@@ -249,8 +236,10 @@ export function AddDocumentDialog({
     mutationFn: () =>
       uploadProjectKnowledgeFiles(projectId, selectedFiles, {
         folderId: uploadFolderId || undefined,
-        visibility: uploadVisibility,
-        teamIds: uploadVisibility === "teams" ? uploadTeamIds : undefined,
+        // Manage Context uploads are always pinned to this project —
+        // searchable only inside its chat, never via the org-wide RAG.
+        visibility: "project",
+        projectIds: [projectId],
       }),
     onSuccess: (result) => {
       invalidate();
@@ -330,10 +319,6 @@ export function AddDocumentDialog({
 
   const handleUpload = () => {
     if (selectedFiles.length === 0) return;
-    if (uploadVisibility === "teams" && uploadTeamIds.length === 0) {
-      toast.error("Pick at least one team for Teams visibility.");
-      return;
-    }
     uploadMutation.mutate();
   };
 
@@ -431,95 +416,39 @@ export function AddDocumentDialog({
                 />
               </div>
 
-              {/* Folder + visibility pickers. Defaults from BE so
-                  the user can press Upload without picking
-                  anything. */}
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label>Folder in Knowledge Core</Label>
-                  <Select
-                    value={uploadFolderId}
-                    onValueChange={setUploadFolderId}
-                  >
-                    <SelectTrigger className="h-10 cursor-pointer">
-                      <SelectValue placeholder="Select a folder" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {kcFolders.map((f) => (
-                        <SelectItem key={f.id} value={f.id}>
-                          {f.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {uploadDefaults &&
-                    uploadFolderId === uploadDefaults.folderId && (
-                      <p className="text-[11px] text-text-3">
-                        Default — auto-created if missing.
-                      </p>
-                    )}
-                </div>
-                <div className="space-y-2">
-                  <Label>Visibility</Label>
-                  <Select
-                    value={uploadVisibility}
-                    onValueChange={(v) =>
-                      setUploadVisibility(v as KnowledgeFileVisibility)
-                    }
-                  >
-                    <SelectTrigger className="h-10 cursor-pointer">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">
-                        Everyone in the company
+              {/* Folder picker only — visibility is hardcoded to
+                  'project' (this project) so the file shows up only
+                  in this project's chat. Cross-project reuse lives on
+                  the /knowledge-core upload flow. */}
+              <div className="space-y-2">
+                <Label>Folder in Knowledge Core</Label>
+                <Select
+                  value={uploadFolderId}
+                  onValueChange={setUploadFolderId}
+                >
+                  <SelectTrigger className="h-10 cursor-pointer">
+                    <SelectValue placeholder="Select a folder" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {kcFolders.map((f) => (
+                      <SelectItem key={f.id} value={f.id}>
+                        {f.name}
                       </SelectItem>
-                      {isAdmin && (
-                        <SelectItem value="admins">Admins only</SelectItem>
-                      )}
-                      <SelectItem value="teams">Specific teams…</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              {uploadVisibility === "teams" && (
-                <div className="space-y-2">
-                  <Label>Teams with access</Label>
-                  {userTeams.length === 0 ? (
+                    ))}
+                  </SelectContent>
+                </Select>
+                {uploadDefaults &&
+                  uploadFolderId === uploadDefaults.folderId && (
                     <p className="text-[11px] text-text-3">
-                      You aren&rsquo;t a member of any team yet — create or
-                      join one first to use this visibility option.
+                      Default — auto-created if missing.
                     </p>
-                  ) : (
-                    <div className="flex max-h-32 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
-                      {userTeams.map((t) => {
-                        const checked = uploadTeamIds.includes(t.id);
-                        return (
-                          <label
-                            key={t.id}
-                            className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={checked}
-                              onChange={() =>
-                                setUploadTeamIds((prev) =>
-                                  checked
-                                    ? prev.filter((id) => id !== t.id)
-                                    : [...prev, t.id],
-                                )
-                              }
-                              className="h-3.5 w-3.5 accent-primary-6"
-                            />
-                            <span className="truncate">{t.name}</span>
-                          </label>
-                        );
-                      })}
-                    </div>
                   )}
-                </div>
-              )}
+                <p className="text-[11px] text-text-3">
+                  These files will only be searchable in this project&rsquo;s
+                  chat. To share across projects, upload via{" "}
+                  <span className="font-medium">Knowledge Core</span> instead.
+                </p>
+              </div>
 
               <DialogFooter>
                 <Button

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -50,6 +50,7 @@ import {
   CheckCircle2,
   AlertTriangle,
   Link2,
+  Unplug,
 } from "lucide-react";
 
 interface AddDocumentDialogProps {
@@ -98,6 +99,16 @@ function IngestionBadge({ status }: { status: string }) {
         className="inline-flex items-center gap-1 text-[11px] text-warning-7"
       >
         <AlertTriangle className="h-3 w-3" /> Skipped
+      </span>
+    );
+  }
+  if (status === "untrained") {
+    return (
+      <span
+        title="Embeddings removed — chat RAG ignores this file until the owner re-trains it."
+        className="inline-flex items-center gap-1 text-[11px] text-text-3"
+      >
+        <Unplug className="h-3 w-3" /> Untrained
       </span>
     );
   }

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -247,18 +247,30 @@ export function AddDocumentDialog({
       toast.error(err.message || "Failed to add text."),
   });
 
-  const uploadMutation = useMutation({
-    mutationFn: () =>
-      uploadProjectKnowledgeFiles(projectId, selectedFiles, {
-        folderId: uploadFolderId || undefined,
-        // Manage Context uploads are always pinned to this project —
-        // searchable only inside its chat, never via the org-wide RAG.
-        visibility: "project",
-        projectIds: [projectId],
-      }),
-    onSuccess: (result) => {
+  // Combined "Add Files" pipeline: upload pending files first
+  // (visibility='project' pinned to this project), then attach the
+  // checked KC files. Either side can be empty; if both are, the
+  // mutation never fires (the CTA guards on total === 0). One
+  // mutation owns both calls so we can show a single combined
+  // toast and refresh queries once.
+  const addFilesMutation = useMutation({
+    mutationFn: async () => {
+      const attachIds = Array.from(attachSelectedIds);
+      const uploadResult =
+        selectedFiles.length > 0
+          ? await uploadProjectKnowledgeFiles(projectId, selectedFiles, {
+              folderId: uploadFolderId || undefined,
+              visibility: "project",
+              projectIds: [projectId],
+            })
+          : null;
+      if (attachIds.length > 0) {
+        await attachKnowledgeFiles(projectId, attachIds);
+      }
+      return { uploadResult, attachedCount: attachIds.length };
+    },
+    onSuccess: ({ uploadResult, attachedCount }) => {
       invalidate();
-      // Also refresh KC views so the file shows up there too.
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
       if (uploadFolderId) {
@@ -267,19 +279,24 @@ export function AddDocumentDialog({
         });
       }
       setSelectedFiles([]);
+      setAttachSelectedIds(new Set());
       if (fileInputRef.current) fileInputRef.current.value = "";
-      if (result.uploaded.length > 0) {
+
+      const uploadedCount = uploadResult?.uploaded.length ?? 0;
+      const duplicates = uploadResult?.duplicates ?? [];
+      const totalAdded = uploadedCount + attachedCount;
+      if (totalAdded > 0) {
         toast.success(
-          `Uploaded ${result.uploaded.length} file(s) and attached to project.`,
+          `Added ${totalAdded} file${totalAdded !== 1 ? "s" : ""} to project context.`,
         );
       }
-      if (result.duplicates.length > 0) {
+      if (duplicates.length > 0) {
         toast.info(
-          result.duplicates.length === 1
-            ? `"${result.duplicates[0].name}" is already in your Knowledge Core.`
-            : `${result.duplicates.length} file(s) already in your Knowledge Core.`,
+          duplicates.length === 1
+            ? `"${duplicates[0].name}" is already in your Knowledge Core.`
+            : `${duplicates.length} file(s) already in your Knowledge Core.`,
           {
-            description: result.duplicates
+            description: duplicates
               .map((d) => `"${d.name}" → "${d.existing.folderName}"`)
               .join("\n"),
           },
@@ -287,19 +304,7 @@ export function AddDocumentDialog({
       }
     },
     onError: (err: Error) =>
-      toast.error(err.message || "Failed to upload."),
-  });
-
-  const attachMutation = useMutation({
-    mutationFn: (fileIds: string[]) =>
-      attachKnowledgeFiles(projectId, fileIds),
-    onSuccess: () => {
-      invalidate();
-      setAttachSelectedIds(new Set());
-      toast.success("Attached to project.");
-    },
-    onError: (err: Error) =>
-      toast.error(err.message || "Failed to attach."),
+      toast.error(err.message || "Failed to add files."),
   });
 
   const detachMutation = useMutation({
@@ -332,9 +337,10 @@ export function AddDocumentDialog({
     addMutation.mutate(content.trim());
   };
 
-  const handleUpload = () => {
-    if (selectedFiles.length === 0) return;
-    uploadMutation.mutate();
+  const handleAddFiles = () => {
+    const total = selectedFiles.length + attachSelectedIds.size;
+    if (total === 0) return;
+    addFilesMutation.mutate();
   };
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -384,20 +390,12 @@ export function AddDocumentDialog({
                 <span className="sm:hidden">Paste</span>
               </TabsTrigger>
               <TabsTrigger
-                value="upload"
+                value="files"
                 className="flex-1 cursor-pointer gap-1.5 text-xs sm:text-sm"
               >
                 <Upload className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">Upload File</span>
-                <span className="sm:hidden">Upload</span>
-              </TabsTrigger>
-              <TabsTrigger
-                value="attach"
-                className="flex-1 cursor-pointer gap-1.5 text-xs sm:text-sm"
-              >
-                <FolderOpen className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">From Knowledge Core</span>
-                <span className="sm:hidden">Attach</span>
+                <span className="hidden sm:inline">Add Files</span>
+                <span className="sm:hidden">Files</span>
               </TabsTrigger>
             </TabsList>
 
@@ -437,12 +435,23 @@ export function AddDocumentDialog({
               </form>
             </TabsContent>
 
-            {/* Upload tab — sends to KC + auto-attaches with project
-                visibility. */}
-            <TabsContent value="upload" className="mt-0">
-              <div className="space-y-4">
+            {/* Add Files tab — unifies upload + attach in one flow.
+                Top section uploads a fresh file to KC pinned to this
+                project; bottom section picks an existing KC file.
+                Both feed into a single CTA at the bottom so the user
+                can mix sources in one go. */}
+            <TabsContent value="files" className="mt-0">
+              <div className="space-y-5">
+                {/* ── Upload new ───────────────────────────────── */}
                 <div className="space-y-2">
-                  <Label>Files</Label>
+                  <div className="flex items-center justify-between">
+                    <Label className="text-text-1">Upload new</Label>
+                    {selectedFiles.length > 0 && (
+                      <span className="text-[11px] text-text-3">
+                        {selectedFiles.length} ready
+                      </span>
+                    )}
+                  </div>
                   <div
                     role="button"
                     tabIndex={0}
@@ -459,7 +468,7 @@ export function AddDocumentDialog({
                     }}
                     onDragLeave={() => setIsDragOver(false)}
                     onDrop={handleDrop}
-                    className={`flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-8 text-center transition-colors ${
+                    className={`flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-7 text-center transition-colors ${
                       isDragOver
                         ? "border-primary-6 bg-primary-1/40"
                         : "border-border-3 hover:border-border-4 hover:bg-bg-1"
@@ -492,8 +501,6 @@ export function AddDocumentDialog({
                       if (picked.length > 0) {
                         setSelectedFiles((prev) => [...prev, ...picked]);
                       }
-                      // Reset so picking the same file again re-fires
-                      // the onChange handler.
                       e.target.value = "";
                     }}
                   />
@@ -516,7 +523,7 @@ export function AddDocumentDialog({
                           <button
                             type="button"
                             onClick={() => removeSelectedFile(i)}
-                            disabled={uploadMutation.isPending}
+                            disabled={addFilesMutation.isPending}
                             className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             <X className="h-3.5 w-3.5" />
@@ -525,72 +532,57 @@ export function AddDocumentDialog({
                       ))}
                     </div>
                   )}
+                  {selectedFiles.length > 0 && (
+                    <div className="grid gap-2 pt-1 sm:grid-cols-[auto_1fr] sm:items-center">
+                      <Label className="text-[12px] font-normal text-text-3">
+                        Save to folder
+                      </Label>
+                      <Select
+                        value={uploadFolderId}
+                        onValueChange={setUploadFolderId}
+                      >
+                        <SelectTrigger className="h-9 w-full cursor-pointer text-sm">
+                          <SelectValue placeholder="Select a folder" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {kcFolders.map((f) => (
+                            <SelectItem key={f.id} value={f.id}>
+                              {f.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
                 </div>
 
-                {/* Folder picker only — visibility is hardcoded to
-                    'project' (this project) so the file shows up only
-                    in this project's chat. */}
+                {/* ── OR divider ───────────────────────────────── */}
+                <div className="flex items-center gap-3">
+                  <div className="h-px flex-1 bg-border-2" />
+                  <span className="text-[11px] font-medium uppercase tracking-wider text-text-3">
+                    or
+                  </span>
+                  <div className="h-px flex-1 bg-border-2" />
+                </div>
+
+                {/* ── Pick from Knowledge Core ─────────────────── */}
                 <div className="space-y-2">
-                  <Label>Folder in Knowledge Core</Label>
-                  <Select
-                    value={uploadFolderId}
-                    onValueChange={setUploadFolderId}
-                  >
-                    <SelectTrigger className="h-10 w-full cursor-pointer">
-                      <SelectValue placeholder="Select a folder" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {kcFolders.map((f) => (
-                        <SelectItem key={f.id} value={f.id}>
-                          {f.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-[11px] text-text-3">
-                    Searchable only in this project&rsquo;s chat. To share
-                    across projects, upload via{" "}
-                    <span className="font-medium">Knowledge Core</span>.
-                  </p>
-                </div>
-
-                <DialogFooter>
-                  <Button
-                    type="button"
-                    disabled={
-                      uploadMutation.isPending || selectedFiles.length === 0
-                    }
-                    onClick={handleUpload}
-                    className="cursor-pointer bg-primary-6 hover:bg-primary-7"
-                  >
-                    {uploadMutation.isPending ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Uploading…
-                      </>
-                    ) : (
-                      `Upload${
-                        selectedFiles.length > 0
-                          ? ` ${selectedFiles.length} file${selectedFiles.length !== 1 ? "s" : ""}`
-                          : ""
-                      }`
+                  <div className="flex items-center justify-between">
+                    <Label className="text-text-1">
+                      Pick from Knowledge Core
+                    </Label>
+                    {attachSelectedIds.size > 0 && (
+                      <span className="text-[11px] text-text-3">
+                        {attachSelectedIds.size} selected
+                      </span>
                     )}
-                  </Button>
-                </DialogFooter>
-              </div>
-            </TabsContent>
-
-            {/* Attach tab — pick existing KC files. */}
-            <TabsContent value="attach" className="mt-0">
-              <div className="space-y-3">
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <div className="space-y-2">
-                    <Label>Folder</Label>
+                  </div>
+                  <div className="grid gap-2 sm:grid-cols-2">
                     <Select
                       value={attachFolderId}
                       onValueChange={setAttachFolderId}
                     >
-                      <SelectTrigger className="h-10 w-full cursor-pointer">
+                      <SelectTrigger className="h-9 w-full cursor-pointer text-sm">
                         <SelectValue placeholder="Pick a folder" />
                       </SelectTrigger>
                       <SelectContent>
@@ -601,93 +593,98 @@ export function AddDocumentDialog({
                         ))}
                       </SelectContent>
                     </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="attach-search">Search</Label>
                     <input
                       id="attach-search"
                       type="text"
-                      placeholder="Filter files in this folder…"
+                      placeholder="Filter files…"
                       value={attachQuery}
                       onChange={(e) => setAttachQuery(e.target.value)}
-                      className="h-10 w-full rounded-md border border-border-3 bg-transparent px-3 text-sm outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
+                      className="h-9 w-full rounded-md border border-border-3 bg-transparent px-3 text-sm outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
                     />
+                  </div>
+
+                  <div className="overflow-hidden rounded-md border border-border-2">
+                    <ScrollArea className="h-40">
+                      {!attachFolderId ? (
+                        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+                          <FolderOpen className="h-6 w-6 text-text-3" />
+                          <p className="text-sm text-text-3">
+                            Pick a folder to see its files.
+                          </p>
+                        </div>
+                      ) : filteredAttachCandidates.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+                          <Inbox className="h-6 w-6 text-text-3" />
+                          <p className="text-sm text-text-3">
+                            No files available to attach.
+                          </p>
+                        </div>
+                      ) : (
+                        <div className="divide-y divide-border-2">
+                          {filteredAttachCandidates.map((f) => {
+                            const checked = attachSelectedIds.has(f.id);
+                            return (
+                              <label
+                                key={f.id}
+                                className="flex cursor-pointer items-center gap-3 px-3 py-2.5 text-sm transition-colors hover:bg-bg-1"
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => {
+                                    setAttachSelectedIds((prev) => {
+                                      const next = new Set(prev);
+                                      if (next.has(f.id)) next.delete(f.id);
+                                      else next.add(f.id);
+                                      return next;
+                                    });
+                                  }}
+                                  className="h-3.5 w-3.5 shrink-0 accent-primary-6"
+                                />
+                                <FileText className="h-3.5 w-3.5 shrink-0 text-text-3" />
+                                <span className="flex-1 truncate text-text-1">
+                                  {f.name}
+                                </span>
+                                <VisibilityBadge visibility={f.visibility} />
+                              </label>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </ScrollArea>
                   </div>
                 </div>
 
-                <div className="overflow-hidden rounded-md border border-border-2">
-                  <ScrollArea className="h-48 sm:h-44">
-                    {!attachFolderId ? (
-                      <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
-                        <FolderOpen className="h-6 w-6 text-text-3" />
-                        <p className="text-sm text-text-3">
-                          Pick a folder to see its files.
-                        </p>
-                      </div>
-                    ) : filteredAttachCandidates.length === 0 ? (
-                      <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
-                        <Inbox className="h-6 w-6 text-text-3" />
-                        <p className="text-sm text-text-3">
-                          No files available to attach.
-                        </p>
-                      </div>
-                    ) : (
-                      <div className="divide-y divide-border-2">
-                        {filteredAttachCandidates.map((f) => {
-                          const checked = attachSelectedIds.has(f.id);
-                          return (
-                            <label
-                              key={f.id}
-                              className="flex cursor-pointer items-center gap-3 px-3 py-2.5 text-sm transition-colors hover:bg-bg-1"
-                            >
-                              <input
-                                type="checkbox"
-                                checked={checked}
-                                onChange={() => {
-                                  setAttachSelectedIds((prev) => {
-                                    const next = new Set(prev);
-                                    if (next.has(f.id)) next.delete(f.id);
-                                    else next.add(f.id);
-                                    return next;
-                                  });
-                                }}
-                                className="h-3.5 w-3.5 shrink-0 accent-primary-6"
-                              />
-                              <FileText className="h-3.5 w-3.5 shrink-0 text-text-3" />
-                              <span className="flex-1 truncate text-text-1">
-                                {f.name}
-                              </span>
-                              <VisibilityBadge visibility={f.visibility} />
-                            </label>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </ScrollArea>
-                </div>
+                <p className="text-[11px] text-text-3">
+                  Uploads land in Knowledge Core scoped to this project.
+                  Picking an existing file just attaches it — its
+                  original visibility stays as-is.
+                </p>
 
                 <DialogFooter>
                   <Button
                     type="button"
                     disabled={
-                      attachMutation.isPending || attachSelectedIds.size === 0
+                      addFilesMutation.isPending ||
+                      (selectedFiles.length === 0 &&
+                        attachSelectedIds.size === 0)
                     }
-                    onClick={() =>
-                      attachMutation.mutate(Array.from(attachSelectedIds))
-                    }
+                    onClick={handleAddFiles}
                     className="cursor-pointer bg-primary-6 hover:bg-primary-7"
                   >
-                    {attachMutation.isPending ? (
+                    {addFilesMutation.isPending ? (
                       <>
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        Attaching…
+                        Adding…
                       </>
                     ) : (
-                      `Attach${
-                        attachSelectedIds.size > 0
-                          ? ` ${attachSelectedIds.size} file${attachSelectedIds.size !== 1 ? "s" : ""}`
-                          : ""
-                      }`
+                      (() => {
+                        const total =
+                          selectedFiles.length + attachSelectedIds.size;
+                        return total > 0
+                          ? `Add ${total} file${total !== 1 ? "s" : ""} to project`
+                          : "Add to project";
+                      })()
                     )}
                   </Button>
                 </DialogFooter>

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -174,11 +174,23 @@ export function AddDocumentDialog({
     enabled: open,
   });
 
-  // KC files attached to this project.
+  // KC files attached to this project. Poll while any attached
+  // file is mid-ingestion so the "Indexing…" badge flips to
+  // "Indexed" (or "Skipped") on its own — the user shouldn't have
+  // to close + reopen the dialog to see the worker finish.
   const { data: attachedFiles = [], isLoading: attachedLoading } = useQuery({
     queryKey: ["project-knowledge-files", projectId],
     queryFn: () => fetchProjectKnowledgeFiles(projectId),
     enabled: open,
+    refetchInterval: (q) => {
+      const rows = q.state.data ?? [];
+      const inFlight = rows.some(
+        (f) =>
+          f.ingestionStatus === "pending" ||
+          f.ingestionStatus === "processing",
+      );
+      return inFlight ? 2000 : false;
+    },
   });
 
   // Smart defaults the BE picks for the upload picker — folder +

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -48,6 +48,10 @@ import {
   AlertTriangle,
   Link2,
   Unplug,
+  X,
+  ClipboardPaste,
+  FolderOpen,
+  Inbox,
 } from "lucide-react";
 
 interface AddDocumentDialogProps {
@@ -57,6 +61,14 @@ interface AddDocumentDialogProps {
 }
 
 /* ── Small visual helpers (kept local — not reused elsewhere) ──── */
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
 
 function VisibilityBadge({ visibility }: { visibility: string }) {
   const tone =
@@ -137,6 +149,9 @@ export function AddDocumentDialog({
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [uploadFolderId, setUploadFolderId] = useState<string>("");
   const [uploadDefaultsApplied, setUploadDefaultsApplied] = useState(false);
+  // Track drag-over state so the dropzone can highlight while the
+  // user is hovering with files. Reset on dragleave / drop.
+  const [isDragOver, setIsDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   /* Attach tab state */
@@ -322,6 +337,16 @@ export function AddDocumentDialog({
     uploadMutation.mutate();
   };
 
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const dropped = Array.from(e.dataTransfer.files);
+    if (dropped.length > 0) setSelectedFiles((prev) => [...prev, ...dropped]);
+  };
+
+  const removeSelectedFile = (idx: number) =>
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== idx));
+
   const filteredAttachCandidates = useMemo(() => {
     const all = attachFolderDetail?.files ?? [];
     const attachedSet = new Set(attachedFiles.map((f) => f.fileId));
@@ -335,154 +360,184 @@ export function AddDocumentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
-        <DialogHeader>
-          <DialogTitle>Manage Context</DialogTitle>
-          <DialogDescription>
+      <DialogContent className="max-h-[90vh] gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogHeader className="border-b border-border-2 px-5 py-4 sm:px-6">
+          <DialogTitle className="text-base sm:text-lg">
+            Manage Context
+          </DialogTitle>
+          <DialogDescription className="text-xs sm:text-sm">
             Project context for chat. Uploaded files live in your
             Knowledge Core so visibility, indexing, and team sharing
-            are managed in one place.
+            stay in one place.
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="paste">
-          <TabsList className="w-full">
-            <TabsTrigger value="paste" className="flex-1">
-              Paste Text
-            </TabsTrigger>
-            <TabsTrigger value="upload" className="flex-1">
-              Upload File
-            </TabsTrigger>
-            <TabsTrigger value="attach" className="flex-1">
-              From Knowledge Core
-            </TabsTrigger>
-          </TabsList>
+        <div className="flex max-h-[calc(90vh-72px)] flex-col overflow-y-auto px-5 py-4 sm:px-6">
+          <Tabs defaultValue="paste" className="gap-4">
+            <TabsList className="h-9 w-full bg-bg-1 p-1">
+              <TabsTrigger
+                value="paste"
+                className="flex-1 cursor-pointer gap-1.5 text-xs sm:text-sm"
+              >
+                <ClipboardPaste className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Paste Text</span>
+                <span className="sm:hidden">Paste</span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="upload"
+                className="flex-1 cursor-pointer gap-1.5 text-xs sm:text-sm"
+              >
+                <Upload className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Upload File</span>
+                <span className="sm:hidden">Upload</span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="attach"
+                className="flex-1 cursor-pointer gap-1.5 text-xs sm:text-sm"
+              >
+                <FolderOpen className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">From Knowledge Core</span>
+                <span className="sm:hidden">Attach</span>
+              </TabsTrigger>
+            </TabsList>
 
-          {/* Paste-text tab — unchanged: snippets stay project-
-              scoped in the `documents` table, they're not a "file"
-              that belongs in KC. */}
-          <TabsContent value="paste">
-            <form onSubmit={handleAddText} className="space-y-4 pt-2">
-              <div className="space-y-2">
-                <Label htmlFor="document-content">Add new context</Label>
-                <Textarea
-                  id="document-content"
-                  placeholder="Paste your document text here…"
-                  value={content}
-                  onChange={(e) => setContent(e.target.value)}
-                  rows={6}
-                  className="resize-y"
-                  required
-                />
-              </div>
-              <DialogFooter>
-                <Button
-                  type="submit"
-                  disabled={addMutation.isPending || !content.trim()}
-                >
-                  {addMutation.isPending ? "Adding…" : "Add Context"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </TabsContent>
-
-          {/* Upload tab — sends to KC + auto-attaches. */}
-          <TabsContent value="upload">
-            <div className="space-y-4 pt-2">
-              <div className="space-y-2">
-                <Label>Files</Label>
-                <div
-                  className="flex cursor-pointer items-center gap-3 rounded-md border border-dashed border-border-3 px-4 py-5 transition-colors hover:border-border-4 hover:bg-bg-1"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <Upload className="h-5 w-5 shrink-0 text-text-3" />
-                  <span className="text-sm text-text-3">
-                    {selectedFiles.length === 0
-                      ? "Click to select files (.pdf, .docx, .xlsx, .png, .jpg)"
-                      : selectedFiles.length === 1
-                        ? selectedFiles[0].name
-                        : `${selectedFiles.length} files selected`}
-                  </span>
-                </div>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  multiple
-                  accept=".pdf,.docx,.xlsx,.xls,.png,.jpg,.jpeg"
-                  className="hidden"
-                  onChange={(e) =>
-                    setSelectedFiles(Array.from(e.target.files ?? []))
-                  }
-                />
-              </div>
-
-              {/* Folder picker only — visibility is hardcoded to
-                  'project' (this project) so the file shows up only
-                  in this project's chat. Cross-project reuse lives on
-                  the /knowledge-core upload flow. */}
-              <div className="space-y-2">
-                <Label>Folder in Knowledge Core</Label>
-                <Select
-                  value={uploadFolderId}
-                  onValueChange={setUploadFolderId}
-                >
-                  <SelectTrigger className="h-10 cursor-pointer">
-                    <SelectValue placeholder="Select a folder" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {kcFolders.map((f) => (
-                      <SelectItem key={f.id} value={f.id}>
-                        {f.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {uploadDefaults &&
-                  uploadFolderId === uploadDefaults.folderId && (
-                    <p className="text-[11px] text-text-3">
-                      Default — auto-created if missing.
-                    </p>
-                  )}
-                <p className="text-[11px] text-text-3">
-                  These files will only be searchable in this project&rsquo;s
-                  chat. To share across projects, upload via{" "}
-                  <span className="font-medium">Knowledge Core</span> instead.
-                </p>
-              </div>
-
-              <DialogFooter>
-                <Button
-                  type="button"
-                  disabled={
-                    uploadMutation.isPending || selectedFiles.length === 0
-                  }
-                  onClick={handleUpload}
-                >
-                  {uploadMutation.isPending ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Uploading…
-                    </>
-                  ) : (
-                    "Upload to Knowledge Core"
-                  )}
-                </Button>
-              </DialogFooter>
-            </div>
-          </TabsContent>
-
-          {/* Attach tab — pick existing KC files. */}
-          <TabsContent value="attach">
-            <div className="space-y-3 pt-2">
-              <div className="grid gap-3 sm:grid-cols-2">
+            {/* Paste-text tab — snippets stay project-scoped in the
+                `documents` table, they're not a "file" that belongs
+                in KC. */}
+            <TabsContent value="paste" className="mt-0">
+              <form onSubmit={handleAddText} className="space-y-4">
                 <div className="space-y-2">
-                  <Label>Folder</Label>
-                  <Select
-                    value={attachFolderId}
-                    onValueChange={setAttachFolderId}
+                  <Label htmlFor="document-content">Add new context</Label>
+                  <Textarea
+                    id="document-content"
+                    placeholder="Paste your document text here…"
+                    value={content}
+                    onChange={(e) => setContent(e.target.value)}
+                    rows={6}
+                    className="resize-y"
+                    required
+                  />
+                </div>
+                <DialogFooter>
+                  <Button
+                    type="submit"
+                    disabled={addMutation.isPending || !content.trim()}
+                    className="cursor-pointer bg-primary-6 hover:bg-primary-7"
                   >
-                    <SelectTrigger className="h-10 cursor-pointer">
-                      <SelectValue placeholder="Pick a folder" />
+                    {addMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Adding…
+                      </>
+                    ) : (
+                      "Add Context"
+                    )}
+                  </Button>
+                </DialogFooter>
+              </form>
+            </TabsContent>
+
+            {/* Upload tab — sends to KC + auto-attaches with project
+                visibility. */}
+            <TabsContent value="upload" className="mt-0">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Files</Label>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => fileInputRef.current?.click()}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        fileInputRef.current?.click();
+                      }
+                    }}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setIsDragOver(true);
+                    }}
+                    onDragLeave={() => setIsDragOver(false)}
+                    onDrop={handleDrop}
+                    className={`flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-4 py-8 text-center transition-colors ${
+                      isDragOver
+                        ? "border-primary-6 bg-primary-1/40"
+                        : "border-border-3 hover:border-border-4 hover:bg-bg-1"
+                    }`}
+                  >
+                    <Upload
+                      className={`h-6 w-6 shrink-0 ${
+                        isDragOver ? "text-primary-6" : "text-text-3"
+                      }`}
+                    />
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-text-1">
+                        {isDragOver
+                          ? "Drop to add files"
+                          : "Click to browse or drag files here"}
+                      </p>
+                      <p className="text-[11px] text-text-3">
+                        PDF, DOCX, XLSX, PNG, JPG
+                      </p>
+                    </div>
+                  </div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    multiple
+                    accept=".pdf,.docx,.xlsx,.xls,.png,.jpg,.jpeg"
+                    className="hidden"
+                    onChange={(e) => {
+                      const picked = Array.from(e.target.files ?? []);
+                      if (picked.length > 0) {
+                        setSelectedFiles((prev) => [...prev, ...picked]);
+                      }
+                      // Reset so picking the same file again re-fires
+                      // the onChange handler.
+                      e.target.value = "";
+                    }}
+                  />
+                  {selectedFiles.length > 0 && (
+                    <div className="flex flex-col gap-1.5 pt-1">
+                      {selectedFiles.map((f, i) => (
+                        <div
+                          key={i}
+                          className="flex items-center gap-2.5 rounded-md border border-border-2 bg-bg-1 px-3 py-2"
+                        >
+                          <FileText className="h-3.5 w-3.5 shrink-0 text-text-3" />
+                          <div className="flex min-w-0 flex-1 flex-col">
+                            <span className="truncate text-[13px] font-medium text-text-1">
+                              {f.name}
+                            </span>
+                            <span className="text-[11px] text-text-3">
+                              {formatBytes(f.size)}
+                            </span>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => removeSelectedFile(i)}
+                            disabled={uploadMutation.isPending}
+                            className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Folder picker only — visibility is hardcoded to
+                    'project' (this project) so the file shows up only
+                    in this project's chat. */}
+                <div className="space-y-2">
+                  <Label>Folder in Knowledge Core</Label>
+                  <Select
+                    value={uploadFolderId}
+                    onValueChange={setUploadFolderId}
+                  >
+                    <SelectTrigger className="h-10 w-full cursor-pointer">
+                      <SelectValue placeholder="Select a folder" />
                     </SelectTrigger>
                     <SelectContent>
                       {kcFolders.map((f) => (
@@ -492,216 +547,312 @@ export function AddDocumentDialog({
                       ))}
                     </SelectContent>
                   </Select>
+                  <p className="text-[11px] text-text-3">
+                    Searchable only in this project&rsquo;s chat. To share
+                    across projects, upload via{" "}
+                    <span className="font-medium">Knowledge Core</span>.
+                  </p>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="attach-search">Search</Label>
-                  <input
-                    id="attach-search"
-                    type="text"
-                    placeholder="Filter files in this folder…"
-                    value={attachQuery}
-                    onChange={(e) => setAttachQuery(e.target.value)}
-                    className="h-10 w-full rounded-md border border-border-3 bg-transparent px-3 text-[14px] outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
-                  />
+
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    disabled={
+                      uploadMutation.isPending || selectedFiles.length === 0
+                    }
+                    onClick={handleUpload}
+                    className="cursor-pointer bg-primary-6 hover:bg-primary-7"
+                  >
+                    {uploadMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Uploading…
+                      </>
+                    ) : (
+                      `Upload${
+                        selectedFiles.length > 0
+                          ? ` ${selectedFiles.length} file${selectedFiles.length !== 1 ? "s" : ""}`
+                          : ""
+                      }`
+                    )}
+                  </Button>
+                </DialogFooter>
+              </div>
+            </TabsContent>
+
+            {/* Attach tab — pick existing KC files. */}
+            <TabsContent value="attach" className="mt-0">
+              <div className="space-y-3">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label>Folder</Label>
+                    <Select
+                      value={attachFolderId}
+                      onValueChange={setAttachFolderId}
+                    >
+                      <SelectTrigger className="h-10 w-full cursor-pointer">
+                        <SelectValue placeholder="Pick a folder" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {kcFolders.map((f) => (
+                          <SelectItem key={f.id} value={f.id}>
+                            {f.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="attach-search">Search</Label>
+                    <input
+                      id="attach-search"
+                      type="text"
+                      placeholder="Filter files in this folder…"
+                      value={attachQuery}
+                      onChange={(e) => setAttachQuery(e.target.value)}
+                      className="h-10 w-full rounded-md border border-border-3 bg-transparent px-3 text-sm outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
+                    />
+                  </div>
                 </div>
-              </div>
 
-              <div className="rounded border border-border-2">
-                <ScrollArea className="h-44">
-                  {!attachFolderId ? (
-                    <p className="py-6 text-center text-sm text-text-3">
-                      Pick a folder to see its files.
-                    </p>
-                  ) : filteredAttachCandidates.length === 0 ? (
-                    <p className="py-6 text-center text-sm text-text-3">
-                      No files available to attach.
-                    </p>
-                  ) : (
-                    <div className="divide-y divide-border-2">
-                      {filteredAttachCandidates.map((f) => {
-                        const checked = attachSelectedIds.has(f.id);
-                        return (
-                          <label
-                            key={f.id}
-                            className="flex cursor-pointer items-center gap-3 px-3 py-2 text-[13px] hover:bg-bg-1"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={checked}
-                              onChange={() => {
-                                setAttachSelectedIds((prev) => {
-                                  const next = new Set(prev);
-                                  if (next.has(f.id)) next.delete(f.id);
-                                  else next.add(f.id);
-                                  return next;
-                                });
-                              }}
-                              className="h-3.5 w-3.5 accent-primary-6"
-                            />
-                            <FileText className="h-3.5 w-3.5 shrink-0 text-text-3" />
-                            <span className="flex-1 truncate text-text-1">
-                              {f.name}
-                            </span>
-                            <VisibilityBadge visibility={f.visibility} />
-                          </label>
-                        );
-                      })}
-                    </div>
-                  )}
-                </ScrollArea>
-              </div>
+                <div className="overflow-hidden rounded-md border border-border-2">
+                  <ScrollArea className="h-48 sm:h-44">
+                    {!attachFolderId ? (
+                      <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+                        <FolderOpen className="h-6 w-6 text-text-3" />
+                        <p className="text-sm text-text-3">
+                          Pick a folder to see its files.
+                        </p>
+                      </div>
+                    ) : filteredAttachCandidates.length === 0 ? (
+                      <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+                        <Inbox className="h-6 w-6 text-text-3" />
+                        <p className="text-sm text-text-3">
+                          No files available to attach.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="divide-y divide-border-2">
+                        {filteredAttachCandidates.map((f) => {
+                          const checked = attachSelectedIds.has(f.id);
+                          return (
+                            <label
+                              key={f.id}
+                              className="flex cursor-pointer items-center gap-3 px-3 py-2.5 text-sm transition-colors hover:bg-bg-1"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={() => {
+                                  setAttachSelectedIds((prev) => {
+                                    const next = new Set(prev);
+                                    if (next.has(f.id)) next.delete(f.id);
+                                    else next.add(f.id);
+                                    return next;
+                                  });
+                                }}
+                                className="h-3.5 w-3.5 shrink-0 accent-primary-6"
+                              />
+                              <FileText className="h-3.5 w-3.5 shrink-0 text-text-3" />
+                              <span className="flex-1 truncate text-text-1">
+                                {f.name}
+                              </span>
+                              <VisibilityBadge visibility={f.visibility} />
+                            </label>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </ScrollArea>
+                </div>
 
-              <DialogFooter>
-                <Button
-                  type="button"
-                  disabled={
-                    attachMutation.isPending || attachSelectedIds.size === 0
-                  }
-                  onClick={() =>
-                    attachMutation.mutate(Array.from(attachSelectedIds))
-                  }
-                >
-                  {attachMutation.isPending
-                    ? "Attaching…"
-                    : `Attach ${attachSelectedIds.size > 0 ? `(${attachSelectedIds.size})` : ""}`}
-                </Button>
-              </DialogFooter>
+                <DialogFooter>
+                  <Button
+                    type="button"
+                    disabled={
+                      attachMutation.isPending || attachSelectedIds.size === 0
+                    }
+                    onClick={() =>
+                      attachMutation.mutate(Array.from(attachSelectedIds))
+                    }
+                    className="cursor-pointer bg-primary-6 hover:bg-primary-7"
+                  >
+                    {attachMutation.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Attaching…
+                      </>
+                    ) : (
+                      `Attach${
+                        attachSelectedIds.size > 0
+                          ? ` ${attachSelectedIds.size} file${attachSelectedIds.size !== 1 ? "s" : ""}`
+                          : ""
+                      }`
+                    )}
+                  </Button>
+                </DialogFooter>
+              </div>
+            </TabsContent>
+          </Tabs>
+
+          <Separator className="my-4" />
+
+          {/* Unified Documents list — paste-text snippets (legacy
+              `documents` rows) + attached KC files. Origin badge
+              distinguishes the two. */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium text-text-1">
+                In this project
+              </Label>
+              <span className="text-[11px] text-text-3">
+                {attachedFiles.length + (groups?.length ?? 0)} item
+                {attachedFiles.length + (groups?.length ?? 0) !== 1 ? "s" : ""}
+              </span>
             </div>
-          </TabsContent>
-        </Tabs>
-
-        <Separator />
-
-        {/* Unified Documents list — paste-text snippets (legacy
-            `documents` rows) + attached KC files. Origin badge
-            distinguishes the two. */}
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">In this project</Label>
-          <ScrollArea className="h-48">
-            {groupsLoading || attachedLoading ? (
-              <div className="flex items-center justify-center py-6">
-                <Loader2 className="h-4 w-4 animate-spin text-text-3" />
-              </div>
-            ) : (groups?.length ?? 0) === 0 && attachedFiles.length === 0 ? (
-              <p className="py-4 text-center text-sm text-text-3">
-                No context yet. Paste text, upload a file, or attach one
-                from Knowledge Core.
-              </p>
-            ) : (
-              <div className="space-y-1">
-                {/* Attached KC files first — they're the richer
-                    surface and most users will reach for them. */}
-                {attachedFiles.map((f: ProjectKnowledgeFile) => (
-                  <div
-                    key={f.fileId}
-                    className="flex items-center justify-between rounded-md border border-border-2 px-3 py-2"
-                  >
-                    <div className="flex min-w-0 items-center gap-2">
-                      <FileText className="h-4 w-4 shrink-0 text-text-3" />
-                      <span className="truncate text-sm text-text-1">
-                        {f.name}
-                      </span>
-                      <Badge
-                        variant="secondary"
-                        className="shrink-0 text-[10px]"
-                        title={`In folder "${f.folderName}"`}
-                      >
-                        <Link2 className="mr-1 h-2.5 w-2.5" /> KC
-                      </Badge>
-                      <VisibilityBadge visibility={f.visibility} />
-                      <IngestionBadge status={f.ingestionStatus} />
-                    </div>
-                    {confirmDeleteId === f.fileId ? (
-                      <div className="flex shrink-0 items-center gap-1">
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          className="h-7 text-xs"
-                          disabled={detachMutation.isPending}
-                          onClick={() => detachMutation.mutate(f.fileId)}
-                          title="Removes from project — the file stays in Knowledge Core"
-                        >
-                          {detachMutation.isPending ? "…" : "Detach"}
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 text-xs"
-                          onClick={() => setConfirmDeleteId(null)}
-                        >
-                          Cancel
-                        </Button>
-                      </div>
-                    ) : (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 shrink-0 text-text-3 hover:text-danger-6"
-                        onClick={() => setConfirmDeleteId(f.fileId)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    )}
+            <div className="overflow-hidden rounded-md border border-border-2">
+              <ScrollArea className="h-48">
+                {groupsLoading || attachedLoading ? (
+                  <div className="flex items-center justify-center py-10">
+                    <Loader2 className="h-4 w-4 animate-spin text-text-3" />
                   </div>
-                ))}
-
-                {/* Then paste-text snippets. */}
-                {(groups ?? []).map((group: DocumentGroup) => (
-                  <div
-                    key={group.groupId}
-                    className="flex items-center justify-between rounded-md border border-border-2 px-3 py-2"
-                  >
-                    <div className="flex min-w-0 items-center gap-2">
-                      <FileText className="h-4 w-4 shrink-0 text-text-3" />
-                      <span className="truncate text-sm text-text-1">
-                        {group.title}
-                      </span>
-                      <Badge
-                        variant="secondary"
-                        className="shrink-0 text-[10px]"
-                      >
-                        Text
-                      </Badge>
-                      <Badge variant="secondary" className="shrink-0 text-xs">
-                        {group.chunkCount}{" "}
-                        {group.chunkCount === 1 ? "chunk" : "chunks"}
-                      </Badge>
-                    </div>
-                    {confirmDeleteId === group.groupId ? (
-                      <div className="flex shrink-0 items-center gap-1">
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          className="h-7 text-xs"
-                          disabled={deleteMutation.isPending}
-                          onClick={() => deleteMutation.mutate(group.groupId)}
-                        >
-                          {deleteMutation.isPending ? "…" : "Confirm"}
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 text-xs"
-                          onClick={() => setConfirmDeleteId(null)}
-                        >
-                          Cancel
-                        </Button>
-                      </div>
-                    ) : (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 shrink-0 text-text-3 hover:text-danger-6"
-                        onClick={() => setConfirmDeleteId(group.groupId)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    )}
+                ) : (groups?.length ?? 0) === 0 &&
+                  attachedFiles.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
+                    <Inbox className="h-6 w-6 text-text-3" />
+                    <p className="text-sm text-text-3">
+                      No context yet. Paste text, upload a file, or attach
+                      one from Knowledge Core.
+                    </p>
                   </div>
-                ))}
-              </div>
-            )}
-          </ScrollArea>
+                ) : (
+                  <div className="divide-y divide-border-2">
+                    {/* Attached KC files first — they're the richer
+                        surface and most users will reach for them. */}
+                    {attachedFiles.map((f: ProjectKnowledgeFile) => (
+                      <div
+                        key={f.fileId}
+                        className="flex items-center justify-between gap-2 px-3 py-2.5"
+                      >
+                        <div className="flex min-w-0 flex-1 items-center gap-2">
+                          <FileText className="h-4 w-4 shrink-0 text-text-3" />
+                          <span className="min-w-0 flex-1 truncate text-sm text-text-1">
+                            {f.name}
+                          </span>
+                          <div className="hidden shrink-0 items-center gap-1.5 sm:flex">
+                            <Badge
+                              variant="secondary"
+                              className="shrink-0 text-[10px]"
+                              title={`In folder "${f.folderName}"`}
+                            >
+                              <Link2 className="mr-1 h-2.5 w-2.5" /> KC
+                            </Badge>
+                            <VisibilityBadge visibility={f.visibility} />
+                            <IngestionBadge status={f.ingestionStatus} />
+                          </div>
+                        </div>
+                        {confirmDeleteId === f.fileId ? (
+                          <div className="flex shrink-0 items-center gap-1">
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              className="h-7 cursor-pointer text-xs"
+                              disabled={detachMutation.isPending}
+                              onClick={() =>
+                                detachMutation.mutate(f.fileId)
+                              }
+                              title="Removes from project — the file stays in Knowledge Core"
+                            >
+                              {detachMutation.isPending ? "…" : "Detach"}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 cursor-pointer text-xs"
+                              onClick={() => setConfirmDeleteId(null)}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 shrink-0 cursor-pointer text-text-3 hover:text-danger-6"
+                            onClick={() => setConfirmDeleteId(f.fileId)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+
+                    {/* Then paste-text snippets. */}
+                    {(groups ?? []).map((group: DocumentGroup) => (
+                      <div
+                        key={group.groupId}
+                        className="flex items-center justify-between gap-2 px-3 py-2.5"
+                      >
+                        <div className="flex min-w-0 flex-1 items-center gap-2">
+                          <ClipboardPaste className="h-4 w-4 shrink-0 text-text-3" />
+                          <span className="min-w-0 flex-1 truncate text-sm text-text-1">
+                            {group.title}
+                          </span>
+                          <div className="hidden shrink-0 items-center gap-1.5 sm:flex">
+                            <Badge
+                              variant="secondary"
+                              className="shrink-0 text-[10px]"
+                            >
+                              Text
+                            </Badge>
+                            <Badge
+                              variant="secondary"
+                              className="shrink-0 text-[10px]"
+                            >
+                              {group.chunkCount}{" "}
+                              {group.chunkCount === 1 ? "chunk" : "chunks"}
+                            </Badge>
+                          </div>
+                        </div>
+                        {confirmDeleteId === group.groupId ? (
+                          <div className="flex shrink-0 items-center gap-1">
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              className="h-7 cursor-pointer text-xs"
+                              disabled={deleteMutation.isPending}
+                              onClick={() =>
+                                deleteMutation.mutate(group.groupId)
+                              }
+                            >
+                              {deleteMutation.isPending ? "…" : "Confirm"}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 cursor-pointer text-xs"
+                              onClick={() => setConfirmDeleteId(null)}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 shrink-0 cursor-pointer text-text-3 hover:text-danger-6"
+                            onClick={() => setConfirmDeleteId(group.groupId)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </ScrollArea>
+            </div>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/add-model-dialog.tsx
+++ b/apps/web/src/components/add-model-dialog.tsx
@@ -3,7 +3,12 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { GripVertical, MoreVertical, Trash2, ArrowUp, ArrowDown } from "lucide-react";
-import { createModel, fetchIntegrations } from "@/lib/api";
+import {
+  createModel,
+  fetchIntegrations,
+  updateModel,
+  type ModelConfig,
+} from "@/lib/api";
 import { SettingsDialog } from "@/components/settings-dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -134,16 +139,39 @@ const selectItemClass =
 
 export function AddModelDialog({
   children,
+  existingModel,
+  open: openProp,
+  onOpenChange,
 }: {
-  children: React.ReactNode;
+  children?: React.ReactNode;
+  /** When passed, the dialog runs in edit mode: prefilled from the
+   *  model, applies via updateModel, and the title/CTA copy flip. */
+  existingModel?: ModelConfig | null;
+  /** Controlled-open hooks. When both are provided (typical for the
+   *  edit flow opened from ModelRow), parent owns the open state.
+   *  When omitted, the dialog falls back to its internal useState +
+   *  the `children` trigger span (the Add flow). */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
-  const [open, setOpen] = useState(false);
+  const isEdit = !!existingModel;
+  const [internalOpen, setInternalOpen] = useState(false);
+  // Controlled when both props are provided; otherwise fall back to
+  // the legacy internal-state pattern with the child trigger span.
+  const isControlled = openProp !== undefined && onOpenChange !== undefined;
+  const open = isControlled ? openProp : internalOpen;
+  const setOpen = (next: boolean) => {
+    if (isControlled) onOpenChange!(next);
+    else setInternalOpen(next);
+  };
   const [customName, setCustomName] = useState("");
   // Tracks whether the user has manually typed into the Custom name
   // field. While false, the field auto-syncs to the picked model's
   // display label so the user doesn't stare at "Model 1" by default.
   // Flips true on the first user edit so a later model swap doesn't
-  // clobber their typed-in alias.
+  // clobber their typed-in alias. Edit flow starts touched so the
+  // prefilled custom name doesn't get clobbered by the model auto-
+  // fill effect.
   const [customNameTouched, setCustomNameTouched] = useState(false);
   const [modelId, setModelId] = useState("");
   const [fallbacks, setFallbacks] = useState<string[]>([]);
@@ -152,6 +180,18 @@ export function AddModelDialog({
   const queryClient = useQueryClient();
   const { models, isLoading: modelsLoading, getLabel: getModelLabel } =
     useAvailableModels();
+
+  // Prefill from the existing model on edit open. Re-runs when the
+  // dialog opens for a different file so the form always reflects
+  // the row the user clicked, not the last edit.
+  useEffect(() => {
+    if (!open || !existingModel) return;
+    setCustomName(existingModel.customName);
+    setCustomNameTouched(true);
+    setModelId(existingModel.modelIdentifier);
+    setFallbacks(existingModel.fallbackModels ?? []);
+    setIntegrationId(existingModel.integrationId ?? "");
+  }, [open, existingModel]);
 
   // Auto-fill the alias as soon as a model is picked, unless the
   // user has already typed something themselves. Runs after the
@@ -176,7 +216,15 @@ export function AddModelDialog({
     integrations?.filter((i) => i.isCustom && i.isEnabled) ?? [];
 
   const mutation = useMutation({
-    mutationFn: createModel,
+    mutationFn: (payload: {
+      customName: string;
+      modelIdentifier: string;
+      fallbackModels: string[];
+      integrationId: string | null;
+    }) =>
+      existingModel
+        ? updateModel(existingModel.id, payload)
+        : createModel(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["models"] });
       setCustomName("");
@@ -268,19 +316,27 @@ export function AddModelDialog({
 
   return (
     <>
-      <span onClick={() => setOpen(true)} className="contents">
-        {children}
-      </span>
+      {!isControlled && (
+        <span onClick={() => setOpen(true)} className="contents">
+          {children}
+        </span>
+      )}
 
       {open && (
         <SettingsDialog
           open={open}
           onClose={handleClose}
           onApply={handleApply}
-          applyLabel={mutation.isPending ? "Saving…" : "Apply"}
+          applyLabel={
+            mutation.isPending ? "Saving…" : isEdit ? "Save" : "Apply"
+          }
           applyPending={mutation.isPending}
-          title="Add model"
-          description="Configure a model to make it available across your workspace."
+          title={isEdit ? "Edit model" : "Add model"}
+          description={
+            isEdit
+              ? "Update this model's configuration."
+              : "Configure a model to make it available across your workspace."
+          }
         >
           <div className="space-y-4">
             {/* Selected model */}

--- a/apps/web/src/components/add-model-dialog.tsx
+++ b/apps/web/src/components/add-model-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { GripVertical, MoreVertical, Trash2, ArrowUp, ArrowDown } from "lucide-react";
 import { createModel, fetchIntegrations } from "@/lib/api";
@@ -138,7 +138,13 @@ export function AddModelDialog({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
-  const [customName, setCustomName] = useState("Model 1");
+  const [customName, setCustomName] = useState("");
+  // Tracks whether the user has manually typed into the Custom name
+  // field. While false, the field auto-syncs to the picked model's
+  // display label so the user doesn't stare at "Model 1" by default.
+  // Flips true on the first user edit so a later model swap doesn't
+  // clobber their typed-in alias.
+  const [customNameTouched, setCustomNameTouched] = useState(false);
   const [modelId, setModelId] = useState("");
   const [fallbacks, setFallbacks] = useState<string[]>([]);
   const [fallbackToAdd, setFallbackToAdd] = useState("");
@@ -146,6 +152,17 @@ export function AddModelDialog({
   const queryClient = useQueryClient();
   const { models, isLoading: modelsLoading, getLabel: getModelLabel } =
     useAvailableModels();
+
+  // Auto-fill the alias as soon as a model is picked, unless the
+  // user has already typed something themselves. Runs after the
+  // models list resolves too — picking a model before models[]
+  // hydrates would otherwise fill with the id (fallback in
+  // getLabel) until the list arrives.
+  useEffect(() => {
+    if (!customNameTouched && modelId) {
+      setCustomName(getModelLabel(modelId));
+    }
+  }, [modelId, customNameTouched, getModelLabel]);
 
   // Custom LLMs the user has registered in Management → Integration.
   // Listed as an optional binding so an alias can route to a self-hosted
@@ -162,7 +179,8 @@ export function AddModelDialog({
     mutationFn: createModel,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["models"] });
-      setCustomName("Model 1");
+      setCustomName("");
+      setCustomNameTouched(false);
       setModelId("");
       setFallbacks([]);
       setIntegrationId("");
@@ -224,6 +242,14 @@ export function AddModelDialog({
   };
 
   const handleClose = () => {
+    // Reset on close so reopening starts clean — otherwise a half-
+    // filled previous attempt (e.g. cancelled after typing a custom
+    // name) leaks into the next dialog open.
+    setCustomName("");
+    setCustomNameTouched(false);
+    setModelId("");
+    setFallbacks([]);
+    setIntegrationId("");
     setOpen(false);
   };
 
@@ -293,7 +319,11 @@ export function AddModelDialog({
               <input
                 type="text"
                 value={customName}
-                onChange={(e) => setCustomName(e.target.value)}
+                onChange={(e) => {
+                  setCustomName(e.target.value);
+                  setCustomNameTouched(true);
+                }}
+                placeholder="Pick a model to autofill"
                 className={`${inputClass} outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50`}
               />
             </div>

--- a/apps/web/src/components/change-file-visibility-dialog.tsx
+++ b/apps/web/src/components/change-file-visibility-dialog.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  fetchProjects,
+  fetchTeams,
+  updateKnowledgeFileVisibility,
+  type KnowledgeFileVisibility,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface FileForVisibility {
+  id: string;
+  name: string;
+  visibility: KnowledgeFileVisibility;
+  teams: { id: string; name: string }[];
+  projects: { id: string; name: string }[];
+}
+
+interface ChangeFileVisibilityDialogProps {
+  file: FileForVisibility | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Fires after a successful PATCH so caller can refresh its queries. */
+  onSuccess?: () => void;
+  /** Admin-only role gate — the BE rejects non-admin callers too,
+   *  but FE-side hiding is cleaner UX. */
+  isAdmin: boolean;
+}
+
+/**
+ * Post-upload visibility editor for a single KC file. Covers all
+ * four tiers (all / admins / teams / project) symmetrically with the
+ * upload-time picker, including the multi-select pickers for teams
+ * and projects. Pre-fills from the file's current state on every
+ * open so the user starts from where they left off.
+ */
+export function ChangeFileVisibilityDialog({
+  file,
+  open,
+  onOpenChange,
+  onSuccess,
+  isAdmin,
+}: ChangeFileVisibilityDialogProps) {
+  const [visibility, setVisibility] =
+    useState<KnowledgeFileVisibility>("all");
+  const [teamIds, setTeamIds] = useState<string[]>([]);
+  const [projectIds, setProjectIds] = useState<string[]>([]);
+
+  // Reset state every time the dialog opens for a new file. Without
+  // this the picker remembers the prior file's selection across
+  // openings, which is misleading.
+  useEffect(() => {
+    if (!open || !file) return;
+    setVisibility(file.visibility);
+    setTeamIds(file.teams.map((t) => t.id));
+    setProjectIds(file.projects.map((p) => p.id));
+  }, [open, file]);
+
+  // Lazy-fetch the picker data — only when the dialog is open AND
+  // the matching visibility branch is active, so closing the dialog
+  // (or picking 'all'/'admins') doesn't burn round-trips.
+  const { data: userTeams = [] } = useQuery({
+    queryKey: ["teams"],
+    queryFn: fetchTeams,
+    enabled: open && visibility === "teams",
+  });
+  const { data: userProjects = [] } = useQuery({
+    queryKey: ["projects", "kc-upload"],
+    queryFn: () => fetchProjects("all"),
+    enabled: open && visibility === "project",
+  });
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!file) throw new Error("Missing file");
+      return updateKnowledgeFileVisibility(
+        file.id,
+        visibility,
+        teamIds,
+        projectIds,
+      );
+    },
+    onSuccess: () => {
+      toast.success("Visibility updated.");
+      onSuccess?.();
+      onOpenChange(false);
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to update visibility."),
+  });
+
+  const handleSave = () => {
+    if (!file) return;
+    if (visibility === "teams" && teamIds.length === 0) {
+      toast.error("Pick at least one team for Teams visibility.");
+      return;
+    }
+    if (visibility === "project" && projectIds.length === 0) {
+      toast.error("Pick at least one project for Project visibility.");
+      return;
+    }
+    mutation.mutate();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change visibility</DialogTitle>
+          <DialogDescription className="truncate" title={file?.name}>
+            {file?.name}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Visibility</Label>
+            <Select
+              value={visibility}
+              onValueChange={(v) =>
+                setVisibility(v as KnowledgeFileVisibility)
+              }
+              disabled={mutation.isPending}
+            >
+              <SelectTrigger className="h-10 w-full cursor-pointer">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Everyone in the company</SelectItem>
+                {isAdmin && (
+                  <SelectItem value="admins">Admins only</SelectItem>
+                )}
+                <SelectItem value="teams">Specific teams…</SelectItem>
+                <SelectItem value="project">Specific project…</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-[11px] text-text-3">
+              {visibility === "admins"
+                ? "Only admins will see this file in chat / arena."
+                : visibility === "teams"
+                  ? "Only members of the teams you pick below will see this file."
+                  : visibility === "project"
+                    ? "This file will only appear in the chat of the project(s) you pick below — never in the org-wide RAG."
+                    : "Every user in the company can see this file in chat / arena."}
+            </p>
+          </div>
+
+          {visibility === "teams" && (
+            <div className="space-y-2">
+              <Label>Teams with access</Label>
+              {userTeams.length === 0 ? (
+                <p className="text-[11px] text-text-3">
+                  You aren&rsquo;t a member of any team yet — create or
+                  join a team first to use this visibility option.
+                </p>
+              ) : (
+                <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
+                  {userTeams.map((t) => {
+                    const checked = teamIds.includes(t.id);
+                    return (
+                      <label
+                        key={t.id}
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={mutation.isPending}
+                          onChange={() =>
+                            setTeamIds((prev) =>
+                              checked
+                                ? prev.filter((id) => id !== t.id)
+                                : [...prev, t.id],
+                            )
+                          }
+                          className="h-3.5 w-3.5 cursor-pointer accent-primary-6"
+                        />
+                        <span className="truncate">{t.name}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {visibility === "project" && (
+            <div className="space-y-2">
+              <Label>Projects with access</Label>
+              {userProjects.length === 0 ? (
+                <p className="text-[11px] text-text-3">
+                  You don&rsquo;t have access to any projects yet — create
+                  one first to use this visibility option.
+                </p>
+              ) : (
+                <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded border border-border-3 p-2">
+                  {userProjects.map((p) => {
+                    const checked = projectIds.includes(p.id);
+                    return (
+                      <label
+                        key={p.id}
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] text-text-1 hover:bg-bg-1"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={mutation.isPending}
+                          onChange={() =>
+                            setProjectIds((prev) =>
+                              checked
+                                ? prev.filter((id) => id !== p.id)
+                                : [...prev, p.id],
+                            )
+                          }
+                          className="h-3.5 w-3.5 cursor-pointer accent-primary-6"
+                        />
+                        <span className="truncate">
+                          {p.name}
+                          {p.teamName ? (
+                            <span className="ml-1 text-text-3">
+                              · {p.teamName}
+                            </span>
+                          ) : null}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+            className="cursor-pointer"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={mutation.isPending || !file}
+            className="cursor-pointer bg-primary-6 hover:bg-primary-7"
+          >
+            {mutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/change-file-visibility-dialog.tsx
+++ b/apps/web/src/components/change-file-visibility-dialog.tsx
@@ -147,9 +147,14 @@ export function ChangeFileVisibilityDialog({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">Everyone in the company</SelectItem>
-                {isAdmin && (
-                  <SelectItem value="admins">Admins only</SelectItem>
-                )}
+                {/* Always rendered so the trigger label still resolves
+                    for files an admin previously set to 'admins'.
+                    Disabled for non-admin so they can switch AWAY
+                    but never INTO that tier — privilege escalation
+                    block matches the BE gate. */}
+                <SelectItem value="admins" disabled={!isAdmin}>
+                  Admins only{!isAdmin ? " (admins only)" : ""}
+                </SelectItem>
                 <SelectItem value="teams">Specific teams…</SelectItem>
                 <SelectItem value="project">Specific project…</SelectItem>
               </SelectContent>

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -92,7 +92,11 @@ export const Appbar = () => {
         m.userId === currentUser.id &&
         m.status === "accepted",
     );
-    return me?.role === "owner" || me?.role === "editor";
+    return (
+      me?.role === "owner" ||
+      me?.role === "admin" ||
+      me?.role === "editor"
+    );
   })();
 
   /* ── Team detail appbar ──────────────────────────────────────────────── */

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -95,6 +95,7 @@ export const Appbar = () => {
     return (
       me?.role === "owner" ||
       me?.role === "admin" ||
+      me?.role === "manager" ||
       me?.role === "editor"
     );
   })();

--- a/apps/web/src/components/layout/footer.tsx
+++ b/apps/web/src/components/layout/footer.tsx
@@ -1,5 +1,13 @@
+/**
+ * Sits in the app shell as the very last child of the scrollable
+ * content column. `mt-auto` pushes it to the bottom of the column
+ * when the page content is short (so the footer sticks to the
+ * viewport bottom on empty pages) and yields naturally when the
+ * content overflows. Rendered on every authed route, not just the
+ * dashboard.
+ */
 export const Footer = () => (
-  <footer className="mt-12 border-t border-border-2 py-6 text-center text-xs text-text-3">
-    <p>&copy; 2024 WorkenAI Inc. All rights reserved.</p>
+  <footer className="mt-auto border-t border-border-2 pt-4 pb-2 text-center text-xs text-text-3">
+    <p>&copy; 2026 WorkenAI Inc. All rights reserved.</p>
   </footer>
 );

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import {
   Activity,
+  Bell,
   BookOpen,
   ChevronsLeft,
   ChevronsRight,
@@ -35,6 +36,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DisabledReasonTooltip } from "@/components/ui/tooltip";
+import { NotificationsPopover } from "@/components/notifications-popover";
 import { useSidebar } from "@/hooks/use-sidebar";
 import { logout } from "@/lib/api";
 
@@ -256,6 +258,35 @@ export const SidebarContent = ({
 
       {/* User Profile */}
       <div className={`mt-auto ${collapsed ? "flex flex-col items-center gap-3" : "flex flex-col items-center gap-3"}`}>
+        {/* Notifications. Lives above the dark-mode toggle by design
+            — bell+badge is the highest-priority item below the main
+            nav, dark-mode is a quality-of-life sibling under it.
+            NotificationsPopover wraps the trigger so the unread
+            badge / popover state is self-contained. */}
+        {collapsed ? (
+          <NotificationsPopover>
+            <button
+              type="button"
+              aria-label="Notifications"
+              title="Notifications"
+              className="flex h-[40px] w-[40px] cursor-pointer items-center justify-center rounded-md p-0 text-text-2 hover:text-text-1 hover:bg-bg-1"
+            >
+              <Bell className="h-5 w-5 text-text-3" />
+            </button>
+          </NotificationsPopover>
+        ) : (
+          <NotificationsPopover>
+            <button
+              type="button"
+              aria-label="Notifications"
+              title="Notifications"
+              className="flex h-10 w-full cursor-pointer items-center justify-start gap-3 rounded-md px-3 font-normal text-text-2 hover:bg-bg-1 hover:text-text-1"
+            >
+              <Bell className="size-5 shrink-0 text-text-3" />
+              <span>Notifications</span>
+            </button>
+          </NotificationsPopover>
+        )}
         {/* Dark mode toggle */}
         {collapsed ? (
           <Button

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -258,14 +258,18 @@ export const SidebarContent = ({
 
       {/* User Profile */}
       <div className={`mt-auto ${collapsed ? "flex flex-col items-center gap-3" : "flex flex-col items-center gap-3"}`}>
-        {/* Notifications. Lives above the dark-mode toggle by design
-            — bell+badge is the highest-priority item below the main
-            nav, dark-mode is a quality-of-life sibling under it.
-            Render-prop pattern so the badge can sit next to the bell
-            icon and the Button shape matches the rest of the nav
-            list exactly (no extra wrapper that would offset the
-            left edge of the icon). */}
-        <NotificationsPopover>
+        {/* Notifications + dark-mode share a tighter sub-cluster.
+            Both are quick-action toggles, so visually they read as
+            a pair — keeping them at `gap-1` distinguishes them from
+            the heavier `gap-3` between the cluster and the user
+            avatar row below. Wrapper is `w-full` in expanded mode so
+            the buttons keep filling the sidebar width. */}
+        <div
+          className={`flex flex-col items-center gap-1 ${
+            collapsed ? "" : "w-full"
+          }`}
+        >
+          <NotificationsPopover>
           {({ unreadCount }) =>
             collapsed ? (
               <Button
@@ -328,6 +332,7 @@ export const SidebarContent = ({
             <span>{themeButtonText}</span>
           </Button>
         )}
+        </div>
         <div
           className={`group flex items-center rounded-lg ${collapsed ? "justify-center" : "w-full gap-3"}`}
         >

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -261,32 +261,49 @@ export const SidebarContent = ({
         {/* Notifications. Lives above the dark-mode toggle by design
             — bell+badge is the highest-priority item below the main
             nav, dark-mode is a quality-of-life sibling under it.
-            NotificationsPopover wraps the trigger so the unread
-            badge / popover state is self-contained. */}
-        {collapsed ? (
-          <NotificationsPopover>
-            <button
-              type="button"
-              aria-label="Notifications"
-              title="Notifications"
-              className="flex h-[40px] w-[40px] cursor-pointer items-center justify-center rounded-md p-0 text-text-2 hover:text-text-1 hover:bg-bg-1"
-            >
-              <Bell className="h-5 w-5 text-text-3" />
-            </button>
-          </NotificationsPopover>
-        ) : (
-          <NotificationsPopover>
-            <button
-              type="button"
-              aria-label="Notifications"
-              title="Notifications"
-              className="flex h-10 w-full cursor-pointer items-center justify-start gap-3 rounded-md px-3 font-normal text-text-2 hover:bg-bg-1 hover:text-text-1"
-            >
-              <Bell className="size-5 shrink-0 text-text-3" />
-              <span>Notifications</span>
-            </button>
-          </NotificationsPopover>
-        )}
+            Render-prop pattern so the badge can sit next to the bell
+            icon and the Button shape matches the rest of the nav
+            list exactly (no extra wrapper that would offset the
+            left edge of the icon). */}
+        <NotificationsPopover>
+          {({ unreadCount }) =>
+            collapsed ? (
+              <Button
+                variant="ghost"
+                aria-label="Notifications"
+                title="Notifications"
+                className="h-[40px] w-[40px] p-0 justify-center text-text-2 hover:text-text-1"
+              >
+                <span className="relative">
+                  <Bell className="size-5 text-text-3" />
+                  {unreadCount > 0 && (
+                    <span className="absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-danger-5 px-1 text-[10px] font-semibold leading-none text-white">
+                      {unreadCount > 99 ? "99+" : unreadCount}
+                    </span>
+                  )}
+                </span>
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="nav"
+                aria-label="Notifications"
+                title="Notifications"
+                className="w-full cursor-pointer justify-start gap-3 font-normal text-text-2 hover:text-text-1"
+              >
+                <span className="relative">
+                  <Bell className="size-5 shrink-0 text-text-3" />
+                  {unreadCount > 0 && (
+                    <span className="absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-danger-5 px-1 text-[10px] font-semibold leading-none text-white">
+                      {unreadCount > 99 ? "99+" : unreadCount}
+                    </span>
+                  )}
+                </span>
+                <span>Notifications</span>
+              </Button>
+            )
+          }
+        </NotificationsPopover>
         {/* Dark mode toggle */}
         {collapsed ? (
           <Button

--- a/apps/web/src/components/management/company-tab.tsx
+++ b/apps/web/src/components/management/company-tab.tsx
@@ -53,7 +53,12 @@ import {
 import { formatBudgetInput, formatCurrency } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { InviteUserDialog } from "@/components/invite-user-dialog";
-import { DisabledReasonTooltip } from "@/components/ui/tooltip";
+import {
+  DisabledReasonTooltip,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // Mirror the wizard step-2 dropdowns so the post-onboarding edit flow
 // offers the same options. Source of truth: setup-profile/step-2 (BE
@@ -674,7 +679,22 @@ export function CompanyTab() {
           <div className="space-y-3">
             <div className="flex items-center gap-3">
               <p className="text-[18px] font-bold text-text-1">Projected</p>
-              <Info className="h-3.5 w-3.5 text-text-3" />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="What does Projected mean?"
+                    className="flex items-center justify-center text-text-3 hover:text-text-1"
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs text-center">
+                  Linear forecast of total company spend by month-end,
+                  extrapolated from the daily run-rate so far. Early in
+                  the month it can swing widely, then stabilizes.
+                </TooltipContent>
+              </Tooltip>
             </div>
             <div className="flex items-center gap-2.5 h-[56px]">
               <span className="text-[16px] text-text-1">{formatCurrency(projected)}</span>

--- a/apps/web/src/components/management/model-row.tsx
+++ b/apps/web/src/components/management/model-row.tsx
@@ -1,8 +1,26 @@
 "use client";
 
-import { MoreVertical, Eye, Trash2, Bot, KeySquare, Globe } from "lucide-react";
+import { useState } from "react";
+import {
+  MoreVertical,
+  Pencil,
+  Trash2,
+  Bot,
+  KeySquare,
+  Globe,
+  Loader2,
+} from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,6 +34,7 @@ import {
   updateModel,
   type ModelConfig,
 } from "@/lib/api";
+import { AddModelDialog } from "@/components/add-model-dialog";
 
 function providerOf(modelId: string): string | null {
   const idx = modelId.indexOf("/");
@@ -24,6 +43,12 @@ function providerOf(modelId: string): string | null {
 
 export function ModelRow({ model }: { model: ModelConfig }) {
   const queryClient = useQueryClient();
+
+  // Edit + delete-confirm dialogs are owned per row so opening one
+  // row's editor doesn't bleed into another. Both stay closed by
+  // default; the dropdown items flip them open.
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   const toggleMutation = useMutation({
     mutationFn: () => updateModel(model.id, { isActive: !model.isActive }),
@@ -36,7 +61,11 @@ export function ModelRow({ model }: { model: ModelConfig }) {
     mutationFn: () => deleteModel(model.id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["models"] });
+      setDeleteConfirmOpen(false);
+      toast.success(`Deleted "${model.customName}".`);
     },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to delete model."),
   });
 
   const fallbacks = (model.fallbackModels ?? []) as string[];
@@ -140,20 +169,79 @@ export function ModelRow({ model }: { model: ModelConfig }) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem className="gap-2">
-              <Eye className="h-4 w-4" />
+            <DropdownMenuItem
+              className="gap-2"
+              onClick={() => setEditOpen(true)}
+            >
+              <Pencil className="h-4 w-4" />
               Edit model
             </DropdownMenuItem>
             <DropdownMenuItem
               className="gap-2 text-danger-6 focus:text-danger-6"
-              disabled={deleteMutation.isPending}
-              onClick={() => deleteMutation.mutate()}
+              onClick={() => setDeleteConfirmOpen(true)}
             >
               <Trash2 className="h-4 w-4" />
               Delete model
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+
+        {/* Edit dialog shares the AddModelDialog component in
+            controlled / existing-model mode so the alias, fallback
+            order, and integration binding stay in one source of
+            truth. */}
+        <AddModelDialog
+          existingModel={model}
+          open={editOpen}
+          onOpenChange={setEditOpen}
+        />
+
+        {/* Delete confirmation — destructive and irreversible, so a
+            full dialog (not an inline toggle) makes the consequences
+            harder to skip. Matches the KC delete-file pattern. */}
+        <Dialog
+          open={deleteConfirmOpen}
+          onOpenChange={(open) =>
+            !deleteMutation.isPending && setDeleteConfirmOpen(open)
+          }
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete model</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to delete{" "}
+                <strong>{model.customName}</strong>? This action cannot be
+                undone. Projects routed to this alias will fall back to the
+                WorkenAI default.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setDeleteConfirmOpen(false)}
+                disabled={deleteMutation.isPending}
+                className="cursor-pointer"
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => deleteMutation.mutate()}
+                disabled={deleteMutation.isPending}
+                className="cursor-pointer"
+              >
+                {deleteMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Deleting…
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </td>
     </tr>
   );

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -9,7 +9,9 @@ import {
   Users,
   CircleDollarSign,
   FileWarning,
+  FolderOpen,
   Loader2,
+  Shield,
 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -58,6 +60,12 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
     return (
       <FileWarning className="h-4 w-4 text-warning-7" strokeWidth={2} />
     );
+  }
+  if (type === "project_created" || type === "project_deleted") {
+    return <FolderOpen className="h-4 w-4 text-text-3" strokeWidth={2} />;
+  }
+  if (type === "guardrail_added") {
+    return <Shield className="h-4 w-4 text-text-3" strokeWidth={2} />;
   }
   if (
     type === "team_renamed" ||

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -49,7 +49,7 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
     );
   }
-  if (type === "team_renamed") {
+  if (type === "team_renamed" || type === "team_role_changed") {
     // Same Users glyph as the team_invite family, muted tone since
     // this is purely informational (no Accept/Decline).
     return <Users className="h-4 w-4 text-text-3" strokeWidth={2} />;

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -165,7 +165,12 @@ export function NotificationsPopover({ children }: NotificationsPopoverProps) {
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>{children({ unreadCount })}</PopoverTrigger>
       <PopoverContent
-        align="end"
+        // Anchored at the bottom of the sidebar, so opening up + to
+        // the right keeps the popup on-screen and away from the row
+        // it was triggered from. Radix' collision handler will flip
+        // if the screen is too short.
+        side="top"
+        align="start"
         sideOffset={8}
         className="w-[360px] max-w-[calc(100vw-2rem)] p-0"
       >

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -49,6 +49,11 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
     );
   }
+  if (type === "team_renamed") {
+    // Same Users glyph as the team_invite family, muted tone since
+    // this is purely informational (no Accept/Decline).
+    return <Users className="h-4 w-4 text-text-3" strokeWidth={2} />;
+  }
   return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;
 }
 

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -42,6 +42,13 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-warning-7" strokeWidth={2} />
     );
   }
+  if (type === "budget_changed") {
+    // Muted tone vs budget_alert — this is informational ("FYI a
+    // cap moved"), not a threshold warning.
+    return (
+      <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
+    );
+  }
   return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;
 }
 

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -8,6 +8,7 @@ import {
   X,
   Users,
   CircleDollarSign,
+  FileWarning,
   Loader2,
 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -42,16 +43,31 @@ function NotificationIcon({ type }: { type: Notification["type"] }) {
       <CircleDollarSign className="h-4 w-4 text-warning-7" strokeWidth={2} />
     );
   }
-  if (type === "budget_changed") {
-    // Muted tone vs budget_alert — this is informational ("FYI a
-    // cap moved"), not a threshold warning.
+  if (
+    type === "budget_changed" ||
+    type === "account_budget_changed" ||
+    type === "member_cap_changed"
+  ) {
+    // Muted tone — these are informational ("FYI a cap moved"),
+    // not threshold warnings.
     return (
       <CircleDollarSign className="h-4 w-4 text-text-3" strokeWidth={2} />
     );
   }
-  if (type === "team_renamed" || type === "team_role_changed") {
-    // Same Users glyph as the team_invite family, muted tone since
-    // this is purely informational (no Accept/Decline).
+  if (type === "file_ingestion_failed") {
+    return (
+      <FileWarning className="h-4 w-4 text-warning-7" strokeWidth={2} />
+    );
+  }
+  if (
+    type === "team_renamed" ||
+    type === "team_role_changed" ||
+    type === "team_member_added" ||
+    type === "team_member_removed" ||
+    type === "team_deleted" ||
+    type === "account_role_changed"
+  ) {
+    // Membership / role changes — Users glyph in muted tone.
     return <Users className="h-4 w-4 text-text-3" strokeWidth={2} />;
   }
   return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import {
+  Bell,
+  CheckCheck,
+  X,
+  Users,
+  CircleDollarSign,
+  Loader2,
+} from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  acceptNotification,
+  declineNotification,
+  dismissNotification,
+  fetchNotifications,
+  fetchNotificationsUnreadCount,
+  markAllNotificationsRead,
+  markNotificationRead,
+  type Notification,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+/**
+ * Type-keyed icon picker. Kept inline because the union is small and
+ * tying each row to a glyph is the only place we map type → visual.
+ */
+function NotificationIcon({ type }: { type: Notification["type"] }) {
+  if (type === "team_invite" || type === "org_invite") {
+    return <Users className="h-4 w-4 text-primary-7" strokeWidth={2} />;
+  }
+  if (type === "budget_alert") {
+    return (
+      <CircleDollarSign className="h-4 w-4 text-warning-7" strokeWidth={2} />
+    );
+  }
+  return <Bell className="h-4 w-4 text-text-3" strokeWidth={2} />;
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+interface NotificationsPopoverProps {
+  /** Renders the trigger; the parent wraps whatever they want
+   *  (sidebar nav button, appbar bell, etc). */
+  children: React.ReactNode;
+}
+
+/**
+ * Bell-icon dropdown listing the user's pending + recent
+ * notifications. Inline Accept / Decline buttons for team invites;
+ * info-only types collapse to a Dismiss X. Polls every 30s while
+ * mounted so the badge stays fresh without a websocket.
+ */
+export function NotificationsPopover({ children }: NotificationsPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { data: items = [], isLoading } = useQuery({
+    queryKey: ["notifications"],
+    queryFn: fetchNotifications,
+    // 30s polling matches the bell-badge refresh; pausing when the
+    // tab is hidden is the default react-query behaviour, so we
+    // don't burn requests in a background tab.
+    refetchInterval: 30_000,
+  });
+
+  // Bell badge — sourced from a dedicated unread-count endpoint so
+  // the bell can mount on every authed page without paying for the
+  // full list fetch. Same 30s cadence.
+  const { data: unread } = useQuery({
+    queryKey: ["notifications", "unread"],
+    queryFn: fetchNotificationsUnreadCount,
+    refetchInterval: 30_000,
+  });
+  const unreadCount = unread?.count ?? 0;
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    queryClient.invalidateQueries({ queryKey: ["notifications", "unread"] });
+  };
+
+  const acceptMutation = useMutation({
+    mutationFn: (id: string) => acceptNotification(id),
+    onSuccess: () => {
+      invalidate();
+      // Accepting a team invite changes membership — refresh
+      // anything that lists teams the user belongs to.
+      queryClient.invalidateQueries({ queryKey: ["teams"] });
+      toast.success("Invitation accepted.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to accept."),
+  });
+  const declineMutation = useMutation({
+    mutationFn: (id: string) => declineNotification(id),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Invitation declined.");
+    },
+    onError: (err: Error) =>
+      toast.error(err.message || "Failed to decline."),
+  });
+  const dismissMutation = useMutation({
+    mutationFn: (id: string) => dismissNotification(id),
+    onSuccess: invalidate,
+  });
+  const markReadMutation = useMutation({
+    mutationFn: (id: string) => markNotificationRead(id),
+    onSuccess: invalidate,
+  });
+  const markAllMutation = useMutation({
+    mutationFn: () => markAllNotificationsRead(),
+    onSuccess: invalidate,
+  });
+
+  // Open-the-popover side effect: flip every visible unread row to
+  // read in one batch. Cheaper than per-row markRead clicks and
+  // matches the user mental model ("I saw the bell, so I've seen
+  // these").
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next && unreadCount > 0) {
+      markAllMutation.mutate();
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <span className="relative inline-flex">
+          {children}
+          {unreadCount > 0 && (
+            <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-danger-5 px-1 text-[10px] font-semibold leading-none text-white">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+        </span>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-[360px] max-w-[calc(100vw-2rem)] p-0"
+      >
+        <header className="flex items-center justify-between border-b border-border-2 px-3 py-2">
+          <span className="text-[13px] font-semibold text-text-1">
+            Notifications
+          </span>
+          <Link
+            href="/notifications"
+            className="text-[12px] text-primary-6 hover:text-primary-7"
+            onClick={() => setOpen(false)}
+          >
+            View all
+          </Link>
+        </header>
+
+        <div className="max-h-[400px] overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center px-3 py-8 text-[12px] text-text-3">
+              <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+              Loading…
+            </div>
+          ) : items.length === 0 ? (
+            <div className="px-3 py-8 text-center text-[12px] text-text-3">
+              You&rsquo;re all caught up.
+            </div>
+          ) : (
+            <ul className="divide-y divide-border-2">
+              {items.slice(0, 10).map((n) => (
+                <li
+                  key={n.id}
+                  className={cn(
+                    "flex items-start gap-2 px-3 py-2.5",
+                    n.readAt == null && "bg-primary-1/40",
+                  )}
+                >
+                  <span className="mt-0.5">
+                    <NotificationIcon type={n.type} />
+                  </span>
+                  <div className="flex flex-1 flex-col gap-1 min-w-0">
+                    <p className="text-[13px] font-medium text-text-1">
+                      {n.title}
+                    </p>
+                    {n.body && (
+                      <p className="text-[12px] text-text-2">{n.body}</p>
+                    )}
+                    <span className="text-[11px] text-text-3">
+                      {relativeTime(n.createdAt)}
+                    </span>
+                    {/* Action row — team_invite is the only type
+                        with Accept/Decline today. Other types show
+                        a passive "Dismiss" since there's nothing to
+                        confirm. Pending status drives whether the
+                        buttons are even meaningful. */}
+                    {n.status === "pending" && n.type === "team_invite" && (
+                      <div className="mt-1 flex gap-2">
+                        <button
+                          type="button"
+                          disabled={acceptMutation.isPending}
+                          onClick={() => acceptMutation.mutate(n.id)}
+                          className="cursor-pointer rounded bg-primary-6 px-2 py-1 text-[12px] font-medium text-white hover:bg-primary-7 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          Accept
+                        </button>
+                        <button
+                          type="button"
+                          disabled={declineMutation.isPending}
+                          onClick={() => declineMutation.mutate(n.id)}
+                          className="cursor-pointer rounded border border-border-3 px-2 py-1 text-[12px] font-medium text-text-1 hover:bg-bg-1 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          Decline
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 gap-1">
+                    {n.readAt == null && (
+                      <button
+                        type="button"
+                        title="Mark read"
+                        aria-label="Mark read"
+                        onClick={() => markReadMutation.mutate(n.id)}
+                        className="flex h-5 w-5 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-1 hover:text-text-1"
+                      >
+                        <CheckCheck className="h-3 w-3" />
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      title="Dismiss"
+                      aria-label="Dismiss"
+                      onClick={() => dismissMutation.mutate(n.id)}
+                      className="flex h-5 w-5 cursor-pointer items-center justify-center rounded text-text-3 hover:bg-bg-1 hover:text-text-1"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -119,19 +119,25 @@ export function NotificationsPopover({ children }: NotificationsPopoverProps) {
   const { data: items = [], isLoading } = useQuery({
     queryKey: ["notifications"],
     queryFn: fetchNotifications,
-    // 30s polling matches the bell-badge refresh; pausing when the
-    // tab is hidden is the default react-query behaviour, so we
-    // don't burn requests in a background tab.
+    // The full list is heavier (every notification body / data
+    // payload) so it stays on a relaxed 30s cadence — the user is
+    // looking at the popover when this matters, and clicking the
+    // bell triggers an instant refetch via refetchOnWindowFocus.
     refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
   });
 
-  // Bell badge — sourced from a dedicated unread-count endpoint so
-  // the bell can mount on every authed page without paying for the
-  // full list fetch. Same 30s cadence.
+  // Bell badge — sourced from a dedicated unread-count endpoint
+  // (SELECT count → indexed cheap). Polled aggressively at 5s so
+  // server-generated notifications (budget alerts, account changes,
+  // file ingestion failures, etc.) surface on the badge within a
+  // few seconds of being created. refetchOnWindowFocus catches the
+  // common "alt-tab back into the app" case immediately.
   const { data: unread } = useQuery({
     queryKey: ["notifications", "unread"],
     queryFn: fetchNotificationsUnreadCount,
-    refetchInterval: 30_000,
+    refetchInterval: 5_000,
+    refetchOnWindowFocus: true,
   });
   const unreadCount = unread?.count ?? 0;
 

--- a/apps/web/src/components/notifications-popover.tsx
+++ b/apps/web/src/components/notifications-popover.tsx
@@ -71,9 +71,15 @@ function relativeTime(iso: string): string {
 }
 
 interface NotificationsPopoverProps {
-  /** Renders the trigger; the parent wraps whatever they want
-   *  (sidebar nav button, appbar bell, etc). */
-  children: React.ReactNode;
+  /**
+   * Render prop for the trigger. Gets the live unread count so the
+   * caller can render its own badge in-place — matters because the
+   * trigger lives inside layouts (sidebar nav row, appbar icon
+   * button) where wrapping it in a positioned span would break
+   * width / alignment. Returning a single element keeps Radix's
+   * `asChild` happy.
+   */
+  children: (state: { unreadCount: number }) => React.ReactElement;
 }
 
 /**
@@ -157,16 +163,7 @@ export function NotificationsPopover({ children }: NotificationsPopoverProps) {
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <span className="relative inline-flex">
-          {children}
-          {unreadCount > 0 && (
-            <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-danger-5 px-1 text-[10px] font-semibold leading-none text-white">
-              {unreadCount > 99 ? "99+" : unreadCount}
-            </span>
-          )}
-        </span>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{children({ unreadCount })}</PopoverTrigger>
       <PopoverContent
         align="end"
         sideOffset={8}

--- a/apps/web/src/components/team-invite-form.tsx
+++ b/apps/web/src/components/team-invite-form.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-type Role = "admin" | "editor" | "viewer";
+type Role = "admin" | "manager" | "editor" | "viewer";
 
 type Mode =
   | { kind: "fixed"; teamId: string }
@@ -150,17 +150,20 @@ export function TeamInviteForm({
             <SelectItem value="admin">
               Admin — Owner-equivalent (manage budget, invites, roles)
             </SelectItem>
+            <SelectItem value="manager">
+              Manager — Owner-equivalent, operational lead
+            </SelectItem>
             <SelectItem value="editor">Editor — Can edit projects and content</SelectItem>
             <SelectItem value="viewer">
               Viewer — Read-only access
             </SelectItem>
           </SelectContent>
         </Select>
-        {role === "admin" && (
+        {(role === "admin" || role === "manager") && (
           <p className="text-[11px] text-text-3">
-            Only the team owner or an existing team admin can seed
-            another admin. Editors trying to send this invite will
-            see an error.
+            Only the team owner, admin, or manager can seed another
+            admin or manager. Editors trying to send this invite
+            will see an error.
           </p>
         )}
       </div>

--- a/apps/web/src/components/team-invite-form.tsx
+++ b/apps/web/src/components/team-invite-form.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-type Role = "editor" | "viewer";
+type Role = "admin" | "editor" | "viewer";
 
 type Mode =
   | { kind: "fixed"; teamId: string }
@@ -147,12 +147,22 @@ export function TeamInviteForm({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="admin">
+              Admin — Owner-equivalent (manage budget, invites, roles)
+            </SelectItem>
             <SelectItem value="editor">Editor — Can edit projects and content</SelectItem>
             <SelectItem value="viewer">
               Viewer — Read-only access
             </SelectItem>
           </SelectContent>
         </Select>
+        {role === "admin" && (
+          <p className="text-[11px] text-text-3">
+            Only the team owner or an existing team admin can seed
+            another admin. Editors trying to send this invite will
+            see an error.
+          </p>
+        )}
       </div>
 
       <Button

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -44,7 +44,12 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 overflow-hidden rounded-md bg-text-1 px-3 py-1.5 text-xs text-text-white shadow-md",
+          // bg-text-1 + text-bg-1 inverts cleanly in both themes —
+          // light: dark navy bg + near-white text; dark: white bg +
+          // near-black text. The previous text-text-white was always
+          // white and turned invisible against the dark-mode bg
+          // (which becomes white too).
+          "z-50 overflow-hidden rounded-md bg-text-1 px-3 py-1.5 text-xs text-bg-1 shadow-md",
           "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2793,6 +2793,7 @@ export type NotificationType =
   | "team_invite"
   | "org_invite"
   | "budget_alert"
+  | "budget_changed"
   | (string & {});
 
 export type NotificationStatus = "pending" | "acted" | "dismissed";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1328,6 +1328,10 @@ export async function* streamCompareModels(
 export interface ArenaRunSummary {
   id: string;
   question: string;
+  /** Model identifiers the run was executed against. The dashboard
+   *  card stack and the sidebar history list both render avatars
+   *  from these without a second round-trip to /runs/:id. */
+  models: string[];
   createdAt: string;
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2794,6 +2794,7 @@ export type NotificationType =
   | "org_invite"
   | "budget_alert"
   | "budget_changed"
+  | "team_renamed"
   | (string & {});
 
 export type NotificationStatus = "pending" | "acted" | "dismissed";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -412,6 +412,7 @@ export async function uploadProjectKnowledgeFiles(
     folderId?: string;
     visibility?: KnowledgeFileVisibility;
     teamIds?: string[];
+    projectIds?: string[];
   } = {},
 ): Promise<ProjectKnowledgeUploadResult> {
   const form = new FormData();
@@ -420,6 +421,9 @@ export async function uploadProjectKnowledgeFiles(
   if (options.visibility) form.append("visibility", options.visibility);
   if (options.visibility === "teams" && options.teamIds) {
     options.teamIds.forEach((id) => form.append("teamIds", id));
+  }
+  if (options.visibility === "project" && options.projectIds) {
+    options.projectIds.forEach((id) => form.append("projectIds", id));
   }
   const res = await apiFetch(
     `/projects/${projectId}/knowledge-files/upload`,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2806,6 +2806,9 @@ export type NotificationType =
   | "account_budget_changed"
   | "member_cap_changed"
   | "file_ingestion_failed"
+  | "project_created"
+  | "project_deleted"
+  | "guardrail_added"
   | (string & {});
 
 export type NotificationStatus = "pending" | "acted" | "dismissed";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1814,7 +1814,11 @@ export interface KnowledgeFolder {
   updatedAt: string;
 }
 
-export type KnowledgeFileVisibility = "all" | "admins" | "teams";
+export type KnowledgeFileVisibility =
+  | "all"
+  | "admins"
+  | "teams"
+  | "project";
 
 /**
  * Compact representation of a team link on a knowledge file. Carries
@@ -1822,6 +1826,16 @@ export type KnowledgeFileVisibility = "all" | "admins" | "teams";
  * the FE having to lookup names from a separate query.
  */
 export interface KnowledgeFileTeamRef {
+  id: string;
+  name: string;
+}
+
+/**
+ * Same shape as KnowledgeFileTeamRef but for the project visibility
+ * tier — the row badge can resolve project names without a second
+ * round-trip.
+ */
+export interface KnowledgeFileProjectRef {
   id: string;
   name: string;
 }
@@ -1839,15 +1853,18 @@ export interface KnowledgeFile {
   // this file. Surfaced as a badge on the folder detail page.
   ingestionStatus: IngestionDocStatus;
   ingestionError: string | null;
-  // Secondary visibility within company scope: 'all' is readable
-  // by every company user, 'admins' restricts to role='admin',
-  // 'teams' restricts to members of the linked team set. Default
-  // 'all'. Admins toggle via the action menu / upload dialog;
-  // basic users can pick 'all' or 'teams' but never 'admins'.
+  // Secondary visibility within company scope:
+  //   - 'all'     : every company user
+  //   - 'admins'  : role='admin' only
+  //   - 'teams'   : members of the linked team set
+  //   - 'project' : visible only in the chat of linked project(s);
+  //                 NEVER in the org-wide RAG.
   visibility: KnowledgeFileVisibility;
-  // Populated only when visibility='teams'; empty array otherwise.
-  // Drives the row badge that names the teams with access.
+  // Populated only when visibility='teams' / 'project'; empty array
+  // otherwise. Drives the row badge that names the teams / projects
+  // with access.
   teams: KnowledgeFileTeamRef[];
+  projects: KnowledgeFileProjectRef[];
   createdAt: string;
 }
 
@@ -1871,6 +1888,7 @@ export interface KnowledgeRecentFile {
   ingestionError: string | null;
   visibility: KnowledgeFileVisibility;
   teams: KnowledgeFileTeamRef[];
+  projects: KnowledgeFileProjectRef[];
   createdAt: string;
 }
 
@@ -1934,18 +1952,23 @@ export async function uploadKnowledgeFiles(
   files: File[],
   visibility: KnowledgeFileVisibility = "all",
   teamIds: string[] = [],
+  projectIds: string[] = [],
 ): Promise<KnowledgeUploadResult> {
   const form = new FormData();
   files.forEach((f) => form.append("files", f));
   // Multipart field for the visibility flag. BE enforces that only
-  // admins can set 'admins'; non-admin callers can pick 'all' or
-  // 'teams'. 'teams' requires teamIds non-empty.
+  // admins can set 'admins'; non-admin callers can pick 'all',
+  // 'teams', or 'project'. 'teams' requires teamIds non-empty;
+  // 'project' requires projectIds non-empty.
   form.append("visibility", visibility);
-  // Append each teamId as a repeated field — multer parses repeats
-  // into an array on the body, matching the controller's expected
+  // Append each id as a repeated field — multer parses repeats into
+  // an array on the body, matching the controller's expected
   // `string | string[]` shape.
   if (visibility === "teams") {
     teamIds.forEach((id) => form.append("teamIds", id));
+  }
+  if (visibility === "project") {
+    projectIds.forEach((id) => form.append("projectIds", id));
   }
   const res = await apiFetch(`/knowledge-core/folders/${folderId}/files`, {
     method: "POST",
@@ -1966,23 +1989,26 @@ export async function updateKnowledgeFileVisibility(
   fileId: string,
   visibility: KnowledgeFileVisibility,
   teamIds: string[] = [],
+  projectIds: string[] = [],
 ): Promise<{
   id: string;
   visibility: KnowledgeFileVisibility;
   teamIds: string[];
+  projectIds: string[];
 }> {
   const res = await apiFetch(
     `/knowledge-core/files/${fileId}/visibility`,
     {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      // `teamIds` is sent only when meaningful — for 'all' / 'admins'
-      // the BE clears any prior links regardless, so the field is
-      // redundant. Keep the payload tight.
+      // Only ship the id array that matches the chosen visibility —
+      // for 'all' / 'admins' the BE clears any prior links anyway.
       body: JSON.stringify(
         visibility === "teams"
           ? { visibility, teamIds }
-          : { visibility },
+          : visibility === "project"
+            ? { visibility, projectIds }
+            : { visibility },
       ),
     },
   );
@@ -2038,9 +2064,11 @@ export async function updateKnowledgeFilesVisibilityBulk(
   fileIds: string[],
   visibility: KnowledgeFileVisibility,
   teamIds: string[] = [],
+  projectIds: string[] = [],
 ): Promise<{
   visibility: KnowledgeFileVisibility;
   teamIds: string[];
+  projectIds: string[];
   affectedIds: string[];
   /** Files skipped because they were mid-ingestion at the time of the
    *  call — BE refuses to flip during processing to avoid leaving
@@ -2054,7 +2082,9 @@ export async function updateKnowledgeFilesVisibilityBulk(
     body: JSON.stringify(
       visibility === "teams"
         ? { fileIds, visibility, teamIds }
-        : { fileIds, visibility },
+        : visibility === "project"
+          ? { fileIds, visibility, projectIds }
+          : { fileIds, visibility },
     ),
   });
   if (!res.ok) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2799,6 +2799,13 @@ export type NotificationType =
   | "budget_changed"
   | "team_renamed"
   | "team_role_changed"
+  | "team_member_added"
+  | "team_member_removed"
+  | "team_deleted"
+  | "account_role_changed"
+  | "account_budget_changed"
+  | "member_cap_changed"
+  | "file_ingestion_failed"
   | (string & {});
 
 export type NotificationStatus = "pending" | "acted" | "dismissed";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2798,6 +2798,7 @@ export type NotificationType =
   | "budget_alert"
   | "budget_changed"
   | "team_renamed"
+  | "team_role_changed"
   | (string & {});
 
 export type NotificationStatus = "pending" | "acted" | "dismissed";

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -341,7 +341,11 @@ export interface TeamListItem extends Team {
 export interface TeamMember {
   id: string;
   email: string;
-  role: "owner" | "editor" | "viewer";
+  // 'admin' is owner-equivalent: same permissions as the team owner
+  // (budget, invites, role changes, integrations) except they aren't
+  // the literal team owner so they can't be removed as such. Only
+  // an owner or another admin can promote / demote to this role.
+  role: "owner" | "admin" | "editor" | "viewer";
   status: "pending" | "accepted";
   createdAt: string;
   userId: string | null;
@@ -446,7 +450,7 @@ export async function inviteUser(
 export async function inviteTeamMember(
   teamId: string,
   email: string,
-  role: "editor" | "viewer",
+  role: "admin" | "editor" | "viewer",
   monthlyCapCents?: number | null,
 ): Promise<InviteTeamMemberResult> {
   const res = await apiFetch(`/teams/${teamId}/members`, {
@@ -492,14 +496,17 @@ export async function revokeInvitation(memberId: string): Promise<void> {
 export async function updateMemberRole(
   teamId: string,
   memberId: string,
-  role: "editor" | "viewer",
+  role: "admin" | "editor" | "viewer",
 ): Promise<TeamMember> {
   const res = await apiFetch(`/teams/${teamId}/members/${memberId}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ role }),
   });
-  if (!res.ok) throw new Error("Failed to update member role");
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to update member role");
+  }
   return res.json();
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2782,3 +2782,82 @@ export async function revokeApiKey(id: string): Promise<void> {
   }
 }
 
+// ─── Notifications ───────────────────────────────────────────────────
+
+/**
+ * Discriminated `type` values the BE emits. Loose-typed string at
+ * the wire so a new type added on the BE doesn't break the FE; the
+ * union covers the renderer-aware ones.
+ */
+export type NotificationType =
+  | "team_invite"
+  | "org_invite"
+  | "budget_alert"
+  | (string & {});
+
+export type NotificationStatus = "pending" | "acted" | "dismissed";
+
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string | null;
+  /** Discriminated payload — schema depends on `type`. Renderers
+   *  cast within their branch. */
+  data: Record<string, unknown>;
+  status: NotificationStatus;
+  readAt: string | null;
+  createdAt: string;
+}
+
+export async function fetchNotifications(): Promise<Notification[]> {
+  const res = await apiFetch("/notifications");
+  if (!res.ok) throw new Error("Failed to fetch notifications");
+  return res.json();
+}
+
+export async function fetchNotificationsUnreadCount(): Promise<{ count: number }> {
+  const res = await apiFetch("/notifications/unread-count");
+  if (!res.ok) throw new Error("Failed to fetch unread count");
+  return res.json();
+}
+
+export async function markNotificationRead(id: string): Promise<Notification> {
+  const res = await apiFetch(`/notifications/${id}/read`, { method: "PATCH" });
+  if (!res.ok) throw new Error("Failed to mark notification read");
+  return res.json();
+}
+
+export async function markAllNotificationsRead(): Promise<{ markedCount: number }> {
+  const res = await apiFetch("/notifications/read-all", { method: "PATCH" });
+  if (!res.ok) throw new Error("Failed to mark all read");
+  return res.json();
+}
+
+export async function acceptNotification(id: string): Promise<{
+  type: NotificationType;
+  teamId?: string;
+}> {
+  const res = await apiFetch(`/notifications/${id}/accept`, { method: "POST" });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to accept");
+  }
+  return res.json();
+}
+
+export async function declineNotification(id: string): Promise<{ ok: true }> {
+  const res = await apiFetch(`/notifications/${id}/decline`, { method: "POST" });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to decline");
+  }
+  return res.json();
+}
+
+export async function dismissNotification(id: string): Promise<{ id: string }> {
+  const res = await apiFetch(`/notifications/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error("Failed to dismiss notification");
+  return res.json();
+}
+

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1686,7 +1686,17 @@ export interface KnowledgeFolder {
   updatedAt: string;
 }
 
-export type KnowledgeFileVisibility = "all" | "admins";
+export type KnowledgeFileVisibility = "all" | "admins" | "teams";
+
+/**
+ * Compact representation of a team link on a knowledge file. Carries
+ * just enough to render the row badge ("Teams: HR, Sales") without
+ * the FE having to lookup names from a separate query.
+ */
+export interface KnowledgeFileTeamRef {
+  id: string;
+  name: string;
+}
 
 export interface KnowledgeFile {
   id: string;
@@ -1702,10 +1712,14 @@ export interface KnowledgeFile {
   ingestionStatus: IngestionDocStatus;
   ingestionError: string | null;
   // Secondary visibility within company scope: 'all' is readable
-  // by every company user, 'admins' restricts to role='admin'.
-  // Default 'all'. Admins toggle via the action menu / upload
-  // dialog; basic users see this read-only.
+  // by every company user, 'admins' restricts to role='admin',
+  // 'teams' restricts to members of the linked team set. Default
+  // 'all'. Admins toggle via the action menu / upload dialog;
+  // basic users can pick 'all' or 'teams' but never 'admins'.
   visibility: KnowledgeFileVisibility;
+  // Populated only when visibility='teams'; empty array otherwise.
+  // Drives the row badge that names the teams with access.
+  teams: KnowledgeFileTeamRef[];
   createdAt: string;
 }
 
@@ -1728,6 +1742,7 @@ export interface KnowledgeRecentFile {
   ingestionStatus: IngestionDocStatus;
   ingestionError: string | null;
   visibility: KnowledgeFileVisibility;
+  teams: KnowledgeFileTeamRef[];
   createdAt: string;
 }
 
@@ -1790,18 +1805,28 @@ export async function uploadKnowledgeFiles(
   folderId: string,
   files: File[],
   visibility: KnowledgeFileVisibility = "all",
+  teamIds: string[] = [],
 ): Promise<KnowledgeUploadResult> {
   const form = new FormData();
   files.forEach((f) => form.append("files", f));
   // Multipart field for the visibility flag. BE enforces that only
-  // admins can set 'admins'; for non-admin callers any value other
-  // than 'all' is rejected, so the caller MUST omit it / pass 'all'.
+  // admins can set 'admins'; non-admin callers can pick 'all' or
+  // 'teams'. 'teams' requires teamIds non-empty.
   form.append("visibility", visibility);
+  // Append each teamId as a repeated field — multer parses repeats
+  // into an array on the body, matching the controller's expected
+  // `string | string[]` shape.
+  if (visibility === "teams") {
+    teamIds.forEach((id) => form.append("teamIds", id));
+  }
   const res = await apiFetch(`/knowledge-core/folders/${folderId}/files`, {
     method: "POST",
     body: form,
   });
-  if (!res.ok) throw new Error("Failed to upload files");
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to upload files");
+  }
   return res.json();
 }
 
@@ -1812,13 +1837,25 @@ export async function uploadKnowledgeFiles(
 export async function updateKnowledgeFileVisibility(
   fileId: string,
   visibility: KnowledgeFileVisibility,
-): Promise<{ id: string; visibility: KnowledgeFileVisibility }> {
+  teamIds: string[] = [],
+): Promise<{
+  id: string;
+  visibility: KnowledgeFileVisibility;
+  teamIds: string[];
+}> {
   const res = await apiFetch(
     `/knowledge-core/files/${fileId}/visibility`,
     {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ visibility }),
+      // `teamIds` is sent only when meaningful — for 'all' / 'admins'
+      // the BE clears any prior links regardless, so the field is
+      // redundant. Keep the payload tight.
+      body: JSON.stringify(
+        visibility === "teams"
+          ? { visibility, teamIds }
+          : { visibility },
+      ),
     },
   );
   if (!res.ok) {
@@ -1853,8 +1890,10 @@ export async function reingestKnowledgeFile(
 export async function updateKnowledgeFilesVisibilityBulk(
   fileIds: string[],
   visibility: KnowledgeFileVisibility,
+  teamIds: string[] = [],
 ): Promise<{
   visibility: KnowledgeFileVisibility;
+  teamIds: string[];
   affectedIds: string[];
   /** Files skipped because they were mid-ingestion at the time of the
    *  call — BE refuses to flip during processing to avoid leaving
@@ -1865,7 +1904,11 @@ export async function updateKnowledgeFilesVisibilityBulk(
   const res = await apiFetch(`/knowledge-core/files/visibility`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ fileIds, visibility }),
+    body: JSON.stringify(
+      visibility === "teams"
+        ? { fileIds, visibility, teamIds }
+        : { fileIds, visibility },
+    ),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1764,11 +1764,33 @@ export async function deleteKnowledgeFolder(id: string): Promise<void> {
   if (!res.ok) throw new Error("Failed to delete folder");
 }
 
+/**
+ * Per-file duplicate descriptor returned by the upload endpoint when
+ * the same SHA-256 content is already in the uploader's Knowledge
+ * Core. `existing.id` is null when the duplicate is detected against
+ * another file in the same upload batch (no row to link to yet —
+ * only the first occurrence got inserted).
+ */
+export interface KnowledgeUploadDuplicate {
+  name: string;
+  existing: {
+    id: string | null;
+    name: string;
+    folderId: string;
+    folderName: string;
+  };
+}
+
+export interface KnowledgeUploadResult {
+  uploaded: Omit<KnowledgeFile, "uploadedByName">[];
+  duplicates: KnowledgeUploadDuplicate[];
+}
+
 export async function uploadKnowledgeFiles(
   folderId: string,
   files: File[],
   visibility: KnowledgeFileVisibility = "all",
-): Promise<Omit<KnowledgeFile, "uploadedByName">[]> {
+): Promise<KnowledgeUploadResult> {
   const form = new FormData();
   files.forEach((f) => form.append("files", f));
   // Multipart field for the visibility flag. BE enforces that only

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -341,11 +341,14 @@ export interface TeamListItem extends Team {
 export interface TeamMember {
   id: string;
   email: string;
-  // 'admin' is owner-equivalent: same permissions as the team owner
-  // (budget, invites, role changes, integrations) except they aren't
-  // the literal team owner so they can't be removed as such. Only
-  // an owner or another admin can promote / demote to this role.
-  role: "owner" | "admin" | "editor" | "viewer";
+  // 'admin' and 'manager' are owner-equivalent: same permissions as
+  // the team owner (budget, invites, role changes, integrations)
+  // except they aren't the literal team owner so they can't be
+  // removed as such. Only an owner, admin, or manager can promote /
+  // demote into these tiers. 'editor' can create team projects,
+  // edit content, and invite editors/viewers but can't touch
+  // admin/manager rows.
+  role: "owner" | "admin" | "manager" | "editor" | "viewer";
   status: "pending" | "accepted";
   createdAt: string;
   userId: string | null;
@@ -450,7 +453,7 @@ export async function inviteUser(
 export async function inviteTeamMember(
   teamId: string,
   email: string,
-  role: "admin" | "editor" | "viewer",
+  role: "admin" | "manager" | "editor" | "viewer",
   monthlyCapCents?: number | null,
 ): Promise<InviteTeamMemberResult> {
   const res = await apiFetch(`/teams/${teamId}/members`, {
@@ -496,7 +499,7 @@ export async function revokeInvitation(memberId: string): Promise<void> {
 export async function updateMemberRole(
   teamId: string,
   memberId: string,
-  role: "admin" | "editor" | "viewer",
+  role: "admin" | "manager" | "editor" | "viewer",
 ): Promise<TeamMember> {
   const res = await apiFetch(`/teams/${teamId}/members/${memberId}`, {
     method: "PATCH",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2012,6 +2012,25 @@ export async function reingestKnowledgeFile(
 }
 
 /**
+ * Wipe a file's embeddings without deleting the upload. Inverse of
+ * `reingestKnowledgeFile` — chunks go away, the file row stays so
+ * download still works, and chat-time RAG stops surfacing it until
+ * the owner triggers Retrain.
+ */
+export async function untrainKnowledgeFile(
+  fileId: string,
+): Promise<{ id: string; ingestionStatus: "untrained" }> {
+  const res = await apiFetch(`/knowledge-core/files/${fileId}/untrain`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to untrain this file");
+  }
+  return res.json();
+}
+
+/**
  * Bulk visibility flip — one round-trip, single BE transaction.
  * Admin-only at the BE. Used by the multi-select action bar.
  */
@@ -2474,7 +2493,8 @@ export type IngestionDocStatus =
   | "pending"
   | "processing"
   | "done"
-  | "failed";
+  | "failed"
+  | "untrained";
 
 export interface IngestionStatusResponse {
   total: number;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -318,6 +318,120 @@ export async function uploadDocumentFile(
   return res.json();
 }
 
+// ─── Project ↔ Knowledge Core attachments ─────────────────────────
+//
+// Manage Context routes file uploads through Knowledge Core now —
+// see ProjectKnowledgeService on the BE. The legacy
+// `uploadDocumentFile` above stays for paste-text snippets and
+// existing data; the helpers below replace the project-scoped
+// upload path with KC linking + KC upload (auto-attach).
+
+export interface ProjectKnowledgeFile {
+  fileId: string;
+  name: string;
+  fileType: string | null;
+  sizeBytes: number;
+  folderId: string;
+  folderName: string;
+  visibility: KnowledgeFileVisibility;
+  ingestionStatus: IngestionDocStatus;
+  ingestionError: string | null;
+  teams: KnowledgeFileTeamRef[];
+  attachedAt: string;
+}
+
+export interface ProjectKnowledgeUploadDefaults {
+  folderId: string;
+  folderName: string;
+  visibility: "all" | "teams";
+  teamIds: string[];
+}
+
+export async function fetchProjectKnowledgeFiles(
+  projectId: string,
+): Promise<ProjectKnowledgeFile[]> {
+  const res = await apiFetch(`/projects/${projectId}/knowledge-files`);
+  if (!res.ok) throw new Error("Failed to fetch project knowledge files");
+  return res.json();
+}
+
+export async function fetchProjectKnowledgeUploadDefaults(
+  projectId: string,
+): Promise<ProjectKnowledgeUploadDefaults> {
+  const res = await apiFetch(
+    `/projects/${projectId}/knowledge-files/upload-defaults`,
+  );
+  if (!res.ok) throw new Error("Failed to fetch upload defaults");
+  return res.json();
+}
+
+export async function attachKnowledgeFiles(
+  projectId: string,
+  fileIds: string[],
+): Promise<{ attached: string[] }> {
+  const res = await apiFetch(`/projects/${projectId}/knowledge-files`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ fileIds }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to attach files");
+  }
+  return res.json();
+}
+
+export async function detachKnowledgeFile(
+  projectId: string,
+  fileId: string,
+): Promise<{ ok: true }> {
+  const res = await apiFetch(
+    `/projects/${projectId}/knowledge-files/${fileId}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) throw new Error("Failed to detach file");
+  return res.json();
+}
+
+export interface ProjectKnowledgeUploadResult {
+  uploaded: Array<{ id: string; name: string; ingestionStatus: string }>;
+  duplicates: KnowledgeUploadDuplicate[];
+}
+
+/**
+ * Upload one or more files from the Manage Context dialog. Routes
+ * through the BE which writes to KC + auto-attaches to the
+ * project. `folderId` / `visibility` / `teamIds` are optional —
+ * omit them to use the smart-default ("Projects" folder, scope-
+ * aware visibility).
+ */
+export async function uploadProjectKnowledgeFiles(
+  projectId: string,
+  files: File[],
+  options: {
+    folderId?: string;
+    visibility?: KnowledgeFileVisibility;
+    teamIds?: string[];
+  } = {},
+): Promise<ProjectKnowledgeUploadResult> {
+  const form = new FormData();
+  files.forEach((f) => form.append("files", f));
+  if (options.folderId) form.append("folderId", options.folderId);
+  if (options.visibility) form.append("visibility", options.visibility);
+  if (options.visibility === "teams" && options.teamIds) {
+    options.teamIds.forEach((id) => form.append("teamIds", id));
+  }
+  const res = await apiFetch(
+    `/projects/${projectId}/knowledge-files/upload`,
+    { method: "POST", body: form },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || "Failed to upload files");
+  }
+  return res.json();
+}
+
 // Teams
 
 export interface Team {

--- a/apps/web/src/lib/route-config.ts
+++ b/apps/web/src/lib/route-config.ts
@@ -94,6 +94,12 @@ const ROUTE_CONFIGS: Record<string, RouteConfig> = {
     hideNotifications: true,
     appbarType: "observability",
   },
+  "/notifications": {
+    bg: "bg-bg-1",
+    title: "Notifications",
+    hideSearch: true,
+    hideNotifications: true,
+  },
   "/compare-models": {
     bg: "bg-bg-1",
     title: "Model Arena",

--- a/packages/database/backfill/add-knowledge-file-content-sha256.sql
+++ b/packages/database/backfill/add-knowledge-file-content-sha256.sql
@@ -1,0 +1,16 @@
+-- Add content_sha256 to knowledge_files for upload-time duplicate
+-- detection. New uploads compute a hex SHA-256 and the upload path
+-- checks for prior rows with the same hash uploaded by the same
+-- user (across all their folders) before inserting.
+--
+-- One-shot, idempotent. Safe before `pnpm db:push`; that push is a
+-- no-op afterwards. Existing rows stay NULL — they simply opt out of
+-- duplicate detection until re-uploaded.
+ALTER TABLE knowledge_files
+  ADD COLUMN IF NOT EXISTS content_sha256 text;
+
+-- Two-column index so the per-uploader scope is enforced in the same
+-- probe as the hash match. Same index name the schema declaration
+-- emits, so `pnpm db:push` sees it as already present.
+CREATE INDEX IF NOT EXISTS knowledge_files_owner_hash_idx
+  ON knowledge_files (uploaded_by_id, content_sha256);

--- a/packages/database/backfill/add-knowledge-file-teams.sql
+++ b/packages/database/backfill/add-knowledge-file-teams.sql
@@ -1,0 +1,21 @@
+-- Add the knowledge_file_teams join table for the new
+-- `visibility='teams'` mode on knowledge_files.
+--
+-- Each row grants one team read access to one file at chat / arena
+-- time. Empty link set === no one can read the file; the upload
+-- path validates non-empty when visibility='teams'. Cascade on
+-- both sides so deleting a file or a team cleans the links.
+--
+-- One-shot, idempotent. Safe before `pnpm db:push`; that push is a
+-- no-op afterwards.
+CREATE TABLE IF NOT EXISTS knowledge_file_teams (
+  file_id    uuid NOT NULL REFERENCES knowledge_files (id) ON DELETE CASCADE,
+  team_id    uuid NOT NULL REFERENCES teams (id)            ON DELETE CASCADE,
+  created_at timestamp NOT NULL DEFAULT now(),
+  PRIMARY KEY (file_id, team_id)
+);
+
+-- Reverse lookup ("which files does team X see?") for team detail
+-- pages and the chat-time membership probe.
+CREATE INDEX IF NOT EXISTS knowledge_file_teams_team_idx
+  ON knowledge_file_teams (team_id);

--- a/packages/database/backfill/add-notifications.sql
+++ b/packages/database/backfill/add-notifications.sql
@@ -1,0 +1,33 @@
+-- In-app notification inbox. Mirrors the actionable subset of what
+-- the mail service sends (team / org invitations) plus auto-emitted
+-- info-only alerts (budget thresholds). Email keeps firing in
+-- parallel so users who don't open the app don't miss invites.
+--
+-- One-shot, idempotent. Safe to run before `pnpm db:push`; the push
+-- is a no-op afterwards.
+CREATE TABLE IF NOT EXISTS notifications (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  type       text NOT NULL,
+  title      text NOT NULL,
+  body       text,
+  data       jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status     text NOT NULL DEFAULT 'pending',
+  read_at    timestamp,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+-- Bell-popover default list: filter by user + status, order newest
+-- first.
+CREATE INDEX IF NOT EXISTS notifications_user_status_idx
+  ON notifications (user_id, status, created_at);
+
+-- Unread badge probe.
+CREATE INDEX IF NOT EXISTS notifications_user_read_idx
+  ON notifications (user_id, read_at);
+
+-- Budget-alert idempotency uses an app-side check-before-insert
+-- against `data->>'thresholdKey'`; under normal load that's fine
+-- since two concurrent chat calls crossing the same threshold in
+-- the same millisecond is rare and the worst case is a duplicate
+-- notification, not a state corruption.

--- a/packages/database/backfill/add-project-knowledge-files.sql
+++ b/packages/database/backfill/add-project-knowledge-files.sql
@@ -1,0 +1,19 @@
+-- Many-to-many link between `projects` and `knowledge_files` so a
+-- project can "attach" KC files for its chat RAG context. Replaces
+-- the previous per-project upload destination — uploads from
+-- Manage Context now land in KC and link here. Cascade on both
+-- sides so deletions stay clean.
+--
+-- One-shot, idempotent. Safe to run before `pnpm db:push`; that
+-- push is a no-op afterwards.
+CREATE TABLE IF NOT EXISTS project_knowledge_files (
+  project_id  uuid NOT NULL REFERENCES projects (id)        ON DELETE CASCADE,
+  file_id     uuid NOT NULL REFERENCES knowledge_files (id) ON DELETE CASCADE,
+  attached_by uuid REFERENCES users (id),
+  attached_at timestamp NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, file_id)
+);
+
+-- Reverse-lookup index for "which projects use this file?"
+CREATE INDEX IF NOT EXISTS project_knowledge_files_file_idx
+  ON project_knowledge_files (file_id);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -469,15 +469,17 @@ export const knowledgeFiles = pgTable("knowledge_files", {
   // uploader-only; company accounts → org-wide. Set from the
   // uploader's profileType at upload time.
   scope: text("scope").notNull().default("personal"),
-  // Within company-scope, a second layer of gating: 'all' lets every
-  // company user (regardless of role) pull these chunks at chat /
-  // arena time; 'admins' restricts them to role='admin'. The choice
-  // is exposed to admins at upload time and is editable post-upload
-  // via PATCH /knowledge-core/files/:id/visibility. Default 'all'
-  // matches the pre-feature behaviour so legacy rows keep working
-  // without a backfill. Irrelevant for scope='personal' (owner-only
-  // already), kept on every row for shape uniformity + search filter
-  // simplicity.
+  // Within company-scope, a second layer of gating:
+  //   - 'all'    : every company user can pull these chunks at chat /
+  //                arena time (default; matches pre-feature behaviour).
+  //   - 'admins' : restricted to role='admin' (admin-only privilege).
+  //   - 'teams'  : restricted to members of the team set in
+  //                `knowledge_file_teams`. Empty link set === no one
+  //                can read; the upload path validates non-empty.
+  // The choice is exposed at upload time and is editable post-upload
+  // via PATCH /knowledge-core/files/:id/visibility. Irrelevant for
+  // scope='personal' (owner-only already), kept on every row for
+  // shape uniformity + search-filter simplicity.
   visibility: text("visibility").notNull().default("all"),
   // Content hash (hex SHA-256) of the uploaded bytes. Used by the
   // upload path to skip files the same uploader already has elsewhere
@@ -496,6 +498,31 @@ export const knowledgeFiles = pgTable("knowledge_files", {
     table.contentSha256,
   ),
 ]);
+
+// Many-to-many link between `knowledge_files` and `teams` for the
+// `visibility = 'teams'` mode. Each row grants one team read access
+// to the file at chat / arena time. Empty link set === no team can
+// read the file; the upload path validates the array is non-empty
+// when visibility='teams'. Cascade on both sides so deleting a file
+// or a team auto-cleans the links — no orphans, no broken RAG.
+export const knowledgeFileTeams = pgTable(
+  "knowledge_file_teams",
+  {
+    fileId: uuid("file_id")
+      .references(() => knowledgeFiles.id, { onDelete: "cascade" })
+      .notNull(),
+    teamId: uuid("team_id")
+      .references(() => teams.id, { onDelete: "cascade" })
+      .notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.fileId, table.teamId] }),
+    // Reverse lookup: "which files does team X get to see?" — used by
+    // the team detail page and the chat-time membership check.
+    index("knowledge_file_teams_team_idx").on(table.teamId),
+  ],
+);
 
 export const shortcuts = pgTable("shortcuts", {
   id: uuid("id").primaryKey().defaultRandom(),

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -479,8 +479,23 @@ export const knowledgeFiles = pgTable("knowledge_files", {
   // already), kept on every row for shape uniformity + search filter
   // simplicity.
   visibility: text("visibility").notNull().default("all"),
+  // Content hash (hex SHA-256) of the uploaded bytes. Used by the
+  // upload path to skip files the same uploader already has elsewhere
+  // in their Knowledge Core — we surface them as duplicates on the FE
+  // instead of inserting another row. Nullable for legacy rows
+  // uploaded before this column existed; those simply opt out of
+  // duplicate detection until they're re-uploaded.
+  contentSha256: text("content_sha256"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+}, (table) => [
+  // Fast lookup for the upload-path dupe check: given an uploader and
+  // a set of candidate hashes, find any pre-existing row. Two-column
+  // index so the per-user scope is enforced in the same probe.
+  index("knowledge_files_owner_hash_idx").on(
+    table.uploadedById,
+    table.contentSha256,
+  ),
+]);
 
 export const shortcuts = pgTable("shortcuts", {
   id: uuid("id").primaryKey().defaultRandom(),

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -499,6 +499,35 @@ export const knowledgeFiles = pgTable("knowledge_files", {
   ),
 ]);
 
+// Many-to-many link between `projects` and `knowledge_files`. Lets
+// a project "attach" KC files so the chat RAG for that project
+// pulls those chunks in addition to its own `documents` rows.
+// Replaces the old per-project upload destination — uploads from
+// Manage Context now land in KC and get linked here.
+//
+// Cascade on both sides so a deleted project / file auto-cleans
+// the link rows. (project_id, file_id) composite PK keeps the link
+// inherently idempotent under repeat-attach attempts.
+export const projectKnowledgeFiles = pgTable(
+  "project_knowledge_files",
+  {
+    projectId: uuid("project_id")
+      .references(() => projects.id, { onDelete: "cascade" })
+      .notNull(),
+    fileId: uuid("file_id")
+      .references(() => knowledgeFiles.id, { onDelete: "cascade" })
+      .notNull(),
+    attachedBy: uuid("attached_by").references(() => users.id),
+    attachedAt: timestamp("attached_at").defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.projectId, table.fileId] }),
+    // Reverse lookup: "which projects reference this KC file?" —
+    // useful for detach-on-file-delete UIs and audit.
+    index("project_knowledge_files_file_idx").on(table.fileId),
+  ],
+);
+
 // Many-to-many link between `knowledge_files` and `teams` for the
 // `visibility = 'teams'` mode. Each row grants one team read access
 // to the file at chat / arena time. Empty link set === no team can

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -537,6 +537,55 @@ export const shortcuts = pgTable("shortcuts", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
+// In-app notification inbox. Mirrors the actionable subset of what
+// the mail service sends (team / org invitations) plus auto-emitted
+// info-only alerts (budget thresholds). Email stays as a parallel
+// channel for now — both fire so we don't drop invites for users
+// who never open the app.
+//
+// `type` is a loose-typed discriminator; `data` carries per-type
+// payload (e.g. team_invite has { teamId, teamName, inviterName,
+// invitationToken, memberId } so the FE can render Accept/Decline
+// without an extra round-trip). Keeping the schema generic means
+// future types (file_failed, guardrail_blocked, …) drop in without
+// migrations.
+//
+// `status` lifecycle:
+//   - 'pending'   : surfaced in the panel with action buttons live
+//   - 'acted'     : user accepted/declined (or the row is otherwise
+//                   resolved); keep the row visible for ~24h then
+//                   age out of the default list
+//   - 'dismissed' : user X'd the row, no action needed
+export const notifications = pgTable(
+  "notifications",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    type: text("type").notNull(),
+    title: text("title").notNull(),
+    body: text("body"),
+    data: jsonb("data").notNull().default({}),
+    status: text("status").notNull().default("pending"),
+    readAt: timestamp("read_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    // Default list query: pending + acted for this user, newest
+    // first. Covering for the common bell-popover fetch.
+    index("notifications_user_status_idx").on(
+      table.userId,
+      table.status,
+      table.createdAt,
+    ),
+    // Unread badge probe — partial would be tighter but a regular
+    // index on read_at suffices since the user_id filter narrows
+    // the scan first.
+    index("notifications_user_read_idx").on(table.userId, table.readAt),
+  ],
+);
+
 export const prompts = pgTable("prompts", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id")


### PR DESCRIPTION
## Povzetek

  Ta PR zaokroži več manjših in večjih iteracij na istem branch-u —
  nov in-app notification system, dva nova team-role tier-ja
  (admin + manager), duplicate-detection in teams-visibility za
  Knowledge Core, integracija Manage Context z Knowledge Core, ter
  kup UX polish-a po dashboard-u, sidebaru in notifications strani.

  ## In-app notifications

  Nov modul `apps/api/src/notifications` (service + controller +
  DTO) z `notifications` tabelo (discriminator `type`, JSONB
  `data` payload, status lifecycle `pending | acted | dismissed`).
  Vse notif so user-scoped, email kanal ostane vklopljen kot
  backup.

  **Pokriti event-i** (vsi auto-emit-ani iz obstoječih flow-ov,
  fire-and-forget — alert failure nikoli ne unwind-a parent
  mutation-a):

  - `team_invite` — Accept/Decline gumbi v vrstici, reuse-a
    obstoječ `acceptInviteByToken`.
  - `org_invite` — info-only za obstoječe userje s spremembo
    role-a.
  - `budget_alert` — 80 % in 100 % threshold crossings na team
    in org budget, idempotenten preko `data.thresholdKey`
    (`YYYY-MM:scope:id:%`). Trigger-i: chat-time pre-flight + admin
    budget update.
  - `budget_changed` — vsak actual change team / org budget-a
    (audit trail, brez dedup).
  - `team_renamed` — vsem accepted member-jem.
  - `team_role_changed` — affected user-ju.
  - `team_member_added` / `team_member_removed` / `team_deleted`
    — broadcast + direct notifs, recipient snapshot pred
    cascade-om.
  - `account_role_changed` / `account_budget_changed` /
    `member_cap_changed` — affected user-ju ob admin-driven
    patch-ih (self-edits silent).
  - `file_ingestion_failed` — uploader-ju, na obeh failure
    path-ih (`No extractable text` + catch).
  - `project_created` / `project_deleted` — team member-jem za
    team-scope projekte.
  - `guardrail_added` — `data.scope = 'team' | 'org'`: fan-out
    ali team member-jem (na new assign-u) ali vsem company
    user-jem (na false→true toggle-u `isOrgWide`).

  **FE**: Bell gumb v sidebaru z unread badge-em (poll 30 s),
  popover z inline Accept/Decline + auto mark-all-read na open,
  dedicated `/notifications` stran s filtri (All / Unread /
  Needs action) + Mark-all-read. Responsivna, dizajn poenoten z
  ostalimi stranmi (`rounded-[20px]` card surface).

  ## Team-role tiers

  - **Admin** — owner-equivalent rights (budget, invites, role
    promote/demote, integrations). Le owner ali drug admin
    lahko promote-a/demote-a admina.
  - **Manager** — paralelni owner-equivalent tier, semantically
    identičen admin-u; label distinkcija (admin = strateški,
    manager = operativni vodja).
  - **Basic user → team-scope projekte** — če ima owner / admin /
    manager / editor role v vsaj enem team-u, lahko ustvarja
    team-scope projekte (`canCreateProject` flag na
    `/auth/me`). Osebni projekti ostanejo gated na org-level
    admin/advanced.

  `getUserTeamRole` razširjen na `'owner' | 'admin' | 'manager' |
  'editor' | 'viewer' | null`. Nov `hasOwnerRights(role)` helper
  za owner-only path-e (team-budget, invitations, role
  promotions). Vse management gates (`updateTeam`, `deleteTeam`,
  `inviteMember`, `removeMember`, member-cap, integrations,
  subteam create, project create, guardrail assign) sprejmejo
  nove role.

  UI: "Team Admin" (oranžen) in "Team Manager" (zelen) badge
  poleg "Team Owner" (modri). Role select dropdown gated tako, da
  editor vidi admin/manager option-e samo kot read-only, ko je
  target že v tem tier-u.

  ## Knowledge Core — dedup + teams visibility

  - **Duplicate detection** — vsak upload se stream-a skozi
    SHA-256, BE preveri uploader-jevo KC za prior row s
    istim hash-em (across all folders). Match-i se skippajo
    (tmp file unlinkan) in surfacejo kot `duplicates: [...]`
    na FE-ju, ki pokaže toast z lokacijo obstoječe kopije.
    Onboarding tudi hashira fajle.
  - **'Teams' visibility** — tretja vrednost poleg `all` in
    `admins`. Nova `knowledge_file_teams` join tabela (file_id,
    team_id, composite PK, dual cascade). Upload dialog odprt
    za vse userje (`admins` ostane admin-only), z checkbox
    panelom team-ov za izbiro. RAG `searchAccessibleChunks`
    dobi četrti branch: `visibility = 'teams' AND EXISTS (...)`
    proti `team_members`.

  ## Manage Context ↔ Knowledge Core unification

  Prej je Manage Context na projektu pisal v lasten `documents`
  silos brez dedup-a, visibility-jev, ingestion-failure
  reporting-a ali cross-project reuse-a. Zdaj:

  - **Nova `project_knowledge_files` join tabela** (composite PK
    `(project_id, file_id)`, dual cascade) povezuje projekt z
    njegovimi KC fajli.
  - **Upload File tab** v Manage Context dialogu zdaj routir-a
    skozi `KnowledgeCoreService.uploadFiles` → fajl gre v KC
    (s tem podeduje dedup + ingestion + visibility validation),
    link row se auto-attacha na projekt. "Projects" KC mapa
    lazy-created per user kot default destination.
  - **Smart defaults** za upload picker iz BE-ja: team projekt
    → `visibility='teams'` z avto-izbiro tega team-a; personal
    projekt → `'all'`. User lahko v pickerju spremeni.
  - **From Knowledge Core tab** — nov picker obstoječih
    user-jevih KC fajlov (folder filter + search + multi-select
    checkbox) za attach.
  - **Paste Text tab** ostane nespremenjen — text snippets
    ostanejo project-scoped v legacy `documents` tabeli (so
    transient project context, ne "file" ki sodi v KC).
  - **Unified Documents list** v dnu dialoga: attached KC files
    + paste-text snippets, z origin / visibility / indexing
    badge-em. Delete za KC file je **detach** (file v KC
    ostane).
  - **Chat-time RAG** razširjen: poleg `documents.searchRelevant`
    in `searchAccessibleChunks`, dodaten `searchProjectAttachedChunks`
    povleče chunks iz attached KC fajlov, **bypass-a visibility
    scopes** — attachment je avtoritativni share za projekt.

  Legacy `documents` rows ostanejo netaknjene, novi upload-i
  grejo skozi KC. Brez backfill SQL-a, brez breaking change-a.

  ## Dashboard polish

  - **Recent Model Comparisons** wired na realne arena runs —
    `GET /compare-models/runs` zdaj vrne tudi `models: string[]`.
    3 najnovejši runs prikazani v responsive grid-u
    (1/2/3 cols glede na count) z derived 2-char model avatars
    (`anthropic/claude-3-opus` → "C3", `openai/gpt-4o` → "G4").
  - **Deep-link**: card linki na `/compare-models?run=<id>`.
    Page bere param na mount-u, hidriira composer + panele iz
    saved run-a in scrub-a param.
  - **Add Model dialog**: Custom name field zdaj auto-fillan
    z display imenom izbranega modela (namesto trdo-kodiranega
    "Model 1"). Touch-flag spoštuje ročno editirano vrednost.

  ## UX polish

  - **Tooltips** na bare info znakcih (Projected metric na
    company / user / team detail, Personal/Team toggle v
    project create).
  - **Footer** pinned na vsako authed stran (prej samo
    dashboard) z `mt-auto`, letnica posodobljena na 2026,
    razmak do roba viewporta zmanjšan iz 48 px na 16 px.
  - **Sidebar** Notifications zdaj poravnan flush-left kot
    ostali nav items (uporablja isti `Button` shape), razmak
    do dark-mode toggle-a tightened z `gap-3 → gap-1`, popover
    se odpre navzgor (`side="top"`).
  - **/notifications stran** dizajn poenoten z drugimi
    stranmi (`rounded-[20px]` white card, shadcn `Button`,
    responsive padding, filter pill-i, empty state z ikono).

  ## Schema migrations

  Nove tabele in stolpci. Backfill SQL-i (idempotent-ni) v
  `packages/database/backfill/`:

  - `add-knowledge-file-content-sha256.sql`
  - `add-knowledge-file-teams.sql`
  - `add-notifications.sql`
  - `add-project-knowledge-files.sql`

  `teamMembers.role` ostane `text` — `manager` se doda kot
  nova veljavna vrednost brez migration-a.

  ## Test plan

  - [x] Knowledge Core: upload istega fajla dvakrat → drugi se
        preskoči s toast-om, ki pokaže kje je prvi.
  - [x] KC: upload z visibility='teams' + checkbox panel → RAG
        vrne fajl samo team member-jem, ne drugim.
  - [x] Team detail: kot owner promote editor v admin → Team
        Admin badge, editor ne more več demote-ati.
  - [x] Team detail: kot owner promote v manager → Team Manager
        badge, same rights.
  - [x] Basic org-user, ki je editor v team-u → "Create
        project" gumb se prikaže, team-scope project create
        uspe.
  - [x] Bell badge se prikaže ob team invite, click → popover
        z Accept/Decline; Accept flipne membership.
  - [ ] Team budget na 0.05$, klici prek 0.04$ → owner/admin/
        manager-ji dobijo 80 % alert, drugi klic spam ne
        dvoji.
  - [ ] Admin spremeni team budget mid-month tako, da spend
        preseže 80 % → notif takoj.
  - [ ] Admin preimenuje team → vsi člani dobijo `team_renamed`.
  - [ ] Removed user dobi direct notif, ostali team-mates
        broadcast.
  - [ ] Failed ingestion (corrupt or image-only file) → uploader
        dobi `file_ingestion_failed`.
  - [ ] Click dashboard Recent Comparison card → routes to
        `/compare-models?run=...`, run loaded, history rail
        odprt.
  - [ ] Add Model dialog: izberi model → Custom name se
        auto-filla.
  - [ ] Manage Context na team projektu: Upload File pickerja
        ima `Teams` visibility + project's team pre-selected,
        upload uspe in fajl se pojavi v KC + v Documents list-u
        z `KC` badge-em.
  - [ ] Manage Context: From Knowledge Core tab → picker
        pokaže fajle iz izbrane mape, multi-select + Attach
        → fajli se prikažejo v Documents list-u.
  - [ ] Detach KC fajl iz projekta → odstrani se iz list-a,
        ampak ostane v Knowledge Core.
  - [ ] Chat v projektu z attached KC fajli → odgovor
        uporablja kontekst iz teh fajlov (RAG pull deluje
        regardless of file visibility, ker je attached).
