### PR TITLE
Team integrations refactor, knowledge core conflict resolution, observability + UX polish

### DIFF
--- a/apps/api/src/integrations/chat-transport.service.ts
+++ b/apps/api/src/integrations/chat-transport.service.ts
@@ -6,6 +6,7 @@ import {
   observabilityEvents,
   orgSettings,
   projects,
+  teamIntegrationLinks,
   teamMembers,
   teams,
   users,
@@ -302,21 +303,38 @@ export class ChatTransportService {
 
       if (teamScopeId) {
         // Predefined providers only — apiUrl IS NULL filter mirrors
-        // the partial unique index that backs the table for team-
-        // scoped BYOK. Custom LLMs aren't supported at team scope yet.
+        // the partial unique index that backs personal predef rows.
+        // We resolve through team_integration_links (the new picker
+        // model): the admin's personal key is linked into the team
+        // and members get to use it via the link. Both the link's
+        // is_enabled (per-team pause) and the underlying
+        // integration's is_enabled (master switch on the personal
+        // tab) must be true; either flag off and we fall through to
+        // the user's own BYOK.
         const [teamByok] = await this.db
-          .select()
-          .from(integrations)
+          .select({
+            apiKeyEncrypted: integrations.apiKeyEncrypted,
+          })
+          .from(teamIntegrationLinks)
+          .innerJoin(
+            integrations,
+            eq(integrations.id, teamIntegrationLinks.integrationId),
+          )
           .where(
             and(
-              eq(integrations.teamId, teamScopeId),
+              eq(teamIntegrationLinks.teamId, teamScopeId),
+              eq(teamIntegrationLinks.isEnabled, true),
               eq(integrations.providerId, provider),
               eq(integrations.isEnabled, true),
               isNull(integrations.apiUrl),
             ),
           )
           .limit(1);
-        if (teamByok?.apiKeyEncrypted) byokRow = teamByok;
+        if (teamByok?.apiKeyEncrypted) {
+          byokRow = {
+            apiKeyEncrypted: teamByok.apiKeyEncrypted,
+          } as typeof integrations.$inferSelect;
+        }
       }
 
       if (!byokRow) {

--- a/apps/api/src/knowledge-core/knowledge-core.controller.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.controller.ts
@@ -19,7 +19,10 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { CurrentUser } from '../auth/current-user.decorator.js';
 import type { AuthenticatedUser } from '../auth/types.js';
-import { KnowledgeCoreService } from './knowledge-core.service.js';
+import {
+  KnowledgeCoreService,
+  type NameConflictAction,
+} from './knowledge-core.service.js';
 
 const UPLOAD_DIR = path.join(process.cwd(), 'uploads', 'knowledge-core');
 fs.mkdirSync(UPLOAD_DIR, { recursive: true });
@@ -110,11 +113,19 @@ export class KnowledgeCoreController {
     // ("teamIds=a" vs. multiple `teamIds=a&teamIds=b` appends).
     // Normalize before passing on so the service only deals with
     // `string[]`.
+    //
+    // `nameConflictActions` is JSON-encoded by the FE — multipart
+    // can't transport an object natively, so the FE stringifies and
+    // the controller parses. Malformed JSON is silently dropped so a
+    // garbage value doesn't blow up the upload; the service then
+    // treats every name conflict as 'skip', i.e. surfaces it back
+    // for the user to resolve.
     @Body()
     body: {
       visibility?: string;
       teamIds?: string | string[];
       projectIds?: string | string[];
+      nameConflictActions?: string;
     },
   ) {
     const teamIds = Array.isArray(body?.teamIds)
@@ -127,6 +138,30 @@ export class KnowledgeCoreController {
       : body?.projectIds
         ? [body.projectIds]
         : [];
+    let nameConflictActions: Record<string, NameConflictAction> | undefined;
+    if (body?.nameConflictActions) {
+      try {
+        const parsed: unknown = JSON.parse(body.nameConflictActions);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          nameConflictActions = {};
+          for (const [key, value] of Object.entries(
+            parsed as Record<string, unknown>,
+          )) {
+            if (
+              typeof key === 'string' &&
+              (value === 'overwrite' ||
+                value === 'keep_both' ||
+                value === 'skip')
+            ) {
+              nameConflictActions[key] = value;
+            }
+          }
+        }
+      } catch {
+        // Fall through — undefined means service treats every name
+        // conflict as 'skip' and bounces them back to the user.
+      }
+    }
     return this.service.uploadFiles(
       folderId,
       user.id,
@@ -134,6 +169,7 @@ export class KnowledgeCoreController {
       body?.visibility,
       teamIds,
       projectIds,
+      nameConflictActions,
     );
   }
 

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -40,6 +40,28 @@ export async function sha256File(filePath: string): Promise<string> {
   return hash.digest('hex');
 }
 
+/**
+ * Pick the next free "<base> (N).<ext>" slot when the user resolves a
+ * same-name conflict with "keep both". Starts at N=2 (Google-Drive-
+ * style: "report.pdf" → "report (2).pdf"). The `used` set is mutated
+ * by the caller across the batch so two "keep_both"s of the same name
+ * don't both pick (2).
+ */
+function pickNextAvailableName(name: string, used: Set<string>): string {
+  const ext = path.extname(name);
+  const base = path.basename(name, ext);
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${base} (${n})${ext}`;
+    if (!used.has(candidate)) return candidate;
+  }
+  // Pathological — 1000 collisions on the exact same base. Fall back
+  // to a timestamp suffix; the row still goes in and the user can
+  // rename it later. Better than throwing.
+  return `${base} (${Date.now()})${ext}`;
+}
+
+export type NameConflictAction = 'overwrite' | 'keep_both' | 'skip';
+
 @Injectable()
 export class KnowledgeCoreService {
   constructor(
@@ -234,6 +256,14 @@ export class KnowledgeCoreService {
     visibilityInput?: string,
     teamIdsInput?: string[],
     projectIdsInput?: string[],
+    // Per-name decision the FE collected from the user after a
+    // previous call surfaced same-name-different-content conflicts in
+    // this folder. Keys are the original filenames the FE re-uploads;
+    // values pick what to do with the prior row. Missing / unknown
+    // entries fall back to 'skip' so the worst case is a soft no-op,
+    // not a silent overwrite. See the name-conflict block below for
+    // the actions' semantics.
+    nameConflictActions?: Record<string, NameConflictAction>,
   ) {
     const [folder] = await this.db
       .select()
@@ -409,12 +439,131 @@ export class KnowledgeCoreService {
       );
     }
 
-    const values = toInsert.map(({ file, hash }) => {
+    // Name-conflict resolution layer. Sits *after* content dedupe so
+    // a same-name-AND-same-bytes upload is still treated as a real
+    // duplicate (no point asking the user about it). What lands here
+    // is only "same name in this folder, different bytes" — the
+    // common case where the user is uploading a new version of a
+    // doc they already have.
+    //
+    // Three actions are supported via `nameConflictActions`:
+    //   - 'overwrite'  — nuke the prior row + chunks + disk file and
+    //                     let the new bytes take the original name.
+    //   - 'keep_both'  — rename the new row to "<base> (N).<ext>"
+    //                     ("report.pdf" → "report (2).pdf").
+    //   - 'skip' / missing — return the conflict back to the FE so
+    //                     the user can pick explicitly. The tmp disk
+    //                     file is unlinked here; the new bytes never
+    //                     enter the DB on this call.
+    //
+    // The first call from the FE generally has no actions map and
+    // serves as the "discover conflicts" pass; the FE then surfaces
+    // a resolution dialog and re-uploads with the chosen actions.
+    const candidateNames = Array.from(
+      new Set(toInsert.map((entry) => entry.file.originalname)),
+    );
+    const nameRows = candidateNames.length
+      ? await this.db
+          .select({
+            id: knowledgeFiles.id,
+            name: knowledgeFiles.name,
+            storagePath: knowledgeFiles.storagePath,
+          })
+          .from(knowledgeFiles)
+          .where(
+            and(
+              eq(knowledgeFiles.uploadedById, userId),
+              eq(knowledgeFiles.folderId, folderId),
+              inArray(knowledgeFiles.name, candidateNames),
+            ),
+          )
+      : [];
+    const existingByName = new Map<
+      string,
+      { id: string; storagePath: string | null }
+    >();
+    for (const row of nameRows) {
+      // Defensive: a folder can in principle hold multiple rows with
+      // the same name (no DB-level unique constraint), so keep the
+      // first match deterministically. Overwriting still only nukes
+      // that one row — the user can resolve any orphan dups later.
+      if (existingByName.has(row.name)) continue;
+      existingByName.set(row.name, {
+        id: row.id,
+        storagePath: row.storagePath,
+      });
+    }
+
+    // Lazy: only loaded when at least one 'keep_both' action fires
+    // (most batches won't touch this code path). Mutated as we pick
+    // names so two "keep_both"s of "report.pdf" in the same batch
+    // can't both pick "report (2).pdf".
+    let usedNamesInFolder: Set<string> | null = null;
+    const loadUsedNames = async () => {
+      if (usedNamesInFolder) return usedNamesInFolder;
+      const rows = await this.db
+        .select({ name: knowledgeFiles.name })
+        .from(knowledgeFiles)
+        .where(eq(knowledgeFiles.folderId, folderId));
+      usedNamesInFolder = new Set(rows.map((r) => r.name));
+      return usedNamesInFolder;
+    };
+
+    const nameConflicts: Array<{
+      name: string;
+      existing: { id: string };
+    }> = [];
+    const toInsertResolved: Array<{
+      file: Express.Multer.File;
+      hash: string;
+      finalName: string;
+    }> = [];
+    for (const entry of toInsert) {
+      const name = entry.file.originalname;
+      const conflict = existingByName.get(name);
+      if (!conflict) {
+        toInsertResolved.push({ ...entry, finalName: name });
+        continue;
+      }
+      const action = nameConflictActions?.[name] ?? 'skip';
+      if (action === 'overwrite') {
+        await this.deleteFileRowAndAssets(
+          conflict.id,
+          conflict.storagePath,
+        );
+        // Also drop the cached name set entry if a prior 'keep_both'
+        // already loaded it — the overwrite freed the slot in case a
+        // later 'keep_both' in this same batch wants to reuse the
+        // base name. Cheap and defensive. Copy to a const ref so
+        // TS's narrowing of the closure-mutated outer let doesn't
+        // collapse the value to `never` here.
+        const cache = usedNamesInFolder as Set<string> | null;
+        if (cache) cache.delete(name);
+        toInsertResolved.push({ ...entry, finalName: name });
+        continue;
+      }
+      if (action === 'keep_both') {
+        const used = await loadUsedNames();
+        for (const r of toInsertResolved) used.add(r.finalName);
+        const finalName = pickNextAvailableName(name, used);
+        used.add(finalName);
+        toInsertResolved.push({ ...entry, finalName });
+        continue;
+      }
+      // 'skip' (or any unrecognized value): surface the conflict to
+      // the FE and clean up the tmp file so we don't leak disk.
+      nameConflicts.push({ name, existing: { id: conflict.id } });
+      if (entry.file.path) {
+        fs.promises.unlink(entry.file.path).catch(() => {});
+      }
+    }
+
+    const values = toInsertResolved.map(({ file, hash, finalName }) => {
       const ext = path.extname(file.originalname).replace('.', '').toUpperCase();
       const fileType = ext || 'FILE';
       return {
         folderId,
-        name: file.originalname,
+        name: finalName,
         fileType,
         sizeBytes: file.size,
         storagePath: path.posix.join(
@@ -495,15 +644,49 @@ export class KnowledgeCoreService {
       // hydrates `teams: [{id,name}]` via hydrateTeamLinks. Adding
       // an ad-hoc `teamIds` here would break that contract for no
       // benefit.
-      return { uploaded: inserted, duplicates };
+      return { uploaded: inserted, duplicates, nameConflicts };
     } catch (error) {
       await Promise.allSettled(
-        toInsert
+        toInsertResolved
           .filter((entry) => entry.file.path)
           .map((entry) => fs.promises.unlink(entry.file.path)),
       );
       throw error;
     }
+  }
+
+  /**
+   * Atomic teardown for a knowledge file: disk copy → chunks → team
+   * links → project attachments → file row. Shared by the regular
+   * delete path and by the upload-time 'overwrite' resolution so
+   * the two stay byte-for-byte aligned (any future cascade rule
+   * lands in one place). Best-effort on the disk unlink — a leftover
+   * tmp file is harmless, but a DB row left behind would resurrect
+   * deleted embeddings the next time the worker scans.
+   */
+  private async deleteFileRowAndAssets(
+    fileId: string,
+    storagePath: string | null,
+  ) {
+    if (storagePath) {
+      try {
+        await fs.promises.unlink(path.resolve(process.cwd(), storagePath));
+      } catch {
+        // File may already be removed from disk
+      }
+    }
+    await this.db.transaction(async (tx) => {
+      await tx
+        .delete(knowledgeChunks)
+        .where(eq(knowledgeChunks.fileId, fileId));
+      await tx
+        .delete(knowledgeFileTeams)
+        .where(eq(knowledgeFileTeams.fileId, fileId));
+      await tx
+        .delete(projectKnowledgeFiles)
+        .where(eq(projectKnowledgeFiles.fileId, fileId));
+      await tx.delete(knowledgeFiles).where(eq(knowledgeFiles.id, fileId));
+    });
   }
 
   /**
@@ -1261,32 +1444,10 @@ export class KnowledgeCoreService {
     if (!file) throw new NotFoundException('File not found');
     if (file.ownerId !== userId) throw new ForbiddenException('Access denied');
 
-    if (file.storagePath) {
-      try {
-        await fs.promises.unlink(path.resolve(process.cwd(), file.storagePath));
-      } catch {
-        // File may already be removed from disk
-      }
-    }
-
-    // Defense-in-depth: clear child rows explicitly inside a
-    // transaction before deleting the file. FK cascade should handle
-    // this, but explicit deletes guarantee chat-time RAG no longer
-    // surfaces this file even if the live DB lost the CASCADE rule.
-    // Order: chunks (RAG embeddings) → team links → project
-    // attachments → the file row itself.
-    await this.db.transaction(async (tx) => {
-      await tx
-        .delete(knowledgeChunks)
-        .where(eq(knowledgeChunks.fileId, fileId));
-      await tx
-        .delete(knowledgeFileTeams)
-        .where(eq(knowledgeFileTeams.fileId, fileId));
-      await tx
-        .delete(projectKnowledgeFiles)
-        .where(eq(projectKnowledgeFiles.fileId, fileId));
-      await tx.delete(knowledgeFiles).where(eq(knowledgeFiles.id, fileId));
-    });
+    // Disk + chunks + team links + project attachments + file row.
+    // Shared with the upload-time 'overwrite' path so any future
+    // cascade rule lands in one place.
+    await this.deleteFileRowAndAssets(fileId, file.storagePath);
 
     await this.db
       .update(knowledgeFolders)

--- a/apps/api/src/knowledge-core/knowledge-core.service.ts
+++ b/apps/api/src/knowledge-core/knowledge-core.service.ts
@@ -124,7 +124,7 @@ export class KnowledgeCoreService {
         uploadedById: knowledgeFiles.uploadedById,
         uploadedByName: users.name,
         // Surface ingestion status so the FE can render the per-file
-        // training badge without a second round-trip.
+        // context-availability badge without a second round-trip.
         ingestionStatus: knowledgeFiles.ingestionStatus,
         ingestionError: knowledgeFiles.ingestionError,
         // Surfaced so the row UI can render the 'Admin only' badge
@@ -959,7 +959,7 @@ export class KnowledgeCoreService {
     }
     if (file.ingestionStatus === 'processing') {
       throw new BadRequestException(
-        'This file is already being trained. Try again once the current run finishes.',
+        'This file is already being added to context. Try again once the current run finishes.',
       );
     }
 
@@ -1027,7 +1027,7 @@ export class KnowledgeCoreService {
     }
     if (file.ingestionStatus === 'processing') {
       throw new BadRequestException(
-        'This file is being trained right now. Try again once the current run finishes.',
+        'This file is being added to context right now. Try again once the current run finishes.',
       );
     }
 
@@ -1125,7 +1125,7 @@ export class KnowledgeCoreService {
     // same guard reingestFile uses; the admin retries in a second.
     if (file.ingestionStatus === 'processing') {
       throw new BadRequestException(
-        'This file is being trained right now. Try again once the current run finishes.',
+        'This file is being added to context right now. Try again once the current run finishes.',
       );
     }
 

--- a/apps/api/src/models/models.service.ts
+++ b/apps/api/src/models/models.service.ts
@@ -9,6 +9,7 @@ import {
   enabledModels,
   integrations,
   modelConfigs,
+  teamIntegrationLinks,
   teamMembers,
   teams,
   users,
@@ -240,14 +241,25 @@ export class ModelsService {
           eq(integrations.isEnabled, true),
         ),
       );
+    // Team enabled providers come through the link table now: an
+    // admin's personal integration linked to one of the caller's
+    // teams counts only if both the link's is_enabled and the
+    // integration's is_enabled are true. Mirrors the chat-transport
+    // BYOK lookup so this surface stays in sync with what chat
+    // would actually use at request time.
     const teamEnabledRows =
       teamIds.length > 0
         ? await this.db
             .select({ providerId: integrations.providerId })
-            .from(integrations)
+            .from(teamIntegrationLinks)
+            .innerJoin(
+              integrations,
+              eq(integrations.id, teamIntegrationLinks.integrationId),
+            )
             .where(
               and(
-                inArray(integrations.teamId, teamIds),
+                inArray(teamIntegrationLinks.teamId, teamIds),
+                eq(teamIntegrationLinks.isEnabled, true),
                 eq(integrations.isEnabled, true),
               ),
             )

--- a/apps/api/src/observability/observability.controller.ts
+++ b/apps/api/src/observability/observability.controller.ts
@@ -164,6 +164,39 @@ export class ObservabilityController {
     return { range: key, ...result };
   }
 
+  /**
+   * Un-paginated variant of `/events` used by the CSV export. Same
+   * filter contract as the paginated route, minus page/pageSize —
+   * the service caps the result at 10k rows and the response carries
+   * a `truncated` flag the FE surfaces as a toast when the cap was
+   * hit. Kept separate from `/events` so the table fetch can't
+   * accidentally request a huge unpaginated payload by passing a
+   * gigantic `pageSize`.
+   */
+  @Get('events/export')
+  async exportEvents(
+    @CurrentUser() caller: AuthenticatedUser,
+    @Query('range') range?: string,
+    @Query('search') search?: string,
+    @Query('user') userId?: string,
+    @Query('team') teamId?: string,
+    @Query('model') model?: string,
+    @Query('eventType') eventType?: string,
+  ) {
+    await this.assertAdmin(caller);
+    const { key, from, to } = parseRange(range);
+    const result = await this.observabilityService.exportEvents({
+      from,
+      to,
+      search: search ?? null,
+      userId: userId ?? null,
+      teamId: teamId ?? null,
+      model: model ?? null,
+      eventType: eventType ?? null,
+    });
+    return { range: key, ...result };
+  }
+
   @Get('guardrail-activity')
   async guardrailActivity(
     @CurrentUser() caller: AuthenticatedUser,

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -250,7 +250,13 @@ export class ObservabilityService {
     }));
   }
 
-  async listEvents(opts: {
+  /**
+   * Shared WHERE-clause builder for the events table. Extracted so the
+   * paginated table view (`listEvents`) and the CSV export
+   * (`exportEvents`) stay byte-for-byte aligned on filtering — adding
+   * a new filter only needs to land in one place.
+   */
+  private buildEventsWhere(opts: {
     from: Date;
     to: Date;
     search?: string | null;
@@ -258,8 +264,6 @@ export class ObservabilityService {
     teamId?: string | null;
     model?: string | null;
     eventType?: string | null;
-    page: number;
-    pageSize: number;
   }) {
     const conditions = [
       gte(observabilityEvents.createdAt, opts.from),
@@ -280,8 +284,21 @@ export class ObservabilityService {
       );
       if (searchClause) conditions.push(searchClause);
     }
+    return and(...conditions);
+  }
 
-    const where = and(...conditions);
+  async listEvents(opts: {
+    from: Date;
+    to: Date;
+    search?: string | null;
+    userId?: string | null;
+    teamId?: string | null;
+    model?: string | null;
+    eventType?: string | null;
+    page: number;
+    pageSize: number;
+  }) {
+    const where = this.buildEventsWhere(opts);
     const limit = Math.max(1, Math.min(opts.pageSize, 200));
     const offset = Math.max(0, (opts.page - 1) * limit);
 
@@ -322,6 +339,69 @@ export class ObservabilityService {
       total: Number(total ?? 0),
       page: opts.page,
       pageSize: limit,
+      events: rows.map((r) => ({
+        ...r,
+        costUsd: r.costUsd === null ? null : Number(r.costUsd),
+      })),
+    };
+  }
+
+  /**
+   * Un-paginated event fetch used by the CSV export path. Same shape
+   * + same WHERE as `listEvents`, just no `limit`/`offset` pagination
+   * — instead we cap at `MAX_EXPORT_ROWS` so a careless export over a
+   * wide range can't OOM the server. The FE shows a toast warning if
+   * the cap was hit so the admin knows they need to narrow the
+   * filter before re-exporting.
+   */
+  async exportEvents(opts: {
+    from: Date;
+    to: Date;
+    search?: string | null;
+    userId?: string | null;
+    teamId?: string | null;
+    model?: string | null;
+    eventType?: string | null;
+  }) {
+    const MAX_EXPORT_ROWS = 10_000;
+    const where = this.buildEventsWhere(opts);
+
+    const [{ total }] = await this.db
+      .select({ total: sql<number>`count(*)::int` })
+      .from(observabilityEvents)
+      .leftJoin(users, eq(users.id, observabilityEvents.userId))
+      .where(where);
+
+    const rows = await this.db
+      .select({
+        id: observabilityEvents.id,
+        createdAt: observabilityEvents.createdAt,
+        eventType: observabilityEvents.eventType,
+        model: observabilityEvents.model,
+        provider: observabilityEvents.provider,
+        totalTokens: observabilityEvents.totalTokens,
+        costUsd: sql<string>`${observabilityEvents.costUsd}::text`,
+        latencyMs: observabilityEvents.latencyMs,
+        success: observabilityEvents.success,
+        errorMessage: observabilityEvents.errorMessage,
+        promptPreview: observabilityEvents.promptPreview,
+        userId: observabilityEvents.userId,
+        userName: users.name,
+        userEmail: users.email,
+        teamId: observabilityEvents.teamId,
+        teamName: teams.name,
+      })
+      .from(observabilityEvents)
+      .leftJoin(users, eq(users.id, observabilityEvents.userId))
+      .leftJoin(teams, eq(teams.id, observabilityEvents.teamId))
+      .where(where)
+      .orderBy(desc(observabilityEvents.createdAt))
+      .limit(MAX_EXPORT_ROWS);
+
+    return {
+      total: Number(total ?? 0),
+      truncated: Number(total ?? 0) > MAX_EXPORT_ROWS,
+      maxRows: MAX_EXPORT_ROWS,
       events: rows.map((r) => ({
         ...r,
         costUsd: r.costUsd === null ? null : Number(r.costUsd),

--- a/apps/api/src/onboarding/onboarding.controller.ts
+++ b/apps/api/src/onboarding/onboarding.controller.ts
@@ -56,7 +56,7 @@ export class OnboardingController {
   }
 
   /**
-   * Drives the step-6 "Training your AI…" progress screen. The FE
+   * Drives the step-6 "Setting up your AI…" progress screen. The FE
    * polls this until `inProgress` is false, then redirects.
    * Cheap query (single SELECT with COUNT-by-status server-side
    * folding), so polling at 1-2s cadence is fine.

--- a/apps/api/src/projects/project-knowledge.service.ts
+++ b/apps/api/src/projects/project-knowledge.service.ts
@@ -243,6 +243,10 @@ export class ProjectKnowledgeService {
       visibility?: string;
       teamIds?: string[];
       projectIds?: string[];
+      nameConflictActions?: Record<
+        string,
+        'overwrite' | 'keep_both' | 'skip'
+      >;
     },
   ): Promise<{
     uploaded: Array<{ id: string; name: string; ingestionStatus: string }>;
@@ -250,6 +254,7 @@ export class ProjectKnowledgeService {
       name: string;
       existing: { id: string | null; name: string; folderId: string; folderName: string };
     }>;
+    nameConflicts: Array<{ name: string; existing: { id: string } }>;
   }> {
     await this.assertProjectAccess(projectId, callerId);
     if (files.length === 0) {
@@ -267,6 +272,7 @@ export class ProjectKnowledgeService {
       options.visibility,
       options.teamIds,
       options.projectIds,
+      options.nameConflictActions,
     );
 
     // Auto-attach every successful upload to this project. The
@@ -300,6 +306,7 @@ export class ProjectKnowledgeService {
         ingestionStatus: u.ingestionStatus,
       })),
       duplicates: result.duplicates,
+      nameConflicts: result.nameConflicts,
     };
   }
 

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -162,6 +162,10 @@ export class ProjectsController {
       visibility?: string;
       teamIds?: string | string[];
       projectIds?: string | string[];
+      // JSON-encoded `{ [filename]: 'overwrite' | 'keep_both' |
+      // 'skip' }`. See `knowledge-core.controller.uploadFiles` for
+      // the format — same parsing rules apply here.
+      nameConflictActions?: string;
     },
     @CurrentUser() user: AuthenticatedUser,
   ) {
@@ -175,11 +179,38 @@ export class ProjectsController {
       : body?.projectIds
         ? [body.projectIds]
         : [];
+    let nameConflictActions:
+      | Record<string, 'overwrite' | 'keep_both' | 'skip'>
+      | undefined;
+    if (body?.nameConflictActions) {
+      try {
+        const parsed: unknown = JSON.parse(body.nameConflictActions);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          nameConflictActions = {};
+          for (const [key, value] of Object.entries(
+            parsed as Record<string, unknown>,
+          )) {
+            if (
+              typeof key === 'string' &&
+              (value === 'overwrite' ||
+                value === 'keep_both' ||
+                value === 'skip')
+            ) {
+              nameConflictActions[key] = value;
+            }
+          }
+        }
+      } catch {
+        // Malformed JSON → undefined → BE treats every name
+        // conflict as 'skip' and bounces them back to the FE.
+      }
+    }
     return this.projectKnowledge.uploadAndAttach(id, user.id, files, {
       folderId: body?.folderId,
       visibility: body?.visibility,
       teamIds,
       projectIds,
+      nameConflictActions,
     });
   }
 }

--- a/apps/api/src/teams/teams.controller.ts
+++ b/apps/api/src/teams/teams.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Put,
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { users } from '@worken/database/schema';
@@ -181,57 +182,67 @@ export class TeamsController {
     return this.teamsService.findGuardrails(id);
   }
 
-  // Team-scoped BYOK integrations. Mirrors POST/PATCH/DELETE on
-  // /integrations but everything lands on a single team-shared row
-  // (one per provider per team), so when any member chats with that
-  // provider the call uses this key first.
-  @Get(':id/integrations')
-  listIntegrations(
+  // ─── Integration links (picker model) ──────────────────────────
+  //
+  // Replaces the legacy team-scoped /integrations endpoints above:
+  // instead of pushing the encrypted key into a separate row per
+  // team, admins configure their key once on /teams?tab=integration
+  // and link it into one or more teams via these endpoints. The old
+  // routes stay during the FE migration but no longer receive new
+  // writes from the picker.
+
+  @Get(':id/integration-links')
+  listIntegrationLinks(
     @Param('id') id: string,
     @CurrentUser() user: AuthenticatedUser,
   ) {
-    return this.teamsService.listIntegrations(id, user.id);
+    return this.teamsService.listIntegrationLinks(id, user.id);
   }
 
-  @Post(':id/integrations')
-  upsertIntegration(
+  // Caller's personal integrations + which are already linked. Drives
+  // the picker UI on team-details — split from `integration-links` so
+  // the read for the picker doesn't need to join in linkage state
+  // that's already on the linked list.
+  @Get(':id/integration-links/linkable')
+  listLinkableIntegrations(
     @Param('id') id: string,
-    @Body()
-    body: {
-      providerId: string;
-      apiKey?: string | null;
-      isEnabled?: boolean;
-    },
     @CurrentUser() user: AuthenticatedUser,
   ) {
-    if (typeof body?.providerId !== 'string' || !body.providerId.trim()) {
-      throw new BadRequestException('`providerId` is required');
+    return this.teamsService.listLinkableIntegrations(id, user.id);
+  }
+
+  @Put(':id/integration-links')
+  setIntegrationLinks(
+    @Param('id') id: string,
+    @Body() body: { integrationIds?: string[] },
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    if (!Array.isArray(body?.integrationIds)) {
+      throw new BadRequestException('`integrationIds` must be an array.');
     }
-    return this.teamsService.upsertIntegration(id, user.id, body);
-  }
-
-  @Patch(':id/integrations/:integrationId')
-  updateIntegration(
-    @Param('id') id: string,
-    @Param('integrationId', new ParseUUIDPipe()) integrationId: string,
-    @Body() body: { isEnabled?: boolean; apiKey?: string | null },
-    @CurrentUser() user: AuthenticatedUser,
-  ) {
-    return this.teamsService.updateIntegration(
+    return this.teamsService.setIntegrationLinks(
       id,
       user.id,
-      integrationId,
-      body,
+      body.integrationIds,
     );
   }
 
-  @Delete(':id/integrations/:integrationId')
-  removeIntegration(
+  @Patch(':id/integration-links/:integrationId')
+  setIntegrationLinkEnabled(
     @Param('id') id: string,
     @Param('integrationId', new ParseUUIDPipe()) integrationId: string,
+    @Body() body: { isEnabled?: boolean },
     @CurrentUser() user: AuthenticatedUser,
   ) {
-    return this.teamsService.removeIntegration(id, user.id, integrationId);
+    if (typeof body?.isEnabled !== 'boolean') {
+      throw new BadRequestException('`isEnabled` must be a boolean.');
+    }
+    return this.teamsService.setIntegrationLinkEnabled(
+      id,
+      user.id,
+      integrationId,
+      body.isEnabled,
+    );
   }
 
   // Per-member monthly cap. Body accepts a number (cents) or null to

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -2153,6 +2153,13 @@ export class TeamsService {
           // (if any survived the backfill) are intentionally invisible
           // so they age out of the UX entirely.
           sql`${integrations.teamId} IS NULL`,
+          // Only integrations the user actually has active on their
+          // Integration tab can be linked from here. A disabled key
+          // can't be picked anyway (it'd be a no-op at chat time), so
+          // showing it just clutters the team picker. To manage a
+          // disabled key, the admin re-enables it on the Integration
+          // tab first.
+          eq(integrations.isEnabled, true),
         ),
       );
 

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -24,17 +24,14 @@ import {
   integrations,
   modelConfigs,
   observabilityEvents,
+  teamIntegrationLinks,
 } from '@worken/database/schema';
 import { DATABASE, type Database } from '../database/database.module.js';
 import { MailService } from '../mail/mail.service.js';
 import { NotificationsService } from '../notifications/notifications.service.js';
 import { EncryptionService } from '../openrouter/encryption.service.js';
 import { OpenRouterProvisioningService } from '../openrouter/openrouter-provisioning.service.js';
-import {
-  PREDEFINED_PROVIDERS,
-  isPredefinedProvider,
-} from '../integrations/predefined-providers.js';
-import type { IntegrationView } from '../integrations/integrations.service.js';
+import { PREDEFINED_PROVIDERS } from '../integrations/predefined-providers.js';
 
 @Injectable()
 export class TeamsService {
@@ -1854,496 +1851,6 @@ export class TeamsService {
     ];
   }
 
-  /**
-   * Team-scoped integrations. Mirrors the personal Integration tab
-   * but the configured key is shared across every team member: when
-   * one of them chats with a model from this provider, chat-transport
-   * routes through this team key first, before falling back to their
-   * personal BYOK or the WorkenAI default.
-   *
-   * Returns both:
-   *   - Predefined providers (Anthropic, OpenAI, …) — at most one row
-   *     per (team, provider). Untouched providers appear with id=null.
-   *   - Team-scoped Custom LLM rows — each is its own card; the bound
-   *     model_configs alias is auto-created at upsert time so members
-   *     see the endpoint in their picker without admin touching
-   *     /catalog separately.
-   */
-  async listIntegrations(
-    teamId: string,
-    userId: string,
-  ): Promise<IntegrationView[]> {
-    const role = await this.getUserTeamRole(teamId, userId);
-    if (!role) {
-      throw new ForbiddenException('You are not a member of this team');
-    }
-
-    const rows = await this.db
-      .select()
-      .from(integrations)
-      .where(eq(integrations.teamId, teamId));
-
-    // Aggregate observability scoped to this team. Same shape as
-    // IntegrationsService.listForUser but the filter is teamId rather
-    // than userId, so cards reflect what the *whole team* spent
-    // through that provider — not whoever last opened the page.
-    const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    const statsRows = await this.db
-      .select({
-        provider: observabilityEvents.provider,
-        successCount: sql<number>`count(*) filter (where ${observabilityEvents.success}=true)::int`,
-        totalCount: sql<number>`count(*)::int`,
-        thisMonth: sql<number>`count(*) filter (where ${observabilityEvents.createdAt} >= date_trunc('month', now()))::int`,
-      })
-      .from(observabilityEvents)
-      .where(
-        and(
-          eq(observabilityEvents.teamId, teamId),
-          gte(observabilityEvents.createdAt, since),
-        ),
-      )
-      .groupBy(observabilityEvents.provider);
-
-    const peakRows = await this.db.execute<{
-      provider: string;
-      peak: number;
-    }>(sql`
-      SELECT provider, MAX(daily_count)::int AS peak
-      FROM (
-        SELECT
-          ${observabilityEvents.provider} AS provider,
-          DATE_TRUNC('day', ${observabilityEvents.createdAt}) AS day,
-          COUNT(*) AS daily_count
-        FROM ${observabilityEvents}
-        WHERE
-          ${observabilityEvents.teamId} = ${teamId}
-          AND ${observabilityEvents.createdAt} >= ${since}
-          AND ${observabilityEvents.provider} IS NOT NULL
-        GROUP BY provider, day
-      ) AS daily
-      GROUP BY provider
-    `);
-
-    const statsByProvider = new Map<
-      string,
-      {
-        successCount: number;
-        totalCount: number;
-        thisMonth: number;
-        peakDaily: number;
-      }
-    >();
-    for (const r of statsRows) {
-      if (!r.provider) continue;
-      statsByProvider.set(r.provider, {
-        successCount: Number(r.successCount ?? 0),
-        totalCount: Number(r.totalCount ?? 0),
-        thisMonth: Number(r.thisMonth ?? 0),
-        peakDaily: 0,
-      });
-    }
-    const peakRowList =
-      (peakRows as { rows?: unknown[] }).rows ?? peakRows;
-    if (Array.isArray(peakRowList)) {
-      for (const r of peakRowList as {
-        provider: string;
-        peak: number;
-      }[]) {
-        if (!r.provider) continue;
-        const existing = statsByProvider.get(r.provider) ?? {
-          successCount: 0,
-          totalCount: 0,
-          thisMonth: 0,
-          peakDaily: 0,
-        };
-        existing.peakDaily = Number(r.peak ?? 0);
-        statsByProvider.set(r.provider, existing);
-      }
-    }
-
-    const buildStats = (providerId: string) => {
-      const s = statsByProvider.get(providerId);
-      const successRate =
-        s && s.totalCount > 0 ? s.successCount / s.totalCount : 0;
-      return {
-        successRate,
-        apiCalls: s?.thisMonth ?? 0,
-        peakDailyCalls: s?.peakDaily ?? 0,
-      };
-    };
-
-    const out: IntegrationView[] = PREDEFINED_PROVIDERS.map((p) => {
-      const row = rows.find(
-        (r) => r.providerId === p.id && r.apiUrl === null,
-      );
-      return {
-        id: row?.id ?? null,
-        providerId: p.id,
-        displayName: p.displayName,
-        description: p.description,
-        iconHint: p.iconHint,
-        apiUrl: null,
-        hasApiKey: !!row?.apiKeyEncrypted,
-        isEnabled: row?.isEnabled ?? false,
-        isCustom: false,
-        openAICompatible: p.openAICompatible,
-        byokSupported: p.byokSupported,
-        boundAliasCount: 0,
-        stats: buildStats(p.id),
-        createdAt: row?.createdAt?.toISOString() ?? null,
-        updatedAt: row?.updatedAt?.toISOString() ?? null,
-      };
-    });
-
-    // Custom LLM rows after predefined, sorted by createdAt asc so
-    // the FE order is stable. Each custom row is its own card —
-    // (teamId, providerId='custom') intentionally not unique.
-    const customs = rows
-      .filter((r) => r.providerId === 'custom' && r.apiUrl !== null)
-      .sort(
-        (a, b) =>
-          new Date(a.createdAt).getTime() -
-          new Date(b.createdAt).getTime(),
-      );
-    if (customs.length > 0) {
-      // For each custom row, surface the bound alias's customName so
-      // admin sees "Local Llama" rather than just the URL hostname.
-      const customIds = customs.map((c) => c.id);
-      const aliasRows = await this.db
-        .select({
-          integrationId: modelConfigs.integrationId,
-          customName: modelConfigs.customName,
-        })
-        .from(modelConfigs)
-        .where(
-          and(
-            eq(modelConfigs.teamId, teamId),
-            inArray(modelConfigs.integrationId, customIds),
-          ),
-        );
-      const aliasNameByIntegration = new Map<string, string>();
-      for (const a of aliasRows) {
-        if (a.integrationId) {
-          aliasNameByIntegration.set(a.integrationId, a.customName);
-        }
-      }
-      for (const r of customs) {
-        const aliasName = aliasNameByIntegration.get(r.id);
-        out.push({
-          id: r.id,
-          providerId: 'custom',
-          displayName: aliasName ?? deriveCustomDisplayName(r.apiUrl ?? ''),
-          description: r.apiUrl ?? '',
-          iconHint: 'custom',
-          apiUrl: r.apiUrl,
-          hasApiKey: !!r.apiKeyEncrypted,
-          isEnabled: r.isEnabled,
-          isCustom: true,
-          openAICompatible: true,
-          byokSupported: true,
-          boundAliasCount: aliasName ? 1 : 0,
-          stats: buildStats('custom'),
-          createdAt: r.createdAt.toISOString(),
-          updatedAt: r.updatedAt.toISOString(),
-        });
-      }
-    }
-    return out;
-  }
-
-  async upsertIntegration(
-    teamId: string,
-    callerId: string,
-    input: {
-      providerId: string;
-      apiUrl?: string | null;
-      apiKey?: string | null;
-      isEnabled?: boolean;
-      // Required for providerId='custom'. Used as the alias's display
-      // name AND model identifier — members will pick this in the
-      // model dropdown and chat-transport routes the call through the
-      // bound integration.
-      customName?: string | null;
-    },
-  ): Promise<IntegrationView> {
-    const role = await this.getUserTeamRole(teamId, callerId);
-    if (
-      role !== 'owner' &&
-      role !== 'admin' &&
-      role !== 'manager' &&
-      role !== 'editor'
-    ) {
-      throw new ForbiddenException(
-        'Only team owners, admins, managers, or editors can manage team integrations',
-      );
-    }
-    const isCustom = input.providerId === 'custom';
-    if (!isCustom && !isPredefinedProvider(input.providerId)) {
-      throw new BadRequestException(
-        `Unknown provider: ${input.providerId}`,
-      );
-    }
-
-    const apiKeyEncrypted = input.apiKey?.trim()
-      ? this.encryptionService.encrypt(input.apiKey.trim())
-      : null;
-
-    // Custom LLMs at team scope: every Add creates a new (integration,
-    // alias) pair — admin can register many endpoints (Ollama, vLLM,
-    // Together, …) per team. The alias is what members see in their
-    // model dropdown; chat-transport's team-scoped lookup routes
-    // through the bound integration.
-    if (isCustom) {
-      if (!input.apiUrl?.trim()) {
-        throw new BadRequestException('Custom LLM requires apiUrl');
-      }
-      try {
-        new URL(input.apiUrl);
-      } catch {
-        throw new BadRequestException('apiUrl is not a valid URL');
-      }
-      const customName = input.customName?.trim();
-      if (!customName) {
-        throw new BadRequestException(
-          'Custom LLM requires a name members will see in the model picker',
-        );
-      }
-      const modelIdentifier = teamCustomModelIdentifier(teamId, customName);
-
-      // Reject collisions on (teamId, modelIdentifier) up-front rather
-      // than letting the DB explode at insert time — gives a clean
-      // error message instead of a 500.
-      const [existing] = await this.db
-        .select({ id: modelConfigs.id })
-        .from(modelConfigs)
-        .where(
-          and(
-            eq(modelConfigs.teamId, teamId),
-            eq(modelConfigs.modelIdentifier, modelIdentifier),
-          ),
-        )
-        .limit(1);
-      if (existing) {
-        throw new BadRequestException(
-          `A Custom LLM named "${customName}" already exists for this team. Pick a different name.`,
-        );
-      }
-
-      const [integration] = await this.db
-        .insert(integrations)
-        .values({
-          ownerId: callerId,
-          teamId,
-          providerId: 'custom',
-          apiUrl: input.apiUrl,
-          apiKeyEncrypted,
-          isEnabled: input.isEnabled ?? true,
-        })
-        .returning();
-      // Auto-create the alias so members can immediately pick the
-      // Custom LLM from their model dropdown without admin needing to
-      // touch /catalog separately.
-      await this.db.insert(modelConfigs).values({
-        ownerId: callerId,
-        teamId,
-        customName,
-        modelIdentifier,
-        integrationId: integration.id,
-        isActive: true,
-      });
-
-      const all = await this.listIntegrations(teamId, callerId);
-      const view = all.find((v) => v.id === integration.id);
-      if (!view) {
-        throw new NotFoundException('Custom integration not found after insert');
-      }
-      return view;
-    }
-
-    // Predefined providers: upsert against the team-scoped partial
-    // unique index — at most one row per (team, providerId).
-    const conflictUpdates: Record<string, unknown> = {
-      updatedAt: new Date(),
-    };
-    if (input.isEnabled !== undefined) {
-      conflictUpdates.isEnabled = input.isEnabled;
-    }
-    if (input.apiKey !== undefined) {
-      conflictUpdates.apiKeyEncrypted = apiKeyEncrypted;
-    }
-
-    await this.db
-      .insert(integrations)
-      .values({
-        ownerId: callerId,
-        teamId,
-        providerId: input.providerId,
-        apiUrl: null,
-        apiKeyEncrypted,
-        isEnabled: input.isEnabled ?? true,
-      })
-      .onConflictDoUpdate({
-        target: [integrations.teamId, integrations.providerId],
-        targetWhere: sql`${integrations.apiUrl} IS NULL AND ${integrations.teamId} IS NOT NULL`,
-        set: conflictUpdates,
-      });
-
-    const all = await this.listIntegrations(teamId, callerId);
-    const view = all.find((v) => v.providerId === input.providerId);
-    if (!view) {
-      throw new NotFoundException('Integration not found after upsert');
-    }
-    return view;
-  }
-
-  async updateIntegration(
-    teamId: string,
-    callerId: string,
-    integrationId: string,
-    input: {
-      isEnabled?: boolean;
-      apiKey?: string | null;
-      /** Custom rows only — new endpoint URL. Validated as URL. */
-      apiUrl?: string;
-      /** Custom rows only — display name in the model picker. The
-       *  underlying modelIdentifier stays stable so ongoing chats
-       *  bound to the alias don't break. */
-      customName?: string;
-    },
-  ): Promise<IntegrationView> {
-    const role = await this.getUserTeamRole(teamId, callerId);
-    if (
-      role !== 'owner' &&
-      role !== 'admin' &&
-      role !== 'manager' &&
-      role !== 'editor'
-    ) {
-      throw new ForbiddenException(
-        'Only team owners, admins, managers, or editors can manage team integrations',
-      );
-    }
-    const [row] = await this.db
-      .select()
-      .from(integrations)
-      .where(eq(integrations.id, integrationId));
-    if (!row) throw new NotFoundException('Integration not found');
-    if (row.teamId !== teamId) {
-      throw new BadRequestException(
-        'Integration does not belong to this team',
-      );
-    }
-
-    // Custom-only fields (apiUrl, customName) are nonsense on
-    // predefined rows — reject up-front so admins don't accidentally
-    // think they renamed Anthropic.
-    const isCustom = row.providerId === 'custom';
-    if (!isCustom && (input.apiUrl !== undefined || input.customName !== undefined)) {
-      throw new BadRequestException(
-        'apiUrl and customName can only be set on Custom LLM integrations.',
-      );
-    }
-
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    if (input.isEnabled !== undefined) updates.isEnabled = input.isEnabled;
-    if (input.apiKey !== undefined) {
-      updates.apiKeyEncrypted = input.apiKey
-        ? this.encryptionService.encrypt(input.apiKey)
-        : null;
-    }
-    if (input.apiUrl !== undefined) {
-      const trimmed = input.apiUrl.trim();
-      if (!trimmed) {
-        throw new BadRequestException('apiUrl cannot be empty.');
-      }
-      try {
-        new URL(trimmed);
-      } catch {
-        throw new BadRequestException('apiUrl is not a valid URL.');
-      }
-      updates.apiUrl = trimmed;
-    }
-    await this.db
-      .update(integrations)
-      .set(updates)
-      .where(eq(integrations.id, integrationId));
-
-    // Custom name lives on the bound alias (model_configs.custom_name),
-    // not on the integration row. Update it there. modelIdentifier
-    // stays untouched on purpose: it's the stable handle members'
-    // chats / conversations are bound to.
-    if (isCustom && input.customName !== undefined) {
-      const trimmedName = input.customName.trim();
-      if (!trimmedName) {
-        throw new BadRequestException('customName cannot be empty.');
-      }
-      await this.db
-        .update(modelConfigs)
-        .set({ customName: trimmedName, updatedAt: new Date() })
-        .where(
-          and(
-            eq(modelConfigs.teamId, teamId),
-            eq(modelConfigs.integrationId, integrationId),
-          ),
-        );
-    }
-
-    const all = await this.listIntegrations(teamId, callerId);
-    const view = isCustom
-      ? all.find((v) => v.id === integrationId)
-      : all.find((v) => v.providerId === row.providerId);
-    if (!view) {
-      throw new NotFoundException('Integration not found after update');
-    }
-    return view;
-  }
-
-  async removeIntegration(
-    teamId: string,
-    callerId: string,
-    integrationId: string,
-  ): Promise<{ success: true }> {
-    const role = await this.getUserTeamRole(teamId, callerId);
-    if (
-      role !== 'owner' &&
-      role !== 'admin' &&
-      role !== 'manager' &&
-      role !== 'editor'
-    ) {
-      throw new ForbiddenException(
-        'Only team owners, admins, managers, or editors can manage team integrations',
-      );
-    }
-    const [row] = await this.db
-      .select()
-      .from(integrations)
-      .where(eq(integrations.id, integrationId));
-    if (!row) throw new NotFoundException('Integration not found');
-    if (row.teamId !== teamId) {
-      throw new BadRequestException(
-        'Integration does not belong to this team',
-      );
-    }
-    // Custom team integrations have a paired team-scoped alias in
-    // model_configs that's auto-created at upsert time. The FK is
-    // ON DELETE SET NULL — without explicit cleanup the alias would
-    // survive as an orphan with integrationId=null AND a
-    // `team:xxx:slug` modelIdentifier that no provider can serve,
-    // showing up in members' pickers as a dead entry. Drop it.
-    if (row.providerId === 'custom') {
-      await this.db
-        .delete(modelConfigs)
-        .where(
-          and(
-            eq(modelConfigs.teamId, teamId),
-            eq(modelConfigs.integrationId, integrationId),
-          ),
-        );
-    }
-    await this.db
-      .delete(integrations)
-      .where(eq(integrations.id, integrationId));
-    return { success: true };
-  }
 
   /**
    * Set the per-member monthly spend cap inside this team. The cap
@@ -2540,6 +2047,457 @@ export class TeamsService {
       usage.set(row.teamId, { spentCents, projectedCents });
     }
     return usage;
+  }
+
+  /* ─── team_integration_links: new picker model ──────────────────
+     Replaces the old "duplicate the encrypted key into a separate
+     team_id-scoped integrations row" pattern with a many-to-many
+     link table. Admins configure their personal BYOK keys once on
+     /teams?tab=integration (IntegrationsService), then come here to
+     activate them per team. Key rotation only has to happen on the
+     personal row — every linked team picks it up automatically. */
+
+  /**
+   * Caller-visible view of one row that is currently linked to a team.
+   * Shape mirrors `IntegrationLinkView` on the FE; small enough that
+   * we don't bother with a separate types file.
+   */
+  // (Type is structurally defined in the return shape of
+  // `listIntegrationLinks` — keeping it inline so FE + BE evolve
+  // together. If the shape grows we'll pull it into a named type.)
+
+  /**
+   * List the integrations currently linked into a team. Returns the
+   * underlying `integrations` row + the link's `isEnabled` flag, so
+   * the picker can render both the master switch (the integration is
+   * on/off in the admin's personal tab) and the per-team toggle.
+   * Read-gated on team membership: any member sees the list. Writes
+   * are gated separately in the mutation methods below.
+   */
+  async listIntegrationLinks(teamId: string, callerId: string) {
+    const role = await this.getUserTeamRole(teamId, callerId);
+    if (!role) {
+      throw new ForbiddenException('You are not a member of this team');
+    }
+    const rows = await this.db
+      .select({
+        integrationId: integrations.id,
+        ownerId: integrations.ownerId,
+        ownerName: users.name,
+        providerId: integrations.providerId,
+        apiUrl: integrations.apiUrl,
+        hasApiKey: sql<boolean>`${integrations.apiKeyEncrypted} IS NOT NULL`,
+        integrationEnabled: integrations.isEnabled,
+        linkEnabled: teamIntegrationLinks.isEnabled,
+        linkedAt: teamIntegrationLinks.linkedAt,
+        linkedBy: teamIntegrationLinks.linkedBy,
+      })
+      .from(teamIntegrationLinks)
+      .innerJoin(
+        integrations,
+        eq(integrations.id, teamIntegrationLinks.integrationId),
+      )
+      .leftJoin(users, eq(users.id, integrations.ownerId))
+      .where(eq(teamIntegrationLinks.teamId, teamId))
+      .orderBy(teamIntegrationLinks.linkedAt);
+
+    return rows.map((r) => ({
+      integrationId: r.integrationId,
+      // Owner identity is surfaced so the FE picker can distinguish
+      // "my key" (caller-editable checkbox) from "another admin's
+      // key" (read-only with a per-team toggle). Without ownerId
+      // the FE would have to cross-reference linkable + linked.
+      ownerId: r.ownerId,
+      ownerName: r.ownerName,
+      providerId: r.providerId,
+      isCustom: r.providerId === 'custom',
+      displayName:
+        r.providerId === 'custom'
+          ? deriveCustomDisplayName(r.apiUrl ?? '')
+          : (PREDEFINED_PROVIDERS.find((p) => p.id === r.providerId)
+              ?.displayName ?? r.providerId),
+      apiUrl: r.apiUrl,
+      hasApiKey: Boolean(r.hasApiKey),
+      linkEnabled: r.linkEnabled,
+      integrationEnabled: r.integrationEnabled,
+      linkedAt: r.linkedAt.toISOString(),
+      linkedBy: r.linkedBy,
+    }));
+  }
+
+  /**
+   * List the *caller's* personal integrations + whether each is
+   * currently linked into this team. Powers the "pick which keys to
+   * activate" UI on team details. Empty list → FE shows the CTA
+   * pointing to /teams?tab=integration where personal keys are
+   * created.
+   */
+  async listLinkableIntegrations(teamId: string, callerId: string) {
+    const role = await this.getUserTeamRole(teamId, callerId);
+    if (!role) {
+      throw new ForbiddenException('You are not a member of this team');
+    }
+    const myIntegrations = await this.db
+      .select({
+        id: integrations.id,
+        providerId: integrations.providerId,
+        apiUrl: integrations.apiUrl,
+        hasApiKey: sql<boolean>`${integrations.apiKeyEncrypted} IS NOT NULL`,
+        isEnabled: integrations.isEnabled,
+      })
+      .from(integrations)
+      .where(
+        and(
+          eq(integrations.ownerId, callerId),
+          // Only personal rows are linkable — legacy team-scoped rows
+          // (if any survived the backfill) are intentionally invisible
+          // so they age out of the UX entirely.
+          sql`${integrations.teamId} IS NULL`,
+        ),
+      );
+
+    const linkedRows = await this.db
+      .select({
+        integrationId: teamIntegrationLinks.integrationId,
+        providerId: integrations.providerId,
+      })
+      .from(teamIntegrationLinks)
+      .innerJoin(
+        integrations,
+        eq(integrations.id, teamIntegrationLinks.integrationId),
+      )
+      .where(eq(teamIntegrationLinks.teamId, teamId));
+
+    // Per-team-per-provider uniqueness for predefined providers: if a
+    // *different* personal integration of the caller's already
+    // occupies that providerId slot on this team, we still surface
+    // the caller's other personal predef for that provider but mark
+    // it `blockedByProvider: true` so the FE can render a disabled
+    // pill explaining why it can't be linked.
+    const linkedIntegrationIds = new Set(linkedRows.map((r) => r.integrationId));
+    const occupiedPredefProviders = new Set(
+      linkedRows
+        .filter((r) => r.providerId !== 'custom')
+        .map((r) => r.providerId),
+    );
+
+    return myIntegrations.map((r) => ({
+      integrationId: r.id,
+      providerId: r.providerId,
+      isCustom: r.providerId === 'custom',
+      displayName:
+        r.providerId === 'custom'
+          ? deriveCustomDisplayName(r.apiUrl ?? '')
+          : (PREDEFINED_PROVIDERS.find((p) => p.id === r.providerId)
+              ?.displayName ?? r.providerId),
+      apiUrl: r.apiUrl,
+      hasApiKey: Boolean(r.hasApiKey),
+      integrationEnabled: r.isEnabled,
+      alreadyLinked: linkedIntegrationIds.has(r.id),
+      // Predef-only: another personal integration of the caller's
+      // (or someone else's) already holds this provider slot on the
+      // team. The FE disables the checkbox + explains in tooltip.
+      blockedByProvider:
+        r.providerId !== 'custom' &&
+        !linkedIntegrationIds.has(r.id) &&
+        occupiedPredefProviders.has(r.providerId),
+    }));
+  }
+
+  /**
+   * Atomic replace of the team's link set. Computes the delta vs
+   * what's currently linked: inserts new links, deletes removed
+   * ones, leaves untouched links alone (so their per-link
+   * `is_enabled` toggle survives a save). Authz: owner / admin /
+   * manager / editor only.
+   *
+   * Validates:
+   *   - every input id exists and is a personal (team_id IS NULL)
+   *     integration the caller can see (defense in depth — the FE
+   *     should only ever submit caller's own ids, but the BE is the
+   *     trust boundary)
+   *   - no two input ids resolve to the same predefined providerId
+   *     (one-Anthropic-per-team rule)
+   *
+   * Side effect for custom LLMs: when a new link lands, we also
+   * provision a team-scoped model_configs alias so the model picker
+   * for team members surfaces the URL. On unlink we drop the alias
+   * so removed integrations stop appearing in pickers.
+   */
+  async setIntegrationLinks(
+    teamId: string,
+    callerId: string,
+    integrationIds: string[],
+  ) {
+    const role = await this.getUserTeamRole(teamId, callerId);
+    if (
+      role !== 'owner' &&
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor'
+    ) {
+      throw new ForbiddenException(
+        'Only team owners, admins, managers, or editors can manage team integrations',
+      );
+    }
+
+    const uniqueIds = Array.from(new Set(integrationIds));
+
+    // Empty input is a valid "clear all my own links" — short-circuit
+    // and do the deletes in one shot. Links owned by *other* admins
+    // stay untouched so a save here can't nuke someone else's setup.
+    if (uniqueIds.length === 0) {
+      const removed = await this.db
+        .select({
+          integrationId: teamIntegrationLinks.integrationId,
+          providerId: integrations.providerId,
+        })
+        .from(teamIntegrationLinks)
+        .innerJoin(
+          integrations,
+          eq(integrations.id, teamIntegrationLinks.integrationId),
+        )
+        .where(
+          and(
+            eq(teamIntegrationLinks.teamId, teamId),
+            eq(integrations.ownerId, callerId),
+          ),
+        );
+      if (removed.length > 0) {
+        await this.db
+          .delete(teamIntegrationLinks)
+          .where(
+            and(
+              eq(teamIntegrationLinks.teamId, teamId),
+              inArray(
+                teamIntegrationLinks.integrationId,
+                removed.map((r) => r.integrationId),
+              ),
+            ),
+          );
+        // Drop team-scoped custom aliases bound to any removed
+        // integration so chat-time pickers stop surfacing them.
+        const customIds = removed
+          .filter((r) => r.providerId === 'custom')
+          .map((r) => r.integrationId);
+        if (customIds.length > 0) {
+          await this.db
+            .delete(modelConfigs)
+            .where(
+              and(
+                eq(modelConfigs.teamId, teamId),
+                inArray(modelConfigs.integrationId, customIds),
+              ),
+            );
+        }
+      }
+      return this.listIntegrationLinks(teamId, callerId);
+    }
+
+    // Resolve the requested integrations + sanity-check ownership /
+    // scope. Pulling the full set in one query keeps the BE round-
+    // trip count predictable regardless of input size.
+    const requested = await this.db
+      .select({
+        id: integrations.id,
+        ownerId: integrations.ownerId,
+        teamId: integrations.teamId,
+        providerId: integrations.providerId,
+        apiUrl: integrations.apiUrl,
+      })
+      .from(integrations)
+      .where(inArray(integrations.id, uniqueIds));
+
+    if (requested.length !== uniqueIds.length) {
+      throw new BadRequestException(
+        'One or more integrations were not found.',
+      );
+    }
+    for (const r of requested) {
+      if (r.teamId !== null) {
+        throw new BadRequestException(
+          'Cannot link a team-scoped integration. Only personal integrations from /teams?tab=integration can be linked.',
+        );
+      }
+      if (r.ownerId !== callerId) {
+        throw new ForbiddenException(
+          'You can only link integrations you own. Ask the integration owner to link it to this team.',
+        );
+      }
+    }
+
+    // One-predef-per-team-per-provider rule. Custom LLMs are exempt
+    // — admin may legitimately want multiple Ollama / vLLM endpoints
+    // for the same team.
+    const predefByProvider = new Map<string, string>();
+    for (const r of requested) {
+      if (r.providerId === 'custom') continue;
+      const seen = predefByProvider.get(r.providerId);
+      if (seen) {
+        throw new BadRequestException(
+          `Two ${r.providerId} integrations were selected. Pick one per provider.`,
+        );
+      }
+      predefByProvider.set(r.providerId, r.id);
+    }
+
+    // Scope the delta to the caller's own integrations: a save here
+    // must never delete a link another admin set up. We compute the
+    // existing set by joining through integrations.owner_id = caller,
+    // and the toInsert/toDelete diffs only over that subset.
+    const existing = await this.db
+      .select({ integrationId: teamIntegrationLinks.integrationId })
+      .from(teamIntegrationLinks)
+      .innerJoin(
+        integrations,
+        eq(integrations.id, teamIntegrationLinks.integrationId),
+      )
+      .where(
+        and(
+          eq(teamIntegrationLinks.teamId, teamId),
+          eq(integrations.ownerId, callerId),
+        ),
+      );
+    const existingSet = new Set(existing.map((e) => e.integrationId));
+    const targetSet = new Set(uniqueIds);
+
+    const toInsert = uniqueIds.filter((id) => !existingSet.has(id));
+    const toDelete = Array.from(existingSet).filter((id) => !targetSet.has(id));
+
+    await this.db.transaction(async (tx) => {
+      if (toDelete.length > 0) {
+        await tx
+          .delete(teamIntegrationLinks)
+          .where(
+            and(
+              eq(teamIntegrationLinks.teamId, teamId),
+              inArray(teamIntegrationLinks.integrationId, toDelete),
+            ),
+          );
+        // Custom alias cleanup — mirror image of the create branch
+        // below; only drops rows we own (team-scoped) referencing a
+        // removed integration.
+        const removedCustoms = await tx
+          .select({ id: integrations.id })
+          .from(integrations)
+          .where(
+            and(
+              inArray(integrations.id, toDelete),
+              eq(integrations.providerId, 'custom'),
+            ),
+          );
+        if (removedCustoms.length > 0) {
+          await tx
+            .delete(modelConfigs)
+            .where(
+              and(
+                eq(modelConfigs.teamId, teamId),
+                inArray(
+                  modelConfigs.integrationId,
+                  removedCustoms.map((r) => r.id),
+                ),
+              ),
+            );
+        }
+      }
+      if (toInsert.length > 0) {
+        await tx.insert(teamIntegrationLinks).values(
+          toInsert.map((integrationId) => ({
+            teamId,
+            integrationId,
+            linkedBy: callerId,
+          })),
+        );
+
+        // Custom alias provision — for each newly-linked custom
+        // integration, surface it in the team's model picker via a
+        // team-scoped model_configs row. Name derived from the
+        // personal alias if one exists, else from the URL hostname.
+        const insertedCustoms = requested.filter(
+          (r) => toInsert.includes(r.id) && r.providerId === 'custom',
+        );
+        if (insertedCustoms.length > 0) {
+          const personalAliasByIntegration = new Map<string, string>();
+          const aliasRows = await tx
+            .select({
+              integrationId: modelConfigs.integrationId,
+              customName: modelConfigs.customName,
+            })
+            .from(modelConfigs)
+            .where(
+              and(
+                eq(modelConfigs.ownerId, callerId),
+                sql`${modelConfigs.teamId} IS NULL`,
+                inArray(
+                  modelConfigs.integrationId,
+                  insertedCustoms.map((c) => c.id),
+                ),
+              ),
+            );
+          for (const a of aliasRows) {
+            if (a.integrationId) {
+              personalAliasByIntegration.set(a.integrationId, a.customName);
+            }
+          }
+          for (const c of insertedCustoms) {
+            const customName =
+              personalAliasByIntegration.get(c.id) ??
+              deriveCustomDisplayName(c.apiUrl ?? '');
+            await tx.insert(modelConfigs).values({
+              ownerId: callerId,
+              teamId,
+              integrationId: c.id,
+              customName,
+              modelIdentifier: teamCustomModelIdentifier(teamId, customName),
+              isActive: true,
+            });
+          }
+        }
+      }
+    });
+
+    return this.listIntegrationLinks(teamId, callerId);
+  }
+
+  /**
+   * Per-link enable / disable toggle. Distinct from the master
+   * `integrations.isEnabled` switch on /teams?tab=integration: that
+   * flag turns the key off everywhere (chat layer skips it for the
+   * owner *and* every linked team); this one only pauses use on a
+   * single team while leaving the underlying key intact. Authz
+   * mirrors `setIntegrationLinks`.
+   */
+  async setIntegrationLinkEnabled(
+    teamId: string,
+    callerId: string,
+    integrationId: string,
+    isEnabled: boolean,
+  ) {
+    const role = await this.getUserTeamRole(teamId, callerId);
+    if (
+      role !== 'owner' &&
+      role !== 'admin' &&
+      role !== 'manager' &&
+      role !== 'editor'
+    ) {
+      throw new ForbiddenException(
+        'Only team owners, admins, managers, or editors can manage team integrations',
+      );
+    }
+    const updated = await this.db
+      .update(teamIntegrationLinks)
+      .set({ isEnabled, updatedAt: new Date() })
+      .where(
+        and(
+          eq(teamIntegrationLinks.teamId, teamId),
+          eq(teamIntegrationLinks.integrationId, integrationId),
+        ),
+      )
+      .returning({ teamId: teamIntegrationLinks.teamId });
+    if (updated.length === 0) {
+      throw new NotFoundException('Integration is not linked to this team.');
+    }
+    return this.listIntegrationLinks(teamId, callerId);
   }
 }
 

--- a/apps/web/src/app/(app)/compare-models/page.tsx
+++ b/apps/web/src/app/(app)/compare-models/page.tsx
@@ -695,7 +695,7 @@ export default function CompareModelsPage() {
   // and silently rendering an empty rail looks broken.
   if (!modelsLoading && availableModels.length < MIN_MODELS) {
     return (
-      <div className="flex h-full min-h-0 items-center justify-center pb-6">
+      <div className="flex h-0 min-h-0 flex-1 items-center justify-center pb-6">
         <div className="flex max-w-[480px] flex-col items-center gap-4 rounded-[20px] bg-bg-white p-8 text-center">
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-1">
             <LayoutGrid className="h-6 w-6 text-primary-7" />
@@ -721,15 +721,32 @@ export default function CompareModelsPage() {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-6 pb-6">
+    // `flex-1 h-0` (not `h-full`) — the app shell wraps pages in a
+    // `min-h-full flex-col` container, which is *min-height*, not
+    // height. That means `h-full` here resolves to auto and the row
+    // below grows with whatever the right rail contains, dragging
+    // the white card with it (so expanding History made the card
+    // visibly "jump"). Using flex-grow against `h-0` forces this
+    // wrapper to claim the remaining definite height of the shell,
+    // which gives the row a fixed height and lets the aside scroll
+    // its history list internally instead of pushing the layout.
+    <div className="flex h-0 min-h-0 flex-1 flex-col gap-6 pb-6">
       {/* Body shell: main column + optional right rail */}
       <div className="flex min-h-0 flex-1 gap-6">
-        {/* Main column — white card per Figma */}
+        {/* Main column — white card per Figma. Layout is intentionally
+            *static*: scrollable area always takes the remaining height
+            and the composer stays pinned at the bottom, regardless of
+            whether a comparison is loaded, history is expanded, or the
+            rail is open. Keeps the white card visually stable across
+            state transitions. */}
         <section className="flex min-w-0 flex-1 flex-col gap-4 overflow-hidden rounded-[20px] bg-bg-white p-6">
-          {/* Scrollable content area (prompt + responses) */}
           <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
             {!hasResults && !loading && !submittedQuestion && (
-              <div className="flex flex-1 flex-col items-center justify-center gap-2 py-16 text-center">
+              // `my-auto` keeps the placeholder vertically centred inside
+              // the scrollable area without changing the area's flex
+              // sizing — so the composer below it stays put and the
+              // white card never reflows when state changes.
+              <div className="mx-auto my-auto flex w-full max-w-[480px] flex-col items-center gap-2 py-10 text-center">
                 <Sparkles className="h-8 w-8 text-text-3" strokeWidth={1.5} />
                 <h3 className="text-[16px] font-semibold text-text-1">
                   Compare models side by side
@@ -1338,13 +1355,17 @@ function Composer({
   const imageInputRef = useRef<HTMLInputElement>(null);
   const questionRef = useRef<HTMLTextAreaElement>(null);
 
-  // Auto-grow the question textarea to fit its content. Runs on every value
-  // change (typing, pasting, programmatic inserts from shortcuts/library).
+  // Auto-grow the question textarea to fit its content, capped so a
+  // pasted novel can't push the composer to fill the page. Past the
+  // cap the textarea scrolls internally.
   useEffect(() => {
     const ta = questionRef.current;
     if (!ta) return;
+    const MAX = 200;
     ta.style.height = "auto";
-    ta.style.height = `${ta.scrollHeight}px`;
+    const next = Math.min(ta.scrollHeight, MAX);
+    ta.style.height = `${next}px`;
+    ta.style.overflowY = ta.scrollHeight > MAX ? "auto" : "hidden";
   }, [question]);
 
   function handleInsertShortcut(shortcut: Shortcut) {

--- a/apps/web/src/app/(app)/guardrails/page.tsx
+++ b/apps/web/src/app/(app)/guardrails/page.tsx
@@ -6,8 +6,6 @@ import {
   AlertTriangle,
   Check,
   CheckCircle,
-  ChevronLeft,
-  ChevronRight,
   Eye,
   Loader2,
   Pencil,
@@ -30,6 +28,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Pagination } from "@/components/ui/pagination";
 import {
   Select,
   SelectContent,
@@ -457,47 +456,12 @@ function OverviewTab({
           </tbody>
         </table>
 
-        {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="flex items-center justify-between border-t border-border-2 px-6 py-3">
-            <Button
-              variant="outline"
-              className="cursor-pointer gap-1.5 text-[13px]"
-              disabled={page <= 1}
-              onClick={() => setPage((p) => p - 1)}
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-              Previous
-            </Button>
-            <div className="flex items-center gap-1">
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map(
-                (p) => (
-                  <button
-                    key={p}
-                    type="button"
-                    onClick={() => setPage(p)}
-                    className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded text-[13px] transition-colors ${
-                      p === page
-                        ? "bg-primary-6 font-semibold text-white"
-                        : "text-text-2 hover:bg-bg-1"
-                    }`}
-                  >
-                    {p}
-                  </button>
-                ),
-              )}
-            </div>
-            <Button
-              variant="outline"
-              className="cursor-pointer gap-1.5 text-[13px]"
-              disabled={page >= totalPages}
-              onClick={() => setPage((p) => p + 1)}
-            >
-              Next
-              <ChevronRight className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-        )}
+        <Pagination
+          page={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+          className="px-6"
+        />
       </div>
 
       {/* Delete dialog */}

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useMemo, useState } from "react";
+import { use, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -68,6 +68,7 @@ import {
 import { useAuth } from "@/components/providers";
 import { ChangeFileVisibilityDialog } from "@/components/change-file-visibility-dialog";
 import { KnowledgeNameConflictDialog } from "@/components/knowledge-name-conflict-dialog";
+import { Pagination } from "@/components/ui/pagination";
 
 const TYPE_STYLES: Record<string, string> = {
   PDF: "bg-danger-1 text-danger-6",
@@ -690,6 +691,31 @@ export default function FolderDetailPage({
     );
   }, [query, folder]);
 
+  // Page state for the folder's file list. 10 rows/page; resets on
+  // search change so the user lands on a populated page when the
+  // result set shrinks. Both the desktop table and the mobile card
+  // grid read `pagedFiles` so they paginate in lockstep.
+  const FILES_PAGE_SIZE = 10;
+  const [filesPage, setFilesPage] = useState(1);
+  useEffect(() => {
+    setFilesPage(1);
+  }, [query]);
+  const filesTotalPages = Math.max(
+    1,
+    Math.ceil(filtered.length / FILES_PAGE_SIZE),
+  );
+  const pagedFiles = useMemo(
+    () =>
+      filtered.slice(
+        (filesPage - 1) * FILES_PAGE_SIZE,
+        filesPage * FILES_PAGE_SIZE,
+      ),
+    [filtered, filesPage],
+  );
+  useEffect(() => {
+    if (filesPage > filesTotalPages) setFilesPage(filesTotalPages);
+  }, [filesPage, filesTotalPages]);
+
   // Tri-state for the select-all header checkbox over the *currently
   // visible* rows (post-search-filter). Selection itself is folder-
   // wide — toggling search filter doesn't drop existing selection.
@@ -883,7 +909,7 @@ export default function FolderDetailPage({
               </tr>
             </thead>
             <tbody>
-              {filtered.map((f) => (
+              {pagedFiles.map((f) => (
                 <tr
                   key={f.id}
                   className={`border-b border-border-2 last:border-b-0 transition-colors hover:bg-bg-1 ${
@@ -1046,7 +1072,7 @@ export default function FolderDetailPage({
 
         {/* Mobile cards */}
         <div className="flex flex-col md:hidden">
-          {filtered.map((f, idx) => (
+          {pagedFiles.map((f, idx) => (
             <div
               key={f.id}
               className={`flex items-center gap-3 px-4 py-4 ${idx > 0 ? "border-t border-border-2" : ""} ${
@@ -1173,6 +1199,13 @@ export default function FolderDetailPage({
             </p>
           )}
         </div>
+
+        <Pagination
+          page={filesPage}
+          totalPages={filesTotalPages}
+          onPageChange={setFilesPage}
+          className="px-4"
+        />
       </div>
 
       {/* Move file dialog */}

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -111,8 +111,10 @@ function formatDateTime(d: string): string {
  * row. Mirrors the same four states the step-6 progress UI uses so
  * the user gets consistent vocabulary across both upload paths.
  *
- *   pending / processing → Loader2 spinner, neutral copy
- *   done                 → success check, "Trained"
+ *   pending / processing → Loader2 spinner, "Queued" / "Adding"
+ *   done                 → success check, "In context"
+ *   untrained            → unplug glyph, "Excluded" — embeddings
+ *                          dropped, file row still on disk
  *   failed               → warning triangle, "Skipped" + tooltip with
  *                          the underlying error so unsupported types
  *                          don't look broken
@@ -128,7 +130,7 @@ function IngestionStatusBadge({
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-success-7">
         <CheckCircle2 className="h-3 w-3" strokeWidth={2} />
-        Trained
+        In context
       </span>
     );
   }
@@ -147,17 +149,17 @@ function IngestionStatusBadge({
     return (
       <span
         className="inline-flex items-center gap-1 rounded-full bg-bg-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-3"
-        title="Embeddings removed — Retrain to make this file searchable again."
+        title="Excluded from context — Include in context to make this file searchable again."
       >
         <Unplug className="h-3 w-3" strokeWidth={2} />
-        Untrained
+        Excluded
       </span>
     );
   }
   return (
     <span className="inline-flex items-center gap-1 rounded-full bg-bg-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-3">
       <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
-      {status === "processing" ? "Training" : "Queued"}
+      {status === "processing" ? "Adding" : "Queued"}
     </span>
   );
 }
@@ -250,7 +252,7 @@ export default function FolderDetailPage({
     queryFn: () => fetchKnowledgeFolder(folderId),
     enabled: !!folderId,
     // Auto-poll while ingestion is still in flight so the status
-    // badge transitions Queued → Processing → Trained without the
+    // badge transitions Queued → Adding → In context without the
     // user having to refresh. Stops polling once every file lands
     // in a terminal state (done / failed) — avoids needless DB
     // round-trips for static folders.
@@ -388,8 +390,8 @@ export default function FolderDetailPage({
     });
   };
 
-  // Single-file re-train. Mirror of the root /knowledge-core page;
-  // see its comment for details.
+  // Single-file include-in-context. Mirror of the root /knowledge-
+  // core page; see its comment for details.
   const reingestMutation = useMutation({
     mutationFn: (fileId: string) => reingestKnowledgeFile(fileId),
     onSuccess: () => {
@@ -398,15 +400,17 @@ export default function FolderDetailPage({
       });
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
-      toast.success("Re-training started.");
+      toast.success("Adding to context.");
     },
     onError: (err: Error) =>
-      toast.error(err.message || "Failed to re-train this file."),
+      toast.error(
+        err.message || "Failed to include this file in context.",
+      ),
   });
 
-  // Inverse of Retrain — drops the file's embeddings so chat RAG
-  // ignores it, but keeps the row + disk copy. See the root page's
-  // mutation comment for the BE-side semantics.
+  // Inverse — drops the file's embeddings so chat RAG ignores it,
+  // but keeps the row + disk copy. See the root page's mutation
+  // comment for the BE-side semantics.
   const untrainMutation = useMutation({
     mutationFn: (fileId: string) => untrainKnowledgeFile(fileId),
     onSuccess: () => {
@@ -415,10 +419,12 @@ export default function FolderDetailPage({
       });
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
-      toast.success("File untrained — embeddings removed.");
+      toast.success("Excluded from context.");
     },
     onError: (err: Error) =>
-      toast.error(err.message || "Failed to untrain this file."),
+      toast.error(
+        err.message || "Failed to exclude this file from context.",
+      ),
   });
 
   // Admin-only PATCH to flip visibility post-upload. BE rejects
@@ -548,11 +554,11 @@ export default function FolderDetailPage({
         toast.success(updatedCopy);
       } else if (res.affectedIds.length === 0) {
         toast.warning(
-          `All ${res.skippedIds.length} selected file(s) are still being trained. Try again once they finish.`,
+          `All ${res.skippedIds.length} selected file(s) are still being added to context. Try again once they finish.`,
         );
       } else {
         toast.warning(
-          `${updatedCopy} ${res.skippedIds.length} file(s) were skipped because they're still being trained — try those again in a moment.`,
+          `${updatedCopy} ${res.skippedIds.length} file(s) were skipped because they're still being added to context — try those again in a moment.`,
         );
       }
       clearSelection();
@@ -561,9 +567,9 @@ export default function FolderDetailPage({
       toast.error(err.message || "Failed to update visibility."),
   });
 
-  // Bulk retrain + delete fan out to the existing per-file
+  // Bulk include + delete fan out to the existing per-file
   // endpoints via Promise.allSettled — same per-row gates (owner
-  // check, status='processing' block for retrain) apply, just
+  // check, status='processing' block for include) apply, just
   // accumulated. Aggregated toast at the end so a single failure
   // doesn't drown out the successes.
   const bulkRetrainMutation = useMutation({
@@ -582,12 +588,14 @@ export default function FolderDetailPage({
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
       if (rejected === 0) {
-        toast.success(`Re-training started for ${fulfilled} file(s).`);
+        toast.success(`Adding ${fulfilled} file(s) to context.`);
       } else if (fulfilled === 0) {
-        toast.error(`Re-train failed for all ${rejected} file(s).`);
+        toast.error(
+          `Couldn't add any of the ${rejected} file(s) to context.`,
+        );
       } else {
         toast.warning(
-          `Re-trained ${fulfilled} file(s); ${rejected} failed (likely already mid-training).`,
+          `Added ${fulfilled} file(s); ${rejected} couldn't be added (likely already being added).`,
         );
       }
       clearSelection();
@@ -784,7 +792,7 @@ export default function FolderDetailPage({
 
       {/* Bulk action bar. Renders sticky above the table whenever the
           user has at least one row selected. Visibility buttons are
-          admin-only — matches the per-file action menu gate; retrain
+          admin-only — matches the per-file action menu gate; include
           and delete are owner-only (BE filters anyway, FE just lets
           the user fire it). */}
       {selectedIds.size > 0 && (
@@ -826,7 +834,7 @@ export default function FolderDetailPage({
               className="cursor-pointer gap-1.5"
             >
               <RotateCw className="h-3.5 w-3.5" />
-              Retrain
+              Include in context
             </Button>
             <Button
               variant="outline"
@@ -961,7 +969,7 @@ export default function FolderDetailPage({
                           }
                         >
                           <RotateCw className="mr-2 h-3.5 w-3.5" />
-                          Retrain
+                          Include in context
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onSelect={() => untrainMutation.mutate(f.id)}
@@ -972,7 +980,7 @@ export default function FolderDetailPage({
                           }
                         >
                           <Unplug className="mr-2 h-3.5 w-3.5" />
-                          Untrain
+                          Exclude from context
                         </DropdownMenuItem>
                         {isAdmin && (
                           <DropdownMenuItem
@@ -1102,7 +1110,7 @@ export default function FolderDetailPage({
                     }
                   >
                     <RotateCw className="mr-2 h-3.5 w-3.5" />
-                    Retrain
+                    Include in context
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => untrainMutation.mutate(f.id)}
@@ -1113,7 +1121,7 @@ export default function FolderDetailPage({
                     }
                   >
                     <Unplug className="mr-2 h-3.5 w-3.5" />
-                    Untrain
+                    Exclude from context
                   </DropdownMenuItem>
                   {isAdmin && (
                     <DropdownMenuItem

--- a/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/[folderId]/page.tsx
@@ -62,9 +62,12 @@ import {
   moveKnowledgeFile,
   deleteKnowledgeFile,
   type KnowledgeFileVisibility,
+  type KnowledgeUploadNameConflict,
+  type NameConflictAction,
 } from "@/lib/api";
 import { useAuth } from "@/components/providers";
 import { ChangeFileVisibilityDialog } from "@/components/change-file-visibility-dialog";
+import { KnowledgeNameConflictDialog } from "@/components/knowledge-name-conflict-dialog";
 
 const TYPE_STYLES: Record<string, string> = {
   PDF: "bg-danger-1 text-danger-6",
@@ -263,20 +266,43 @@ export default function FolderDetailPage({
     },
   });
 
+  // Same-name-different-content conflicts surfaced by the BE on the
+  // last upload call. Held in state so the resolution dialog can
+  // re-trigger an upload of *only* the conflicting files once the
+  // user picks per-name actions. `pendingFiles` is the original
+  // File[] from the first call so we don't ask the user to re-pick
+  // them in the OS file dialog.
+  const [pendingConflicts, setPendingConflicts] = useState<{
+    conflicts: KnowledgeUploadNameConflict[];
+    files: File[];
+    visibility: KnowledgeFileVisibility;
+    teamIds: string[];
+    projectIds: string[];
+  } | null>(null);
+
   const uploadMutation = useMutation({
     mutationFn: ({
       files,
       visibility,
       teamIds,
       projectIds,
+      nameConflictActions,
     }: {
       files: File[];
       visibility: KnowledgeFileVisibility;
       teamIds: string[];
       projectIds: string[];
+      nameConflictActions?: Record<string, NameConflictAction>;
     }) =>
-      uploadKnowledgeFiles(folderId, files, visibility, teamIds, projectIds),
-    onSuccess: ({ uploaded, duplicates }) => {
+      uploadKnowledgeFiles(
+        folderId,
+        files,
+        visibility,
+        teamIds,
+        projectIds,
+        nameConflictActions,
+      ),
+    onSuccess: ({ uploaded, duplicates, nameConflicts }, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["knowledge-folder", folderId],
       });
@@ -301,10 +327,66 @@ export default function FolderDetailPage({
           },
         );
       }
+      // Name conflicts kick off a separate resolution dialog. If we
+      // get here with conflicts AFTER the user already picked
+      // actions in the prior pass, treat it as a no-op + a warning
+      // — re-opening the dialog would loop on 'skip' picks.
+      if (nameConflicts.length > 0) {
+        if (variables.nameConflictActions) {
+          toast.info(
+            `${nameConflicts.length} file(s) were skipped.`,
+            {
+              description: nameConflicts
+                .map((c) => `"${c.name}"`)
+                .join("\n"),
+            },
+          );
+          return;
+        }
+        setPendingConflicts({
+          conflicts: nameConflicts,
+          files: variables.files,
+          visibility: variables.visibility,
+          teamIds: variables.teamIds,
+          projectIds: variables.projectIds,
+        });
+      }
     },
     onError: (err: Error) =>
       toast.error(err.message || "Failed to upload files."),
   });
+
+  const resolveNameConflicts = (
+    actions: Record<string, NameConflictAction>,
+  ) => {
+    if (!pendingConflicts) return;
+    // Re-upload only the files the user *actually* wants to act on
+    // — anything left as 'skip' is dropped client-side so we don't
+    // round-trip just to have the BE bounce it back unchanged.
+    const conflictNames = new Set(
+      pendingConflicts.conflicts.map((c) => c.name),
+    );
+    const filesToResend = pendingConflicts.files.filter(
+      (f) => conflictNames.has(f.name) && actions[f.name] !== "skip",
+    );
+    const skippedCount = pendingConflicts.conflicts.filter(
+      (c) => (actions[c.name] ?? "skip") === "skip",
+    ).length;
+    setPendingConflicts(null);
+    if (filesToResend.length === 0) {
+      if (skippedCount > 0) {
+        toast.info(`Skipped ${skippedCount} file(s).`);
+      }
+      return;
+    }
+    uploadMutation.mutate({
+      files: filesToResend,
+      visibility: pendingConflicts.visibility,
+      teamIds: pendingConflicts.teamIds,
+      projectIds: pendingConflicts.projectIds,
+      nameConflictActions: actions,
+    });
+  };
 
   // Single-file re-train. Mirror of the root /knowledge-core page;
   // see its comment for details.
@@ -1422,6 +1504,17 @@ export default function FolderDetailPage({
           queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
           queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
         }}
+      />
+
+      {/* Same-name resolution. Only fires when the BE flagged at
+          least one file as conflicting in this folder under the
+          same uploader; user picks overwrite / keep both / skip
+          per file (or in bulk) and we re-upload accordingly. */}
+      <KnowledgeNameConflictDialog
+        open={pendingConflicts !== null}
+        conflicts={pendingConflicts?.conflicts ?? []}
+        onResolve={resolveNameConflicts}
+        onCancel={() => setPendingConflicts(null)}
       />
     </div>
   );

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/api";
 import { useAuth } from "@/components/providers";
 import { KnowledgeNameConflictDialog } from "@/components/knowledge-name-conflict-dialog";
+import { Pagination } from "@/components/ui/pagination";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -633,6 +634,30 @@ export default function KnowledgeCorePage() {
     );
   }, [query, recentFiles]);
 
+  // Client-side pagination over the filtered recent-files list.
+  // 10 rows/page matches the Figma comp; resets to 1 on any filter
+  // change so the user always lands on a populated first page.
+  const FILES_PAGE_SIZE = 10;
+  const [filesPage, setFilesPage] = useState(1);
+  useEffect(() => {
+    setFilesPage(1);
+  }, [query]);
+  const filesTotalPages = Math.max(
+    1,
+    Math.ceil(filteredFiles.length / FILES_PAGE_SIZE),
+  );
+  const pagedFiles = useMemo(
+    () =>
+      filteredFiles.slice(
+        (filesPage - 1) * FILES_PAGE_SIZE,
+        filesPage * FILES_PAGE_SIZE,
+      ),
+    [filteredFiles, filesPage],
+  );
+  useEffect(() => {
+    if (filesPage > filesTotalPages) setFilesPage(filesTotalPages);
+  }, [filesPage, filesTotalPages]);
+
   if (foldersLoading || filesLoading) {
     return (
       <div className="flex flex-1 items-center justify-center py-20">
@@ -760,7 +785,7 @@ export default function KnowledgeCorePage() {
       <section className="flex flex-col gap-6">
         <h2 className="text-[18px] font-bold text-text-1">Recent Files</h2>
         <div className="flex flex-col gap-3">
-          {filteredFiles.map((file) => (
+          {pagedFiles.map((file) => (
             <div
               key={file.id}
               className="flex items-center gap-4 rounded border border-border-2 bg-bg-white px-4 py-3 transition-colors hover:bg-primary-1"
@@ -894,6 +919,11 @@ export default function KnowledgeCorePage() {
             </p>
           )}
         </div>
+        <Pagination
+          page={filesPage}
+          totalPages={filesTotalPages}
+          onPageChange={setFilesPage}
+        />
       </section>
 
       {/* New Folder Dialog */}

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -98,9 +98,12 @@ function formatDateTime(d: string): string {
 }
 
 /**
- * Ingestion lifecycle pill — same vocabulary as the folder detail
- * page. Inline-duplicated rather than imported because the two
- * pages currently don't share a components file for this domain.
+ * Context-availability pill — same vocabulary as the folder detail
+ * page. Wording is intentionally about "context" (what chat / arena
+ * can pull from at answer time); no model weights are actually
+ * updated by ingestion — embeddings get added to or removed from
+ * the RAG index. Inline-duplicated rather than imported because the
+ * two pages currently don't share a components file for this domain.
  */
 function IngestionStatusBadge({
   status,
@@ -113,7 +116,7 @@ function IngestionStatusBadge({
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-success-7">
         <CheckCircle2 className="h-3 w-3" strokeWidth={2} />
-        Trained
+        In context
       </span>
     );
   }
@@ -132,17 +135,17 @@ function IngestionStatusBadge({
     return (
       <span
         className="inline-flex items-center gap-1 rounded-full bg-bg-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-3"
-        title="Embeddings removed — Retrain to make this file searchable again."
+        title="Excluded from context — Include in context to make this file searchable again."
       >
         <Unplug className="h-3 w-3" strokeWidth={2} />
-        Untrained
+        Excluded
       </span>
     );
   }
   return (
     <span className="inline-flex items-center gap-1 rounded-full bg-bg-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-3">
       <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
-      {status === "processing" ? "Training" : "Queued"}
+      {status === "processing" ? "Adding" : "Queued"}
     </span>
   );
 }
@@ -314,37 +317,38 @@ export default function KnowledgeCorePage() {
     onError: () => toast.error("Failed to delete file."),
   });
 
-  // Force a fresh chunk + embed pass on a single file. Available to
-  // any owner — the BE blocks the call if the file is mid-ingestion
-  // (status='processing') so we don't race the worker. After the
-  // POST returns, the polling refetchInterval picks up the new
-  // 'Queued'/'Training' badge automatically.
+  // Re-run chunk + embed on a single file so it's available to chat /
+  // arena again. Available to any owner — the BE blocks the call if
+  // the file is mid-ingestion (status='processing') so we don't race
+  // the worker. After the POST returns, the polling refetchInterval
+  // picks up the new 'Queued'/'Adding' badge automatically.
   const reingestMutation = useMutation({
     mutationFn: (fileId: string) => reingestKnowledgeFile(fileId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-folder"] });
-      toast.success("Re-training started.");
+      toast.success("Adding to context.");
     },
     onError: (err: Error) =>
-      toast.error(err.message || "Failed to re-train this file."),
+      toast.error(err.message || "Failed to include this file in context."),
   });
 
-  // Inverse of Retrain: drop the file's embeddings so chat RAG stops
-  // surfacing it, but keep the row + disk copy so Download / Retrain
-  // still work. BE gates on owner + mid-ingestion same way Retrain
-  // does, so we share the same disabled rule on the menu item.
+  // Inverse of "Include in context": drop the file's embeddings so
+  // chat RAG stops surfacing it, but keep the row + disk copy so
+  // Download and re-include still work. BE gates on owner + mid-
+  // ingestion the same way the include path does, so we share the
+  // same disabled rule on the menu item.
   const untrainMutation = useMutation({
     mutationFn: (fileId: string) => untrainKnowledgeFile(fileId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-folder"] });
-      toast.success("File untrained — embeddings removed.");
+      toast.success("Excluded from context.");
     },
     onError: (err: Error) =>
-      toast.error(err.message || "Failed to untrain this file."),
+      toast.error(err.message || "Failed to exclude this file from context."),
   });
 
   // Admin-only PATCH to flip a file's visibility between 'all' and
@@ -825,7 +829,7 @@ export default function KnowledgeCorePage() {
                     }
                   >
                     <RotateCw className="mr-2 h-3.5 w-3.5" />
-                    Retrain
+                    Include in context
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onSelect={() => untrainMutation.mutate(file.id)}
@@ -836,7 +840,7 @@ export default function KnowledgeCorePage() {
                     }
                   >
                     <Unplug className="mr-2 h-3.5 w-3.5" />
-                    Untrain
+                    Exclude from context
                   </DropdownMenuItem>
                   {isAdmin && (
                     <DropdownMenuItem

--- a/apps/web/src/app/(app)/knowledge-core/page.tsx
+++ b/apps/web/src/app/(app)/knowledge-core/page.tsx
@@ -40,8 +40,11 @@ import {
   type KnowledgeFolder,
   type KnowledgeFileVisibility,
   type KnowledgeRecentFile,
+  type KnowledgeUploadNameConflict,
+  type NameConflictAction,
 } from "@/lib/api";
 import { useAuth } from "@/components/providers";
+import { KnowledgeNameConflictDialog } from "@/components/knowledge-name-conflict-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -416,6 +419,17 @@ export default function KnowledgeCorePage() {
   // selection doesn't leak into the next one.
   const [stagedTeamIds, setStagedTeamIds] = useState<string[]>([]);
   const [stagedProjectIds, setStagedProjectIds] = useState<string[]>([]);
+  // Held between the first upload and the user's resolution choice.
+  // Mirrors the per-folder page state — see the comment there for
+  // the full lifecycle (`pendingConflicts` → dialog → re-upload).
+  const [pendingConflicts, setPendingConflicts] = useState<{
+    folderId: string;
+    conflicts: KnowledgeUploadNameConflict[];
+    files: File[];
+    visibility: KnowledgeFileVisibility;
+    teamIds: string[];
+    projectIds: string[];
+  } | null>(null);
 
   // Pull the user's team list once; only meaningful for company
   // profiles, but we render it lazily anyway (the picker only appears
@@ -449,35 +463,22 @@ export default function KnowledgeCorePage() {
     setUploading(true);
     try {
       const folderId = await getAllFilesFolderId();
-      const { uploaded, duplicates } = await uploadKnowledgeFiles(
-        folderId,
-        stagedFiles,
-        stagedVisibility,
-        stagedTeamIds,
-        stagedProjectIds,
-      );
-      await Promise.all([
-        queryClient.refetchQueries({ queryKey: ["knowledge-folders"] }),
-        queryClient.refetchQueries({ queryKey: ["knowledge-recent"] }),
-        queryClient.refetchQueries({ queryKey: ["knowledge-folder", folderId] }),
-      ]);
-      // Three outcomes: all-new, mixed, all-duplicates. The mixed
-      // case fires both toasts so the user sees what was actually
-      // saved AND why a few were skipped.
-      if (uploaded.length > 0) {
-        toast.success(`Uploaded ${uploaded.length} file(s) to All Files.`);
-      }
-      if (duplicates.length > 0) {
-        toast.info(
-          duplicates.length === 1
-            ? `"${duplicates[0].name}" is already in your Knowledge Core.`
-            : `${duplicates.length} file(s) were already in your Knowledge Core.`,
-          {
-            description: duplicates
-              .map((d) => `"${d.name}" → "${d.existing.folderName}"`)
-              .join("\n"),
-          },
-        );
+      const result = await runUpload(folderId, stagedFiles, undefined);
+      if (result.nameConflicts.length > 0) {
+        // Hold the conflict context so the resolution dialog can
+        // re-upload the right files in the right folder with the
+        // chosen actions. Don't clear the staged-files dialog yet
+        // either — actually do clear it so the user can stage a
+        // separate batch in parallel; the held `files` reference
+        // is enough to drive the resolution call.
+        setPendingConflicts({
+          folderId,
+          conflicts: result.nameConflicts,
+          files: stagedFiles,
+          visibility: stagedVisibility,
+          teamIds: stagedTeamIds,
+          projectIds: stagedProjectIds,
+        });
       }
       setStagedFiles([]);
       setStagedVisibility("all");
@@ -485,6 +486,112 @@ export default function KnowledgeCorePage() {
       setStagedProjectIds([]);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to upload files.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  /**
+   * Shared upload runner used by the initial submit AND the
+   * resolution-dialog re-submit. Calls the API, fires the
+   * regular success/duplicates toasts, and returns the BE
+   * response so the caller can drive name-conflict UX off the
+   * `nameConflicts[]` field. The toast for "files skipped after
+   * resolution" lives at the call site so it can suppress it on
+   * the initial pass (where conflicts are not yet "skipped" —
+   * they're "to be resolved").
+   */
+  const runUpload = async (
+    folderId: string,
+    files: File[],
+    actions: Record<string, NameConflictAction> | undefined,
+  ) => {
+    const result = await uploadKnowledgeFiles(
+      folderId,
+      files,
+      stagedVisibility,
+      stagedTeamIds,
+      stagedProjectIds,
+      actions,
+    );
+    await Promise.all([
+      queryClient.refetchQueries({ queryKey: ["knowledge-folders"] }),
+      queryClient.refetchQueries({ queryKey: ["knowledge-recent"] }),
+      queryClient.refetchQueries({
+        queryKey: ["knowledge-folder", folderId],
+      }),
+    ]);
+    if (result.uploaded.length > 0) {
+      toast.success(
+        `Uploaded ${result.uploaded.length} file(s) to All Files.`,
+      );
+    }
+    if (result.duplicates.length > 0) {
+      toast.info(
+        result.duplicates.length === 1
+          ? `"${result.duplicates[0].name}" is already in your Knowledge Core.`
+          : `${result.duplicates.length} file(s) were already in your Knowledge Core.`,
+        {
+          description: result.duplicates
+            .map((d) => `"${d.name}" → "${d.existing.folderName}"`)
+            .join("\n"),
+        },
+      );
+    }
+    return result;
+  };
+
+  const resolveNameConflicts = async (
+    actions: Record<string, NameConflictAction>,
+  ) => {
+    if (!pendingConflicts) return;
+    const conflictNames = new Set(
+      pendingConflicts.conflicts.map((c) => c.name),
+    );
+    const filesToResend = pendingConflicts.files.filter(
+      (f) => conflictNames.has(f.name) && actions[f.name] !== "skip",
+    );
+    const skippedCount = pendingConflicts.conflicts.filter(
+      (c) => (actions[c.name] ?? "skip") === "skip",
+    ).length;
+    const ctx = pendingConflicts;
+    setPendingConflicts(null);
+    if (filesToResend.length === 0) {
+      if (skippedCount > 0) toast.info(`Skipped ${skippedCount} file(s).`);
+      return;
+    }
+    setUploading(true);
+    try {
+      const result = await uploadKnowledgeFiles(
+        ctx.folderId,
+        filesToResend,
+        ctx.visibility,
+        ctx.teamIds,
+        ctx.projectIds,
+        actions,
+      );
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: ["knowledge-folders"] }),
+        queryClient.refetchQueries({ queryKey: ["knowledge-recent"] }),
+        queryClient.refetchQueries({
+          queryKey: ["knowledge-folder", ctx.folderId],
+        }),
+      ]);
+      if (result.uploaded.length > 0) {
+        toast.success(
+          `Uploaded ${result.uploaded.length} file(s) to All Files.`,
+        );
+      }
+      if (skippedCount > 0) {
+        toast.info(`Skipped ${skippedCount} file(s).`);
+      }
+      // If the BE still reports conflicts here, the user kept some
+      // as 'skip' — silent on this branch because the toast above
+      // already covers the skip count.
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to upload files.",
+      );
     } finally {
       setUploading(false);
     }
@@ -1152,6 +1259,15 @@ export default function KnowledgeCorePage() {
           queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
           queryClient.invalidateQueries({ queryKey: ["knowledge-folder"] });
         }}
+      />
+
+      {/* Soft warning when uploads collide on name (different
+          bytes) with existing files in this folder. */}
+      <KnowledgeNameConflictDialog
+        open={pendingConflicts !== null}
+        conflicts={pendingConflicts?.conflicts ?? []}
+        onResolve={resolveNameConflicts}
+        onCancel={() => setPendingConflicts(null)}
       />
     </div>
   );

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -55,13 +55,19 @@ export default function AppLayout({
             <Sidebar />
             <main className="flex min-w-0 flex-1 flex-col">
               <Appbar />
-              <div className="min-h-0 flex-1 overflow-auto">
+              <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
                 {/* `min-h-full flex-col` + `mt-auto` on Footer makes
                     the copyright row stick to the viewport bottom on
                     short pages and yield naturally on long ones.
                     Bottom padding lives on the Footer now, so we
-                    don't double-pad below the copyright line. */}
-                <div className="flex min-h-full flex-col px-6 pb-2">
+                    don't double-pad below the copyright line.
+                    `min-w-0` on the inner column lets long, no-wrap
+                    content (badges, identifiers, long names) collapse
+                    inside its container instead of pushing the whole
+                    page wider than the viewport — tables that need
+                    horizontal scroll wrap themselves in
+                    `overflow-x-auto` so they keep working. */}
+                <div className="flex min-h-full min-w-0 flex-col px-6 pb-2">
                   {children}
                   <Footer />
                 </div>

--- a/apps/web/src/app/(app)/observability/page.tsx
+++ b/apps/web/src/app/(app)/observability/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "recharts";
 
 import { Input } from "@/components/ui/input";
+import { Pagination } from "@/components/ui/pagination";
 import {
   PageTabs,
   PageTabsContent,
@@ -174,6 +175,9 @@ export default function ObservabilityPage() {
   const [search, setSearch] = useState("");
   const [eventType, setEventType] = useState<string>("all");
   const [page, setPage] = useState(1);
+  // Separate page state for the Team Analytics drilldown so paging
+  // the event log doesn't reset the team table and vice versa.
+  const [teamsPage, setTeamsPage] = useState(1);
 
   const [summary, setSummary] = useState<ObservabilitySummary | null>(null);
   const [tokenUsage, setTokenUsage] = useState<ObservabilityTokenUsage | null>(null);
@@ -363,6 +367,31 @@ export default function ObservabilityPage() {
     return Math.max(1, Math.ceil(events.total / events.pageSize));
   }, [events]);
 
+  // Team Analytics pagination: typical org has <20 teams, so the
+  // bar only ever fires for very large companies — but the
+  // Pagination component auto-hides on a single page, so wiring it
+  // is essentially free.
+  const TEAMS_PAGE_SIZE = 10;
+  const teamRows = teamAnalytics?.teams ?? [];
+  const teamsTotalPages = Math.max(
+    1,
+    Math.ceil(teamRows.length / TEAMS_PAGE_SIZE),
+  );
+  const pagedTeamRows = useMemo(
+    () =>
+      teamRows.slice(
+        (teamsPage - 1) * TEAMS_PAGE_SIZE,
+        teamsPage * TEAMS_PAGE_SIZE,
+      ),
+    [teamRows, teamsPage],
+  );
+  useEffect(() => {
+    setTeamsPage(1);
+  }, [range]);
+  useEffect(() => {
+    if (teamsPage > teamsTotalPages) setTeamsPage(teamsTotalPages);
+  }, [teamsPage, teamsTotalPages]);
+
   if (forbidden) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-border-2 bg-bg-white px-6 py-16 text-center">
@@ -529,7 +558,7 @@ export default function ObservabilityPage() {
                 </tr>
               </thead>
               <tbody>
-                {teamAnalytics.teams.map((t, i) => (
+                {pagedTeamRows.map((t, i) => (
                   <tr
                     key={`${t.teamId ?? "personal"}-${i}`}
                     className="border-b border-border-2 last:border-b-0 hover:bg-bg-1/40"
@@ -556,6 +585,11 @@ export default function ObservabilityPage() {
                 ))}
               </tbody>
             </table>
+            <Pagination
+              page={teamsPage}
+              totalPages={teamsTotalPages}
+              onPageChange={setTeamsPage}
+            />
           </div>
         ) : (
           <div className="rounded-md border border-dashed border-border-2 bg-bg-1/40 px-4 py-6 text-center text-[13px] text-text-3">
@@ -628,30 +662,11 @@ export default function ObservabilityPage() {
         </div>
 
         {events && events.total > events.pageSize && (
-          <div className="flex items-center justify-between border-t border-border-2 pt-3 text-[12px] text-text-2">
-            <span>
-              {(events.page - 1) * events.pageSize + 1}–
-              {Math.min(events.page * events.pageSize, events.total)} of {events.total}
-            </span>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                disabled={page <= 1}
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                className="h-8 cursor-pointer rounded border border-border-2 px-3 text-text-1 transition-colors hover:border-primary-6 disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                Previous
-              </button>
-              <button
-                type="button"
-                disabled={page >= totalPages}
-                onClick={() => setPage((p) => p + 1)}
-                className="h-8 cursor-pointer rounded border border-border-2 px-3 text-text-1 transition-colors hover:border-primary-6 disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                Next
-              </button>
-            </div>
-          </div>
+          <Pagination
+            page={page}
+            totalPages={totalPages}
+            onPageChange={(next) => setPage(next)}
+          />
         )}
       </section>
 

--- a/apps/web/src/app/(app)/observability/page.tsx
+++ b/apps/web/src/app/(app)/observability/page.tsx
@@ -42,6 +42,7 @@ import {
 import {
   fetchObservabilityCostByProvider,
   fetchObservabilityEvents,
+  fetchObservabilityEventsExport,
   fetchObservabilityGuardrailActivity,
   fetchObservabilitySummary,
   fetchObservabilityTeamAnalytics,
@@ -277,24 +278,85 @@ export default function ObservabilityPage() {
     };
   }, [range, search, eventType, page, forbidden]);
 
-  const handleExport = () => {
-    if (!events?.events?.length) {
-      toast.error("Nothing to export.");
-      return;
+  const [exporting, setExporting] = useState(false);
+
+  // Tell the appbar Export CSV button whether there's anything to
+  // export. Tracks `events.total` (the BE-reported full count for the
+  // current filters) — not `events.events.length`, which is only the
+  // current page. Re-fires on every state change so the appbar stays
+  // in sync with filters / pagination / refetches.
+  useEffect(() => {
+    const hasRows = (events?.total ?? 0) > 0;
+    window.dispatchEvent(
+      new CustomEvent("observability:export-enabled", { detail: hasRows }),
+    );
+  }, [events]);
+
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent("observability:export-busy", { detail: exporting }),
+    );
+  }, [exporting]);
+
+  /**
+   * CSV export fetches the *un-paginated* event set from the BE so
+   * the resulting file covers every row matching the current filters
+   * — not just the 25 rendered on the current page of the table.
+   * Capped server-side at 10k rows; if the cap was hit the toast
+   * tells the admin to narrow the range so they don't end up with a
+   * silently-truncated CSV.
+   */
+  const handleExport = async () => {
+    if (exporting) return;
+    setExporting(true);
+    const exportToastId = toast.loading("Preparing CSV…");
+    try {
+      const data = await fetchObservabilityEventsExport({
+        range,
+        search: search.trim() || undefined,
+        eventType: eventType === "all" ? undefined : eventType,
+      });
+      if (data.events.length === 0) {
+        toast.error("Nothing to export with these filters.", {
+          id: exportToastId,
+        });
+        return;
+      }
+      const csv = eventsToCsv(data.events);
+      const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      downloadCsv(`observability-${range}-${ts}.csv`, csv);
+      if (data.truncated) {
+        toast.warning(
+          `Exported ${data.events.length.toLocaleString()} of ${data.total.toLocaleString()} rows. Narrow the range or filters to get the rest.`,
+          { id: exportToastId },
+        );
+      } else {
+        toast.success(
+          `Exported ${data.events.length.toLocaleString()} row${data.events.length === 1 ? "" : "s"}.`,
+          { id: exportToastId },
+        );
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Couldn't export events.",
+        { id: exportToastId },
+      );
+    } finally {
+      setExporting(false);
     }
-    const csv = eventsToCsv(events.events);
-    const ts = new Date().toISOString().replace(/[:.]/g, "-");
-    downloadCsv(`observability-${range}-${ts}.csv`, csv);
   };
 
   // Appbar's Export CSV button dispatches this event.
   useEffect(() => {
-    const onExport = () => handleExport();
+    const onExport = () => {
+      void handleExport();
+    };
     window.addEventListener("observability:export", onExport);
     return () => window.removeEventListener("observability:export", onExport);
-    // handleExport closes over `events` and `range`; re-bind when they change.
+    // handleExport closes over `range`/`search`/`eventType`/`exporting`;
+    // re-bind on each change so the latest filters reach the BE.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [events, range]);
+  }, [range, search, eventType, exporting]);
 
   const totalPages = useMemo(() => {
     if (!events) return 1;

--- a/apps/web/src/app/(app)/observability/page.tsx
+++ b/apps/web/src/app/(app)/observability/page.tsx
@@ -661,7 +661,7 @@ export default function ObservabilityPage() {
           </table>
         </div>
 
-        {events && events.total > events.pageSize && (
+        {events && (
           <Pagination
             page={page}
             totalPages={totalPages}

--- a/apps/web/src/app/(app)/resources/page.tsx
+++ b/apps/web/src/app/(app)/resources/page.tsx
@@ -144,7 +144,7 @@ export default function ResourcesPage() {
         </div>
 
         <p className="max-w-[672px] text-[15px] leading-[1.5]">
-          Access enterprise-grade tools and training to build, optimize, and
+          Access enterprise-grade tools and resources to build, optimize, and
           master AI prompts for procurement workflows. Designed specifically
           for Fortune 500 teams.
         </p>

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -52,6 +52,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Pagination } from "@/components/ui/pagination";
 import Link from "next/link";
 import {
   fetchTeam,
@@ -467,6 +468,66 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     };
   }, [team]);
 
+  // Client-side pagination for the three team-details tables. State
+  // lives ABOVE the loading/error early returns so the Rules of Hooks
+  // hold across render branches; the slices themselves operate on
+  // empty arrays until `team` resolves and are harmless. PAGE_SIZE
+  // matches the Figma pagination comp (`Centered page numbers/
+  // Desktop`) — 10 rows per page.
+  const PAGE_SIZE = 10;
+  const [subteamsPage, setSubteamsPage] = useState(1);
+  const [membersPage, setMembersPage] = useState(1);
+  const [guardrailsPage, setGuardrailsPage] = useState(1);
+
+  const subteamsTotalPages = Math.max(
+    1,
+    Math.ceil(subteams.length / PAGE_SIZE),
+  );
+  const pagedSubteams = useMemo(
+    () =>
+      subteams.slice(
+        (subteamsPage - 1) * PAGE_SIZE,
+        subteamsPage * PAGE_SIZE,
+      ),
+    [subteams, subteamsPage],
+  );
+  useEffect(() => {
+    if (subteamsPage > subteamsTotalPages) setSubteamsPage(subteamsTotalPages);
+  }, [subteamsPage, subteamsTotalPages]);
+
+  const members = team?.members ?? [];
+  const membersTotalPages = Math.max(
+    1,
+    Math.ceil(members.length / PAGE_SIZE),
+  );
+  const pagedMembers = useMemo(
+    () =>
+      members.slice(
+        (membersPage - 1) * PAGE_SIZE,
+        membersPage * PAGE_SIZE,
+      ),
+    [members, membersPage],
+  );
+  useEffect(() => {
+    if (membersPage > membersTotalPages) setMembersPage(membersTotalPages);
+  }, [membersPage, membersTotalPages]);
+
+  const guardrailsTotalPages = Math.max(
+    1,
+    Math.ceil(guardrails.length / PAGE_SIZE),
+  );
+  const pagedGuardrails = useMemo(
+    () =>
+      guardrails.slice(
+        (guardrailsPage - 1) * PAGE_SIZE,
+        guardrailsPage * PAGE_SIZE,
+      ),
+    [guardrails, guardrailsPage],
+  );
+  useEffect(() => {
+    if (guardrailsPage > guardrailsTotalPages) setGuardrailsPage(guardrailsTotalPages);
+  }, [guardrailsPage, guardrailsTotalPages]);
+
   if (isLoading) return <div className="flex items-center justify-center py-24"><Loader2 className="h-8 w-8 animate-spin text-text-3" /></div>;
   if (error || !team) return <div className="flex items-center justify-center py-24"><p className="text-text-3">Failed to load team.</p></div>;
 
@@ -777,7 +838,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                 </tr>
               </thead>
               <tbody>
-                {subteams.map((sub) => {
+                {pagedSubteams.map((sub) => {
                   const subBudget = sub.monthlyBudgetCents / 100;
                   const subSpent = sub.spentCents / 100;
                   const subRemaining = subBudget - subSpent;
@@ -886,6 +947,12 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                 })}
               </tbody>
             </table>
+            <Pagination
+              page={subteamsPage}
+              totalPages={subteamsTotalPages}
+              onPageChange={setSubteamsPage}
+              className="px-4"
+            />
           </div>
         )}
       </div>
@@ -943,7 +1010,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                 </tr>
               </thead>
               <tbody>
-                {team.members.map((m) => {
+                {pagedMembers.map((m) => {
                   const capLabel =
                     m.monthlyCapCents == null
                       ? "No cap"
@@ -1094,6 +1161,12 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
               </tbody>
             </table>
           </div>
+          <Pagination
+            page={membersPage}
+            totalPages={membersTotalPages}
+            onPageChange={setMembersPage}
+            className="bg-bg-white px-4"
+          />
         </div>
       </div>
 
@@ -1137,7 +1210,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                   </tr>
                 </thead>
                 <tbody>
-                  {guardrails.map((g) => (
+                  {pagedGuardrails.map((g) => (
                     <tr key={g.id} className="h-14 border-b border-bg-1">
                       <td className="px-4 align-middle">
                         <div className="flex items-center gap-2">
@@ -1234,6 +1307,12 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                 </tbody>
               </table>
             </div>
+            <Pagination
+              page={guardrailsPage}
+              totalPages={guardrailsTotalPages}
+              onPageChange={setGuardrailsPage}
+              className="px-4"
+            />
           </div>
         )}
       </div>

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -593,7 +593,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
     <div className="space-y-6">
       {/* ── Description + Budget card ──────────────────────────────── */}
       <div className="bg-bg-white rounded p-4 space-y-[30px]">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex items-center gap-3 min-w-0 flex-1">
             <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-full overflow-hidden">
               <svg viewBox="0 0 80 80" className="h-full w-full">
@@ -633,7 +633,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
               they're contextual to the form state. The "enter edit
               mode" pencil lives up in the appbar. */}
           {editing && (
-            <div className="flex items-center gap-2 shrink-0 mt-1">
+            <div className="flex flex-wrap items-center gap-2 shrink-0 self-end sm:mt-1">
               <Button
                 variant="outline"
                 className="h-10 gap-2 border-border-2"
@@ -742,7 +742,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
 
       {/* ── Subteams ──────────────────────────────────────────────── */}
       <div className="space-y-3">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-[18px] font-bold text-text-1">Subteams</p>
           {canManageTeam ? (
             <AddSubteamDialog parentTeamId={id}>
@@ -764,15 +764,15 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
           <div className="bg-bg-white rounded overflow-hidden"><div className="px-4 py-8 text-center text-[16px] text-text-3">No subteams yet.</div></div>
         ) : (
           <div className="overflow-x-auto bg-bg-white rounded">
-            <table className="w-full min-w-[800px]">
+            <table className="w-full min-w-[480px] md:min-w-[640px] lg:min-w-[800px]">
               <thead>
                 <tr className="h-[33px] border-b border-bg-1">
                   <th className="px-4 text-left align-middle text-[13px] font-normal text-text-2">Team</th>
-                  <th className="px-4 text-left align-middle text-[13px] font-normal text-text-2">Description</th>
+                  <th className="hidden px-4 text-left align-middle text-[13px] font-normal text-text-2 md:table-cell">Description</th>
                   <th className="px-4 text-left align-middle text-[13px] font-normal text-text-2">Monthly Budget</th>
                   <th className="px-4 text-left align-middle text-[13px] font-normal text-text-2">Spent / Remaining</th>
-                  <th className="px-4 text-left align-middle text-[13px] font-normal text-text-2">Projected</th>
-                  <th className="px-4 text-left align-middle text-[13px] font-normal text-text-2">Members</th>
+                  <th className="hidden px-4 text-left align-middle text-[13px] font-normal text-text-2 lg:table-cell">Projected</th>
+                  <th className="hidden px-4 text-left align-middle text-[13px] font-normal text-text-2 sm:table-cell">Members</th>
                   <th className="px-4 text-right align-middle text-[13px] font-normal text-text-2">Actions</th>
                 </tr>
               </thead>
@@ -787,7 +787,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                   return (
                     <tr key={sub.id} className="h-14 border-b border-bg-1 transition-colors hover:bg-bg-1/50">
                       <td className="px-4 align-middle text-base text-text-1 whitespace-nowrap">{sub.name}</td>
-                      <td className="px-4 align-middle text-sm text-text-2 whitespace-nowrap">{sub.description ?? "—"}</td>
+                      <td className="hidden px-4 align-middle text-sm text-text-2 whitespace-nowrap md:table-cell">{sub.description ?? "—"}</td>
                       <td className="px-4 align-middle text-sm text-text-1 whitespace-nowrap">
                         {subBudget > 0 ? formatCurrency(subBudget) : "—"}
                       </td>
@@ -810,7 +810,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                           <span className="text-sm text-text-1">—</span>
                         )}
                       </td>
-                      <td className="px-4 align-middle whitespace-nowrap">
+                      <td className="hidden px-4 align-middle whitespace-nowrap lg:table-cell">
                         {subBudget > 0 ? (
                           <div className="flex items-center gap-1.5">
                             <span className="text-sm text-text-1">{formatCurrency(subProjected)}</span>
@@ -822,7 +822,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                           <span className="text-sm text-text-1">—</span>
                         )}
                       </td>
-                      <td className="px-4 align-middle">
+                      <td className="hidden px-4 align-middle sm:table-cell">
                         {sub.members.length > 0 ? (
                           <div className="flex items-center">
                             <div className="flex -space-x-2">
@@ -912,7 +912,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
             </p>
           </div>
         )}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-[18px] font-bold text-text-1">Users</p>
           {canManageTeam ? (
             <InviteMemberDialog teamId={id}>
@@ -932,13 +932,13 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
         </div>
         <div className="rounded overflow-hidden">
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[640px]">
+            <table className="w-full min-w-[420px] md:min-w-[640px]">
               <thead>
                 <tr>
-                  <th className="bg-bg-white px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 w-[300px]">Name</th>
-                  <th className="bg-bg-white px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2">Email</th>
+                  <th className="bg-bg-white px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 w-[180px] sm:w-[260px] lg:w-[300px]">Name</th>
+                  <th className="hidden bg-bg-white px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 sm:table-cell">Email</th>
                   <th className="bg-bg-white px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2">Role</th>
-                  <th className="bg-bg-white px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 w-[180px]">Monthly Cap</th>
+                  <th className="hidden bg-bg-white px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 w-[180px] lg:table-cell">Monthly Cap</th>
                   <th className="bg-bg-white px-4 py-2 text-center align-middle text-[13px] font-normal text-text-2 w-[93px]">Actions</th>
                 </tr>
               </thead>
@@ -958,7 +958,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                         : "text-text-3";
                   return (
                     <tr key={m.id} className="h-14 border-b border-border-2">
-                      <td className="bg-bg-white px-4 align-middle w-[300px]">
+                      <td className="bg-bg-white px-4 align-middle w-[180px] sm:w-[260px] lg:w-[300px]">
                         <div className="flex items-center gap-2.5">
                           <UserAvatar name={memberName(m)} picture={m.userPicture} size={24} />
                           <span className="flex items-center gap-2 text-[16px] text-text-1 whitespace-nowrap">
@@ -982,7 +982,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                           </span>
                         </div>
                       </td>
-                      <td className="bg-bg-white px-4 align-middle text-[16px] text-text-1 whitespace-nowrap">{m.email}</td>
+                      <td className="hidden bg-bg-white px-4 align-middle text-[16px] text-text-1 whitespace-nowrap sm:table-cell">{m.email}</td>
                       <td className="bg-bg-white px-4 align-middle">
                         {m.role === "owner" ? (
                           <span className="inline-flex h-8 items-center rounded-md border border-border-2 bg-bg-1 px-3 text-sm font-medium text-text-1">
@@ -1038,7 +1038,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                           </Select>
                         )}
                       </td>
-                      <td className="bg-bg-white px-4 align-middle w-[180px]">
+                      <td className="hidden bg-bg-white px-4 align-middle w-[180px] lg:table-cell">
                         <span
                           className={`text-[14px] ${capTone}`}
                           title="Use Actions → Change monthly cap to edit"
@@ -1102,7 +1102,7 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
 
       {/* ── Guardrails ────────────────────────────────────────────── */}
       <div className="space-y-2">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-[18px] font-bold text-text-1">Guardrails</p>
           {canManageTeam ? (
             <AddGuardrailDialog teamId={id}>
@@ -1125,13 +1125,13 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
         ) : (
           <div className="bg-bg-white rounded overflow-hidden">
             <div className="overflow-x-auto">
-              <table className="w-full min-w-[700px]">
+              <table className="w-full min-w-[420px] md:min-w-[560px] lg:min-w-[700px]">
                 <thead>
                   <tr>
                     <th className="px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2">Name</th>
-                    <th className="px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2">Type</th>
-                    <th className="px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2">Severity</th>
-                    <th className="px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2">Triggers</th>
+                    <th className="hidden px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 md:table-cell">Type</th>
+                    <th className="hidden px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 lg:table-cell">Severity</th>
+                    <th className="hidden px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 lg:table-cell">Triggers</th>
                     <th className="px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 w-[167px]">Status</th>
                     <th className="px-4 py-2 text-left align-middle text-[13px] font-normal text-text-2 w-[93px]">Actions</th>
                   </tr>
@@ -1152,8 +1152,8 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                           )}
                         </div>
                       </td>
-                      <td className="px-4 align-middle">
-                        <div className="flex gap-2.5">
+                      <td className="hidden px-4 align-middle md:table-cell">
+                        <div className="flex flex-wrap gap-2.5">
                           {g.type.split(",").map((t) => (
                             <span key={t} className="rounded-lg bg-bg-2 px-2 py-1 text-[13px] text-text-3 whitespace-nowrap">
                               {t.trim()}
@@ -1161,10 +1161,10 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
                           ))}
                         </div>
                       </td>
-                      <td className="px-4 align-middle">
+                      <td className="hidden px-4 align-middle lg:table-cell">
                         <span className="rounded-lg bg-bg-1 px-2 py-1 text-[13px] text-text-3">{g.severity}</span>
                       </td>
-                      <td className="px-4 align-middle text-[16px] text-text-1">
+                      <td className="hidden px-4 align-middle text-[16px] text-text-1 lg:table-cell">
                         {g.triggers.toLocaleString()}
                       </td>
                       <td className="px-4 align-middle w-[167px]">

--- a/apps/web/src/app/(app)/teams/[id]/page.tsx
+++ b/apps/web/src/app/(app)/teams/[id]/page.tsx
@@ -890,9 +890,6 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
         )}
       </div>
 
-      {/* ── AI Provider Keys (team-scoped BYOK) ───────────────────── */}
-      <TeamIntegrationsSection teamId={id} canManage={canManageTeam} />
-
       {/* ── Users ─────────────────────────────────────────────────── */}
       <div className="space-y-3">
         {/* Over-allocation soft warning. Soft because chat-time gate
@@ -1099,6 +1096,9 @@ export default function TeamDetailPage({ params }: { params: Promise<{ id: strin
           </div>
         </div>
       </div>
+
+      {/* ── AI Provider Keys ──────────────────────────────────────── */}
+      <TeamIntegrationsSection teamId={id} canManage={canManageTeam} />
 
       {/* ── Guardrails ────────────────────────────────────────────── */}
       <div className="space-y-2">

--- a/apps/web/src/app/setup-profile/layout.tsx
+++ b/apps/web/src/app/setup-profile/layout.tsx
@@ -96,8 +96,8 @@ export default function SetupProfileLayout({
   // Snapshotted ONCE on mount via a ref. Step 6's submit invalidates
   // ["auth","me"], which would flip onboardingCompleted to true mid-
   // flow; if we re-evaluated on every change we'd redirect away from
-  // the "Training your AI…" progress screen before it had a chance to
-  // poll. Step 6 owns the post-success redirect itself.
+  // the "Setting up your AI…" progress screen before it had a chance
+  // to poll. Step 6 owns the post-success redirect itself.
   const guardRanRef = useRef(false);
   // Tri-state guard:
   //   "checking" — initial; we don't yet know if this visitor is

--- a/apps/web/src/app/setup-profile/step-6/page.tsx
+++ b/apps/web/src/app/setup-profile/step-6/page.tsx
@@ -57,13 +57,14 @@ function hasAllowedExtension(name: string) {
 
 /**
  * Phases of the step-6 submit flow:
- *  - `idle`     — user is choosing files, primary CTA visible
- *  - `training` — onboarding API succeeded, ingestion is running in
- *                 the background, FE is polling /ingestion-status
- *  - `done`     — ingestion finished (or had nothing to ingest); we
- *                 redirect on this transition
+ *  - `idle`      — user is choosing files, primary CTA visible
+ *  - `preparing` — onboarding API succeeded, ingestion (chunking +
+ *                  embedding into the RAG index) is running in the
+ *                  background, FE is polling /ingestion-status
+ *  - `done`      — ingestion finished (or had nothing to ingest);
+ *                  we redirect on this transition
  */
-type SubmitPhase = "idle" | "training" | "done";
+type SubmitPhase = "idle" | "preparing" | "done";
 
 export default function SetupProfileStep6Page() {
   const router = useRouter();
@@ -170,9 +171,10 @@ export default function SetupProfileStep6Page() {
         // redirect right away so the path stays as fast as it was.
         finishAndRedirect();
       } else {
-        // Switch to the "Training your AI…" screen; the polling query
-        // below transitions us to `done` once ingestion finishes.
-        setPhase("training");
+        // Switch to the "Setting up your AI…" screen; the polling
+        // query below transitions us to `done` once ingestion
+        // finishes.
+        setPhase("preparing");
       }
     },
     onError: (err: Error) => {
@@ -191,13 +193,13 @@ export default function SetupProfileStep6Page() {
     window.location.href = target;
   };
 
-  // Poll ingestion status only while the user is on the training
+  // Poll ingestion status only while the user is on the preparing
   // screen. `refetchInterval` returns false on terminal state to
   // stop hammering the API.
   const ingestionQuery = useQuery<IngestionStatusResponse>({
     queryKey: ["onboarding", "ingestion-status"],
     queryFn: getOnboardingIngestionStatus,
-    enabled: phase === "training",
+    enabled: phase === "preparing",
     refetchInterval: (query) =>
       query.state.data && !query.state.data.inProgress ? false : 1500,
   });
@@ -205,7 +207,7 @@ export default function SetupProfileStep6Page() {
   // Two-phase transition so the "Your AI is ready" copy actually
   // gets a chance to render before we navigate away.
   //
-  // Pass 1: flip phase training → done as soon as the poll reports
+  // Pass 1: flip phase preparing → done as soon as the poll reports
   //   inProgress=false. No timer scheduled here.
   // Pass 2: once phase is `done`, schedule the redirect. The
   //   previous single-effect version returned the setTimeout's
@@ -213,7 +215,7 @@ export default function SetupProfileStep6Page() {
   //   clearing the timer right after we set it and leaving the
   //   user stranded on "Your AI is ready" with no redirect.
   useEffect(() => {
-    if (phase !== "training") return;
+    if (phase !== "preparing") return;
     const data = ingestionQuery.data;
     if (data && !data.inProgress) {
       setPhase("done");
@@ -226,7 +228,7 @@ export default function SetupProfileStep6Page() {
     return () => clearTimeout(t);
   }, [phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (phase === "training" || phase === "done") {
+  if (phase === "preparing" || phase === "done") {
     const data = ingestionQuery.data;
     const total = data?.total ?? filesAtSubmitRef.current;
     const completed = (data?.done ?? 0) + (data?.failed ?? 0);
@@ -259,12 +261,12 @@ export default function SetupProfileStep6Page() {
 
           <div className="flex flex-col gap-2 text-center">
             <h1 className="text-[28px] font-bold leading-tight text-text-1">
-              {allDone ? "Your AI is ready" : "Training your AI…"}
+              {allDone ? "Your AI is ready" : "Setting up your AI…"}
             </h1>
             <p className="text-[15px] font-normal leading-snug text-text-2">
               {allDone
                 ? "Knowledge Core is initialized. Redirecting to your workspace."
-                : "We're chunking and embedding your uploads so the assistant can draw on them. This usually takes under a minute."}
+                : "We're adding your documents to your AI's context so the assistant can draw on them. This usually takes under a minute."}
             </p>
           </div>
 
@@ -311,11 +313,11 @@ export default function SetupProfileStep6Page() {
                   </span>
                   <span className="text-[11px] uppercase tracking-wide text-text-3">
                     {doc.status === "done"
-                      ? "Trained"
+                      ? "Added"
                       : doc.status === "failed"
                         ? "Skipped"
                         : doc.status === "processing"
-                          ? "Processing"
+                          ? "Adding"
                           : "Queued"}
                   </span>
                 </li>
@@ -357,8 +359,8 @@ export default function SetupProfileStep6Page() {
               Initialize your Knowledge Core
             </h1>
             <p className="text-[18px] font-normal leading-snug text-text-2 text-center">
-              Upload documents to train your enterprise AI on your internal
-              expertise and institutional knowledge.
+              Upload documents so your enterprise AI can answer using
+              your internal expertise and institutional knowledge.
             </p>
           </div>
 

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -16,7 +16,10 @@ import {
   uploadProjectKnowledgeFiles,
   type DocumentGroup,
   type ProjectKnowledgeFile,
+  type KnowledgeUploadNameConflict,
+  type NameConflictAction,
 } from "@/lib/api";
+import { KnowledgeNameConflictDialog } from "@/components/knowledge-name-conflict-dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -164,6 +167,16 @@ export function AddDocumentDialog({
   /* Delete-confirm shared by both lists */
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
+  /* Held between an upload that hit same-name-different-content
+     collisions and the user's resolution choice. Powers the
+     KnowledgeNameConflictDialog below. Identical shape to the
+     two KC pages — see those for the lifecycle comment. */
+  const [pendingConflicts, setPendingConflicts] = useState<{
+    folderId: string;
+    conflicts: KnowledgeUploadNameConflict[];
+    files: File[];
+  } | null>(null);
+
   /* ── Queries ──────────────────────────────────────────────────── */
 
   // Legacy paste-text snippets (existing /documents data, plus
@@ -279,9 +292,16 @@ export function AddDocumentDialog({
       if (attachIds.length > 0) {
         await attachKnowledgeFiles(projectId, attachIds);
       }
-      return { uploadResult, attachedCount: attachIds.length };
+      // Pass the *original* File[] through so the resolution dialog
+      // can re-upload the conflicting ones without re-prompting the
+      // user via the OS file picker.
+      return {
+        uploadResult,
+        attachedCount: attachIds.length,
+        sourceFiles: selectedFiles,
+      };
     },
-    onSuccess: ({ uploadResult, attachedCount }) => {
+    onSuccess: ({ uploadResult, attachedCount, sourceFiles }) => {
       invalidate();
       queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
       queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
@@ -296,6 +316,7 @@ export function AddDocumentDialog({
 
       const uploadedCount = uploadResult?.uploaded.length ?? 0;
       const duplicates = uploadResult?.duplicates ?? [];
+      const nameConflicts = uploadResult?.nameConflicts ?? [];
       const totalAdded = uploadedCount + attachedCount;
       if (totalAdded > 0) {
         toast.success(
@@ -314,10 +335,74 @@ export function AddDocumentDialog({
           },
         );
       }
+      if (nameConflicts.length > 0 && uploadFolderId) {
+        setPendingConflicts({
+          folderId: uploadFolderId,
+          conflicts: nameConflicts,
+          files: sourceFiles,
+        });
+      }
     },
     onError: (err: Error) =>
       toast.error(err.message || "Failed to add files."),
   });
+
+  /**
+   * Re-upload the conflicting files with the user's per-name
+   * decisions. Same pattern as the two KC pages: drop 'skip's
+   * client-side and toast the skipped count, then post the rest
+   * with `nameConflictActions` so the BE can apply overwrites /
+   * "keep both" renames.
+   */
+  const resolveNameConflicts = async (
+    actions: Record<string, NameConflictAction>,
+  ) => {
+    if (!pendingConflicts) return;
+    const ctx = pendingConflicts;
+    setPendingConflicts(null);
+    const conflictNames = new Set(ctx.conflicts.map((c) => c.name));
+    const filesToResend = ctx.files.filter(
+      (f) => conflictNames.has(f.name) && actions[f.name] !== "skip",
+    );
+    const skippedCount = ctx.conflicts.filter(
+      (c) => (actions[c.name] ?? "skip") === "skip",
+    ).length;
+    if (filesToResend.length === 0) {
+      if (skippedCount > 0) toast.info(`Skipped ${skippedCount} file(s).`);
+      return;
+    }
+    try {
+      const result = await uploadProjectKnowledgeFiles(
+        projectId,
+        filesToResend,
+        {
+          folderId: ctx.folderId,
+          visibility: "project",
+          projectIds: [projectId],
+          nameConflictActions: actions,
+        },
+      );
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: ["knowledge-folders"] });
+      queryClient.invalidateQueries({ queryKey: ["knowledge-recent"] });
+      queryClient.invalidateQueries({
+        queryKey: ["knowledge-folder", ctx.folderId],
+      });
+      const addedAfterResolve = result.uploaded.length;
+      if (addedAfterResolve > 0) {
+        toast.success(
+          `Added ${addedAfterResolve} file${addedAfterResolve !== 1 ? "s" : ""} to project context.`,
+        );
+      }
+      if (skippedCount > 0) {
+        toast.info(`Skipped ${skippedCount} file(s).`);
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to add files.",
+      );
+    }
+  };
 
   const detachMutation = useMutation({
     mutationFn: (fileId: string) => detachKnowledgeFile(projectId, fileId),
@@ -377,6 +462,7 @@ export function AddDocumentDialog({
   /* ── Render ──────────────────────────────────────────────────── */
 
   return (
+    <>
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] gap-0 overflow-hidden p-0 sm:max-w-3xl">
         <DialogHeader className="border-b border-border-2 px-5 py-4 sm:px-6">
@@ -865,5 +951,15 @@ export function AddDocumentDialog({
         </div>
       </DialogContent>
     </Dialog>
+    {/* Sibling dialog. Sits outside the main dialog so closing
+        the parent doesn't unmount mid-resolution; both are
+        portalled by Radix anyway. */}
+    <KnowledgeNameConflictDialog
+      open={pendingConflicts !== null}
+      conflicts={pendingConflicts?.conflicts ?? []}
+      onResolve={resolveNameConflicts}
+      onCancel={() => setPendingConflicts(null)}
+    />
+    </>
   );
 }

--- a/apps/web/src/components/add-document-dialog.tsx
+++ b/apps/web/src/components/add-document-dialog.tsx
@@ -99,17 +99,17 @@ function IngestionBadge({ status }: { status: string }) {
   if (status === "done") {
     return (
       <span
-        title="Indexed for chat search"
+        title="Included in this project's context"
         className="inline-flex items-center gap-1 text-[11px] text-success-7"
       >
-        <CheckCircle2 className="h-3 w-3" /> Indexed
+        <CheckCircle2 className="h-3 w-3" /> In context
       </span>
     );
   }
   if (status === "failed") {
     return (
       <span
-        title="Couldn't be indexed"
+        title="Couldn't be added to context"
         className="inline-flex items-center gap-1 text-[11px] text-warning-7"
       >
         <AlertTriangle className="h-3 w-3" /> Skipped
@@ -119,16 +119,16 @@ function IngestionBadge({ status }: { status: string }) {
   if (status === "untrained") {
     return (
       <span
-        title="Embeddings removed — chat RAG ignores this file until the owner re-trains it."
+        title="Excluded from context — chat ignores this file until the owner includes it again from Knowledge Core."
         className="inline-flex items-center gap-1 text-[11px] text-text-3"
       >
-        <Unplug className="h-3 w-3" /> Untrained
+        <Unplug className="h-3 w-3" /> Excluded
       </span>
     );
   }
   return (
     <span className="inline-flex items-center gap-1 text-[11px] text-text-3">
-      <Loader2 className="h-3 w-3 animate-spin" /> Indexing…
+      <Loader2 className="h-3 w-3 animate-spin" /> Adding…
     </span>
   );
 }
@@ -188,9 +188,9 @@ export function AddDocumentDialog({
   });
 
   // KC files attached to this project. Poll while any attached
-  // file is mid-ingestion so the "Indexing…" badge flips to
-  // "Indexed" (or "Skipped") on its own — the user shouldn't have
-  // to close + reopen the dialog to see the worker finish.
+  // file is mid-ingestion so the "Adding…" badge flips to
+  // "In context" (or "Skipped") on its own — the user shouldn't
+  // have to close + reopen the dialog to see the worker finish.
   const { data: attachedFiles = [], isLoading: attachedLoading } = useQuery({
     queryKey: ["project-knowledge-files", projectId],
     queryFn: () => fetchProjectKnowledgeFiles(projectId),

--- a/apps/web/src/components/invite-member-dialog.tsx
+++ b/apps/web/src/components/invite-member-dialog.tsx
@@ -24,7 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-type TeamRole = "editor" | "viewer";
+type TeamRole = "admin" | "manager" | "editor" | "viewer";
 type OrgRole = "basic" | "advanced";
 
 function TeamInviteDialog({
@@ -119,6 +119,12 @@ function TeamInviteDialog({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value="admin">
+                  Admin — Full team management rights
+                </SelectItem>
+                <SelectItem value="manager">
+                  Manager — Manage members, budgets and integrations
+                </SelectItem>
                 <SelectItem value="editor">
                   Editor — Can edit projects and content
                 </SelectItem>

--- a/apps/web/src/components/knowledge-name-conflict-dialog.tsx
+++ b/apps/web/src/components/knowledge-name-conflict-dialog.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { FileText, AlertTriangle } from "lucide-react";
+import type {
+  KnowledgeUploadNameConflict,
+  NameConflictAction,
+} from "@/lib/api";
+
+interface Props {
+  open: boolean;
+  // Names the BE rejected as same-name-different-content in the
+  // target folder. Each entry has `existing.id` pointing at the
+  // prior row so the BE-side overwrite path can find it.
+  conflicts: KnowledgeUploadNameConflict[];
+  // Called with the user's per-name choice. Caller re-uploads ONLY
+  // the conflicting files with this map. Keys must match the names
+  // surfaced in `conflicts`.
+  onResolve: (actions: Record<string, NameConflictAction>) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Soft warning shown after the BE flagged same-name-different-content
+ * uploads. Lets the user decide per file: overwrite the prior row,
+ * keep both (BE renames the new one to "<base> (N).<ext>"), or skip
+ * the upload entirely. "Apply to all" shortcuts make a bulk decision
+ * possible without clicking every row.
+ *
+ * Intentionally a single shared component — the three upload entry
+ * points (Manage Context, root KC, KC folder page) all need the same
+ * UI and copy, so any tweak lands in one place.
+ */
+export function KnowledgeNameConflictDialog({
+  open,
+  conflicts,
+  onResolve,
+  onCancel,
+}: Props) {
+  // Per-name action. Defaults to 'skip' so a user who clicks "Apply"
+  // without touching the picker doesn't end up nuking anything they
+  // didn't explicitly opt into.
+  const [actions, setActions] = useState<Record<string, NameConflictAction>>(
+    {},
+  );
+
+  // Re-seed defaults whenever the conflict list changes (e.g. caller
+  // closed + reopened with a different batch). Keep prior choices
+  // for names that are still present so a user who toggled then
+  // toggled bulk doesn't lose their picks.
+  useEffect(() => {
+    setActions((prev) => {
+      const next: Record<string, NameConflictAction> = {};
+      for (const c of conflicts) {
+        next[c.name] = prev[c.name] ?? "skip";
+      }
+      return next;
+    });
+  }, [conflicts]);
+
+  const summary = useMemo(() => {
+    let overwrite = 0;
+    let keepBoth = 0;
+    let skip = 0;
+    for (const c of conflicts) {
+      const a = actions[c.name] ?? "skip";
+      if (a === "overwrite") overwrite++;
+      else if (a === "keep_both") keepBoth++;
+      else skip++;
+    }
+    return { overwrite, keepBoth, skip };
+  }, [actions, conflicts]);
+
+  const applyToAll = (action: NameConflictAction) => {
+    setActions(() => {
+      const next: Record<string, NameConflictAction> = {};
+      for (const c of conflicts) next[c.name] = action;
+      return next;
+    });
+  };
+
+  // Dialog is *only* meaningful with at least one conflict. If the
+  // caller mounts it empty, treat the next mount as a fresh start.
+  if (conflicts.length === 0) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+    >
+      <DialogContent className="max-h-[80vh] gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="border-b border-border-2 px-5 py-4 sm:px-6">
+          <DialogTitle className="flex items-center gap-2 text-base sm:text-lg">
+            <AlertTriangle className="h-4 w-4 text-warning-7" />
+            File name already in use
+          </DialogTitle>
+          <DialogDescription className="text-xs sm:text-sm">
+            {conflicts.length === 1
+              ? `A file named "${conflicts[0].name}" already exists in this folder with different content. Pick what to do.`
+              : `${conflicts.length} files share a name with existing files in this folder (different content). Pick what to do for each, or apply to all.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3 px-5 py-4 sm:px-6">
+          {conflicts.length > 1 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[12px] font-medium text-text-3">
+                Apply to all:
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 cursor-pointer text-xs"
+                onClick={() => applyToAll("overwrite")}
+              >
+                Overwrite
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 cursor-pointer text-xs"
+                onClick={() => applyToAll("keep_both")}
+              >
+                Keep both
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 cursor-pointer text-xs"
+                onClick={() => applyToAll("skip")}
+              >
+                Skip
+              </Button>
+            </div>
+          )}
+
+          <div className="overflow-hidden rounded-md border border-border-2">
+            <ScrollArea className="max-h-[44vh]">
+              <div className="divide-y divide-border-2">
+                {conflicts.map((c) => {
+                  const action = actions[c.name] ?? "skip";
+                  return (
+                    <div
+                      key={`${c.existing.id}-${c.name}`}
+                      className="flex flex-col gap-2 px-3 py-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        <FileText className="h-4 w-4 shrink-0 text-text-3" />
+                        <span className="min-w-0 flex-1 truncate text-sm text-text-1">
+                          {c.name}
+                        </span>
+                      </div>
+                      <div className="flex shrink-0 gap-1">
+                        <ChoicePill
+                          label="Overwrite"
+                          active={action === "overwrite"}
+                          tone="danger"
+                          onClick={() =>
+                            setActions((prev) => ({
+                              ...prev,
+                              [c.name]: "overwrite",
+                            }))
+                          }
+                        />
+                        <ChoicePill
+                          label="Keep both"
+                          active={action === "keep_both"}
+                          tone="primary"
+                          onClick={() =>
+                            setActions((prev) => ({
+                              ...prev,
+                              [c.name]: "keep_both",
+                            }))
+                          }
+                        />
+                        <ChoicePill
+                          label="Skip"
+                          active={action === "skip"}
+                          tone="neutral"
+                          onClick={() =>
+                            setActions((prev) => ({
+                              ...prev,
+                              [c.name]: "skip",
+                            }))
+                          }
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          </div>
+
+          <p className="text-[11px] leading-relaxed text-text-3">
+            <strong>Overwrite</strong> deletes the existing file (and its
+            chat embeddings) and replaces it with the new bytes.{" "}
+            <strong>Keep both</strong> saves the new file as
+            &ldquo;<em>name</em> (2).<em>ext</em>&rdquo; alongside the
+            existing one. <strong>Skip</strong> does nothing — the new
+            file is discarded.
+          </p>
+        </div>
+
+        <DialogFooter className="gap-2 border-t border-border-2 px-5 py-3 sm:px-6">
+          <span className="mr-auto text-[11px] text-text-3 sm:text-xs">
+            {summary.overwrite > 0 && `${summary.overwrite} overwrite · `}
+            {summary.keepBoth > 0 && `${summary.keepBoth} keep both · `}
+            {summary.skip > 0 && `${summary.skip} skip`}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            className="cursor-pointer"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="cursor-pointer bg-primary-6 hover:bg-primary-7"
+            onClick={() => onResolve(actions)}
+          >
+            Apply
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ChoicePill({
+  label,
+  active,
+  tone,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  tone: "danger" | "primary" | "neutral";
+  onClick: () => void;
+}) {
+  const activeClass =
+    tone === "danger"
+      ? "border-danger-6 bg-danger-1 text-danger-7"
+      : tone === "primary"
+        ? "border-primary-6 bg-primary-1 text-primary-7"
+        : "border-border-4 bg-bg-1 text-text-1";
+  const inactiveClass =
+    "border-border-2 bg-bg-white text-text-2 hover:border-border-4 hover:text-text-1";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex h-7 cursor-pointer items-center rounded-md border px-2.5 text-[12px] font-medium transition-colors ${
+        active ? activeClass : inactiveClass
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/web/src/components/layout/appbar.tsx
+++ b/apps/web/src/components/layout/appbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import {
@@ -743,6 +743,28 @@ const OBSERVABILITY_RANGES = [
 
 function ObservabilityAppbarSlot() {
   const [range, setRange] = useState<string>("7d");
+  // Page → appbar signal: enables / disables Export CSV based on
+  // whether the current filter set has any rows on the BE. Default
+  // disabled until the page reports a non-empty result, so the button
+  // can't be clicked before the first events fetch resolves.
+  const [exportEnabled, setExportEnabled] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  useEffect(() => {
+    const onEnabled = (e: Event) => {
+      const detail = (e as CustomEvent<boolean>).detail;
+      setExportEnabled(Boolean(detail));
+    };
+    const onExporting = (e: Event) => {
+      const detail = (e as CustomEvent<boolean>).detail;
+      setExporting(Boolean(detail));
+    };
+    window.addEventListener("observability:export-enabled", onEnabled);
+    window.addEventListener("observability:export-busy", onExporting);
+    return () => {
+      window.removeEventListener("observability:export-enabled", onEnabled);
+      window.removeEventListener("observability:export-busy", onExporting);
+    };
+  }, []);
   return (
     <>
       <Select
@@ -782,16 +804,24 @@ function ObservabilityAppbarSlot() {
       </Select>
       <Button
         variant="outline"
+        disabled={!exportEnabled || exporting}
         onClick={() =>
           window.dispatchEvent(new CustomEvent("observability:export"))
+        }
+        title={
+          exporting
+            ? "Preparing CSV…"
+            : exportEnabled
+              ? "Export the currently filtered events as CSV"
+              : "No events match the current filters"
         }
         // Project Button defaults to h-12 (size=default in this fork), so
         // the Time Range Select at h-9 looked shorter. Pin h-9 + matching
         // px-3 / text-sm so the two controls read as a pair.
-        className="h-9 shrink-0 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white px-3 text-sm font-normal text-text-1"
+        className="h-9 shrink-0 cursor-pointer gap-2 rounded-lg border-border-2 bg-bg-white px-3 text-sm font-normal text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Download className="h-4 w-4" />
-        Export CSV
+        {exporting ? "Exporting…" : "Export CSV"}
       </Button>
     </>
   );

--- a/apps/web/src/components/management/api-tab.tsx
+++ b/apps/web/src/components/management/api-tab.tsx
@@ -17,6 +17,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Pagination } from "@/components/ui/pagination";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -108,6 +109,21 @@ export function ApiTab() {
   }, [copyToast]);
 
   const keys = keysQuery.data ?? [];
+
+  // Page API keys — usually a small set (<20) so the Pagination
+  // component auto-hides on a single page, but power users can have
+  // many keys and the picker is the cheapest way to keep the table
+  // bounded.
+  const KEYS_PAGE_SIZE = 10;
+  const [keysPage, setKeysPage] = useState(1);
+  const keysTotalPages = Math.max(1, Math.ceil(keys.length / KEYS_PAGE_SIZE));
+  const pagedKeys = keys.slice(
+    (keysPage - 1) * KEYS_PAGE_SIZE,
+    keysPage * KEYS_PAGE_SIZE,
+  );
+  useEffect(() => {
+    if (keysPage > keysTotalPages) setKeysPage(keysTotalPages);
+  }, [keysPage, keysTotalPages]);
 
   return (
     <div className="py-5">
@@ -218,7 +234,7 @@ export function ApiTab() {
                     </td>
                   </tr>
                 )}
-              {keys.map((key) => (
+              {pagedKeys.map((key) => (
                 <tr
                   key={key.id}
                   className="h-14 border-b border-bg-1 last:border-0 transition-colors hover:bg-bg-1/50"
@@ -263,6 +279,12 @@ export function ApiTab() {
               ))}
             </tbody>
           </table>
+          <Pagination
+            page={keysPage}
+            totalPages={keysTotalPages}
+            onPageChange={setKeysPage}
+            className="px-4"
+          />
         </div>
       </div>
 

--- a/apps/web/src/components/management/catalog-tab.tsx
+++ b/apps/web/src/components/management/catalog-tab.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/api";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
+import { Pagination } from "@/components/ui/pagination";
 
 function getProvider(modelId: string): string {
   const idx = modelId.indexOf("/");
@@ -87,6 +88,30 @@ export function CatalogTab() {
       );
     });
   }, [catalog, search, provider]);
+
+  // Catalog can return 100s–1000s of models — pagination is necessary
+  // here, not just nice-to-have. Reset to page 1 whenever the filter
+  // set changes so the user always lands on populated rows.
+  const CATALOG_PAGE_SIZE = 25;
+  const [catalogPage, setCatalogPage] = useState(1);
+  useEffect(() => {
+    setCatalogPage(1);
+  }, [search, provider]);
+  const catalogTotalPages = Math.max(
+    1,
+    Math.ceil(filtered.length / CATALOG_PAGE_SIZE),
+  );
+  const pagedCatalog = useMemo(
+    () =>
+      filtered.slice(
+        (catalogPage - 1) * CATALOG_PAGE_SIZE,
+        catalogPage * CATALOG_PAGE_SIZE,
+      ),
+    [filtered, catalogPage],
+  );
+  useEffect(() => {
+    if (catalogPage > catalogTotalPages) setCatalogPage(catalogTotalPages);
+  }, [catalogPage, catalogTotalPages]);
 
   // Drop selections that are no longer visible (e.g. after the user
   // tightens search/provider filter). Avoids confusing "5 selected" while
@@ -296,7 +321,7 @@ export function CatalogTab() {
             </tr>
           </thead>
           <tbody className="divide-y divide-border-2">
-            {filtered.map((m) => (
+            {pagedCatalog.map((m) => (
               <CatalogRow
                 key={m.id}
                 model={m}
@@ -320,6 +345,12 @@ export function CatalogTab() {
             )}
           </tbody>
         </table>
+        <Pagination
+          page={catalogPage}
+          totalPages={catalogTotalPages}
+          onPageChange={setCatalogPage}
+          className="px-4"
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/management/company-tab.tsx
+++ b/apps/web/src/components/management/company-tab.tsx
@@ -38,6 +38,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Pagination } from "@/components/ui/pagination";
 import { useAuth } from "@/components/providers";
 import {
   deleteCompanyProfile,
@@ -326,6 +327,23 @@ export function CompanyTab() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profile]);
 
+  // Page the participants table — admins is usually small enough to
+  // skip. State must live above the loading / error / non-company
+  // early returns to satisfy the Rules of Hooks; the slice operates
+  // on an empty array until orgUsers resolves and is harmless.
+  const PARTICIPANTS_PAGE_SIZE = 10;
+  const [participantsPage, setParticipantsPage] = useState(1);
+  const participantsCount = orgUsers.filter((u) => u.role !== "admin").length;
+  const participantsTotalPages = Math.max(
+    1,
+    Math.ceil(participantsCount / PARTICIPANTS_PAGE_SIZE),
+  );
+  useEffect(() => {
+    if (participantsPage > participantsTotalPages) {
+      setParticipantsPage(participantsTotalPages);
+    }
+  }, [participantsPage, participantsTotalPages]);
+
   if (profileLoading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -392,6 +410,10 @@ export function CompanyTab() {
   // Everyone who isn't an admin — basic + advanced both land here.
   // They can view company-wide screens but not mutate org settings.
   const participants = orgUsers.filter((u) => u.role !== "admin");
+  const pagedParticipants = participants.slice(
+    (participantsPage - 1) * PARTICIPANTS_PAGE_SIZE,
+    participantsPage * PARTICIPANTS_PAGE_SIZE,
+  );
   const companyDisplay = profile.companyName?.trim() || "Unnamed company";
 
   return (
@@ -841,7 +863,7 @@ export function CompanyTab() {
                 </tr>
               </thead>
               <tbody>
-                {participants.map((u) => {
+                {pagedParticipants.map((u) => {
                   const display = u.name ?? u.email;
                   const badgeClass =
                     u.role === "advanced"
@@ -924,6 +946,12 @@ export function CompanyTab() {
               </tbody>
             </table>
           </div>
+          <Pagination
+            page={participantsPage}
+            totalPages={participantsTotalPages}
+            onPageChange={setParticipantsPage}
+            className="px-4"
+          />
         </div>
       </div>
 

--- a/apps/web/src/components/team-integrations-section.tsx
+++ b/apps/web/src/components/team-integrations-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   AlertTriangle,
   ArrowUpRight,
@@ -12,9 +12,7 @@ import {
 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import { useAuth } from "@/components/providers";
 import {
   fetchLinkableIntegrations,
   fetchTeamIntegrationLinks,
@@ -100,14 +98,16 @@ function iconForProvider(providerId: string): React.ReactNode {
  *   - Keys are not entered here. The banner steers admins back to the
  *     Integration tab as the single place to add / rotate / delete a
  *     personal BYOK row.
- *   - "Active for this team" lists everything currently linked, with
- *     a per-team Switch and (for caller-owned rows) an Unlink action.
- *     Rows linked by other admins are visible read-only; only their
- *     owner can remove the link, but anyone with team-edit rights
- *     can flip the per-team toggle.
- *   - "Your integrations" surfaces every caller-owned personal
- *     integration as a save-staged checkbox — pre-checked when
- *     already linked. Save commits the diff in a single round-trip.
+ *   - "Your AI Provider Keys" surfaces every caller-owned personal
+ *     integration as a Switch — default off (= not linked). Flipping
+ *     it on immediately links + activates the key for this team; off
+ *     unlinks. No save button: the toggle IS the commit, so a brand-
+ *     new team shows every available key idle until the admin opts
+ *     in per row.
+ *   - "Active for this team" surfaces links added by *other* admins
+ *     so the caller knows what's available beyond their own. A
+ *     per-team Switch pauses use without unlinking; only the link
+ *     owner can fully remove it.
  */
 export function TeamIntegrationsSection({
   teamId,
@@ -117,8 +117,6 @@ export function TeamIntegrationsSection({
   canManage: boolean;
 }) {
   const queryClient = useQueryClient();
-  const { user } = useAuth();
-  const callerId = user?.id ?? null;
 
   const linksKey = ["team-integration-links", teamId] as const;
   const linkableKey = ["team-linkable-integrations", teamId] as const;
@@ -132,55 +130,65 @@ export function TeamIntegrationsSection({
     queryFn: () => fetchLinkableIntegrations(teamId),
   });
 
-  // Save-staged picker state. Seeded from `linkable.alreadyLinked` so
-  // the first paint reflects the current backend set; re-seeded any
-  // time the linkable query refetches with a fresh server state so
-  // an outside change (another tab, another admin) doesn't leave the
-  // user staring at a phantom "unsaved" badge.
-  const [picked, setPicked] = useState<Set<string>>(new Set());
-  const initialPickedKey = useMemo(
-    () =>
-      linkable
+  // Per-row link toggle for caller's own integrations. Each toggle
+  // is its own immediate commit — no staged save / discard buttons —
+  // so a brand-new team can be configured by flipping the Switches
+  // one at a time without an extra "Save" click. Optimistic updates
+  // flip both caches (links + linkable) ahead of the request, rolling
+  // back on error so the Switch never enters its disabled state mid-
+  // flight.
+  //
+  // The full-set PUT endpoint is reused: we read the caller's current
+  // linked-ids from `linkable.alreadyLinked`, build the next set with
+  // the target id added or removed, and ship it. Other admins' links
+  // are *not* in this set and won't be touched (the BE scopes the
+  // delta to caller-owned rows defensively, but staying out of those
+  // ids in the request keeps the contract obvious).
+  const linkToggleMutation = useMutation({
+    mutationFn: ({
+      integrationId,
+      next,
+    }: {
+      integrationId: string;
+      next: boolean;
+    }) => {
+      const currentMineLinked = linkable
         .filter((l) => l.alreadyLinked)
-        .map((l) => l.integrationId)
-        .sort()
-        .join(","),
-    [linkable],
-  );
-  useEffect(() => {
-    setPicked(
-      new Set(
-        linkable
-          .filter((l) => l.alreadyLinked)
-          .map((l) => l.integrationId),
-      ),
-    );
-  }, [initialPickedKey, linkable]);
-
-  const initialPickedSet = useMemo(() => {
-    return new Set(
-      linkable
-        .filter((l) => l.alreadyLinked)
-        .map((l) => l.integrationId),
-    );
-  }, [linkable]);
-
-  const hasUnsavedChanges = useMemo(() => {
-    if (picked.size !== initialPickedSet.size) return true;
-    for (const id of picked) if (!initialPickedSet.has(id)) return true;
-    return false;
-  }, [picked, initialPickedSet]);
-
-  const saveMutation = useMutation({
-    mutationFn: () =>
-      setTeamIntegrationLinks(teamId, Array.from(picked)),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: linksKey });
-      queryClient.invalidateQueries({ queryKey: linkableKey });
-      toast.success("Team integrations updated.");
+        .map((l) => l.integrationId);
+      const target = next
+        ? Array.from(new Set([...currentMineLinked, integrationId]))
+        : currentMineLinked.filter((id) => id !== integrationId);
+      return setTeamIntegrationLinks(teamId, target);
     },
-    onError: (err: Error) =>
-      toast.error(err.message ?? "Couldn't save team integrations."),
+    onMutate: async ({ integrationId, next }) => {
+      await queryClient.cancelQueries({ queryKey: linkableKey });
+      await queryClient.cancelQueries({ queryKey: linksKey });
+      const prevLinkable =
+        queryClient.getQueryData<LinkableIntegration[]>(linkableKey);
+      const prevLinks =
+        queryClient.getQueryData<TeamIntegrationLink[]>(linksKey);
+      queryClient.setQueryData<LinkableIntegration[]>(linkableKey, (old) =>
+        old?.map((l) =>
+          l.integrationId === integrationId
+            ? { ...l, alreadyLinked: next }
+            : l,
+        ),
+      );
+      return { prevLinkable, prevLinks };
+    },
+    onError: (err: Error, _vars, ctx) => {
+      if (ctx?.prevLinkable) {
+        queryClient.setQueryData(linkableKey, ctx.prevLinkable);
+      }
+      if (ctx?.prevLinks) {
+        queryClient.setQueryData(linksKey, ctx.prevLinks);
+      }
+      toast.error(err.message ?? "Couldn't update team integrations.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: linkableKey });
+      queryClient.invalidateQueries({ queryKey: linksKey });
+    },
   });
 
   // Per-link enabled toggle. Optimistic update so the Switch never
@@ -281,145 +289,105 @@ export function TeamIntegrationsSection({
         <EmptyStateCta />
       ) : (
         <>
-          {/* Active for this team — current link set, including links
-              owned by other admins. Read-only checkbox state for
-              those; per-team Switch always works for any team
-              manager. */}
-          {links.length > 0 && (
-            <section className="flex flex-col gap-2">
-              <h3 className="text-[13px] font-semibold text-text-1">
-                Active for this team
-              </h3>
-              <ul className="flex flex-col divide-y divide-border-2 overflow-hidden rounded-lg border border-border-2 bg-bg-white">
-                {[...myLinks, ...othersLinks].map((link) => {
-                  const mine = link.ownerId === callerId;
-                  return (
-                    <li
-                      key={link.integrationId}
-                      className="flex items-center gap-3 px-4 py-3"
-                    >
-                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-bg-1">
-                        {iconForProvider(link.providerId)}
-                      </span>
-                      <div className="flex min-w-0 flex-1 flex-col">
-                        <span className="truncate text-[14px] font-medium text-text-1">
-                          {link.displayName}
-                          {link.isCustom && link.apiUrl ? (
-                            <span className="ml-2 text-[12px] font-normal text-text-3">
-                              {link.apiUrl}
-                            </span>
-                          ) : null}
-                        </span>
-                        <span className="text-[12px] text-text-3">
-                          {mine
-                            ? "Your key"
-                            : `by ${link.ownerName ?? "another admin"}`}
-                          {!link.hasApiKey && " · no API key set"}
-                          {!link.integrationEnabled &&
-                            " · disabled in Integration tab"}
-                        </span>
-                      </div>
-                      {canManage ? (
-                        <div className="flex shrink-0 items-center gap-3">
-                          <Switch
-                            checked={link.linkEnabled}
-                            onCheckedChange={(next) =>
-                              toggleMutation.mutate({
-                                integrationId: link.integrationId,
-                                next,
-                              })
-                            }
-                            aria-label={
-                              link.linkEnabled
-                                ? "Pause use on this team"
-                                : "Resume use on this team"
-                            }
-                          />
-                          <span className="w-12 text-right text-[12px] text-text-3">
-                            {link.linkEnabled ? "Active" : "Paused"}
-                          </span>
-                        </div>
-                      ) : (
-                        <span className="shrink-0 text-[12px] text-text-3">
-                          {link.linkEnabled ? "Active" : "Paused"}
-                        </span>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            </section>
-          )}
-
-          {/* Picker for caller's own integrations. Save-staged so
-              admin can untick three at once and commit in one
-              round-trip — important when each commit could rotate
-              chat routing for every team member. */}
+          {/* Picker for caller's own integrations. Each Switch is an
+              immediate commit — flipping it links / unlinks the key
+              for this team without a save step. Default off so a
+              brand-new team starts every key idle and the admin opts
+              in deliberately per provider. */}
           {canManage && linkable.length > 0 && (
             <section className="flex flex-col gap-2">
-              <div className="flex items-end justify-between gap-3">
-                <h3 className="text-[13px] font-semibold text-text-1">
-                  Your AI Provider Keys
-                </h3>
-                {hasUnsavedChanges && (
-                  <span className="text-[12px] text-text-3">
-                    Unsaved changes
-                  </span>
-                )}
-              </div>
+              <h3 className="text-[13px] font-semibold text-text-1">
+                Your AI Provider Keys
+              </h3>
               <ul className="flex flex-col divide-y divide-border-2 overflow-hidden rounded-lg border border-border-2 bg-bg-white">
                 {linkable.map((row) => (
                   <PickerRow
                     key={row.integrationId}
                     row={row}
-                    checked={picked.has(row.integrationId)}
-                    onToggle={(next) => {
-                      setPicked((prev) => {
-                        const out = new Set(prev);
-                        if (next) out.add(row.integrationId);
-                        else out.delete(row.integrationId);
-                        return out;
-                      });
-                    }}
+                    onToggle={(next) =>
+                      linkToggleMutation.mutate({
+                        integrationId: row.integrationId,
+                        next,
+                      })
+                    }
                   />
                 ))}
               </ul>
-              <div className="flex items-center justify-end gap-2 pt-1">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="cursor-pointer"
-                  disabled={!hasUnsavedChanges || saveMutation.isPending}
-                  onClick={() => setPicked(new Set(initialPickedSet))}
-                >
-                  Discard
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  className="cursor-pointer bg-primary-6 hover:bg-primary-7"
-                  disabled={!hasUnsavedChanges || saveMutation.isPending}
-                  onClick={() => saveMutation.mutate()}
-                >
-                  {saveMutation.isPending ? (
-                    <>
-                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                      Saving…
-                    </>
-                  ) : (
-                    "Save changes"
-                  )}
-                </Button>
-              </div>
             </section>
           )}
 
-          {canManage && noPersonalKeys && links.length === 0 && (
+          {/* Active for this team — only links added by OTHER admins.
+              Caller's own links live in the picker above with a
+              single Switch; surfacing them again here would just
+              create two Switches doing different things. The
+              per-team Switch on these rows pauses use without
+              touching the underlying key. */}
+          {othersLinks.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-[13px] font-semibold text-text-1">
+                Linked by other admins
+              </h3>
+              <ul className="flex flex-col divide-y divide-border-2 overflow-hidden rounded-lg border border-border-2 bg-bg-white">
+                {othersLinks.map((link) => (
+                  <li
+                    key={link.integrationId}
+                    className="flex items-center gap-3 px-4 py-3"
+                  >
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-bg-1">
+                      {iconForProvider(link.providerId)}
+                    </span>
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate text-[14px] font-medium text-text-1">
+                        {link.displayName}
+                        {link.isCustom && link.apiUrl ? (
+                          <span className="ml-2 text-[12px] font-normal text-text-3">
+                            {link.apiUrl}
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="text-[12px] text-text-3">
+                        by {link.ownerName ?? "another admin"}
+                        {!link.hasApiKey && " · no API key set"}
+                        {!link.integrationEnabled &&
+                          " · disabled in Integration tab"}
+                      </span>
+                    </div>
+                    {canManage ? (
+                      <div className="flex shrink-0 items-center gap-3">
+                        <Switch
+                          checked={link.linkEnabled}
+                          onCheckedChange={(next) =>
+                            toggleMutation.mutate({
+                              integrationId: link.integrationId,
+                              next,
+                            })
+                          }
+                          aria-label={
+                            link.linkEnabled
+                              ? "Pause use on this team"
+                              : "Resume use on this team"
+                          }
+                        />
+                        <span className="w-12 text-right text-[12px] text-text-3">
+                          {link.linkEnabled ? "Active" : "Paused"}
+                        </span>
+                      </div>
+                    ) : (
+                      <span className="shrink-0 text-[12px] text-text-3">
+                        {link.linkEnabled ? "Active" : "Paused"}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {canManage && noPersonalKeys && othersLinks.length === 0 && (
             <EmptyStateCta />
           )}
 
-          {canManage && noPersonalKeys && links.length > 0 && (
+          {canManage && noPersonalKeys && othersLinks.length > 0 && (
             <div className="flex items-start gap-3 rounded-lg border border-border-2 bg-bg-1/60 px-4 py-3 text-[13px] text-text-2">
               <PlugZap className="mt-0.5 h-4 w-4 shrink-0 text-text-3" />
               <div>
@@ -447,34 +415,30 @@ export function TeamIntegrationsSection({
 
 function PickerRow({
   row,
-  checked,
   onToggle,
 }: {
   row: LinkableIntegration;
-  checked: boolean;
   onToggle: (next: boolean) => void;
 }) {
-  // Disable + explain why when:
-  //   - the integration is master-off on the Integration tab, or
-  //   - another personal predef already holds this team's slot.
+  // Switch state mirrors the BE truth: `alreadyLinked` flips on a
+  // successful link / unlink (optimistically in onMutate, server-
+  // confirmed onSettled). No local component state — the row stays
+  // in sync with the cache even across refetches / cross-tab edits.
+  const checked = row.alreadyLinked;
+  // Disable + explain why when another personal predef of the
+  // caller's already holds this team's slot. (The master-off case is
+  // filtered out BE-side so we never see disabled integrations
+  // here — keep the guard anyway as defense in depth.)
   const masterOff = !row.integrationEnabled;
   const blocked = row.blockedByProvider;
   const disabled = (masterOff && !checked) || blocked;
   const reason = blocked
-    ? `Another ${row.providerId} key is already linked to this team. Unlink it first.`
+    ? `Another ${row.providerId} key is already linked to this team. Turn it off first.`
     : masterOff
-      ? "This integration is disabled on the Integration tab. Re-enable it there to link."
+      ? "Disabled on the Integration tab. Re-enable it there to use here."
       : null;
   return (
     <li className="flex items-center gap-3 px-4 py-3">
-      <input
-        type="checkbox"
-        className="h-4 w-4 cursor-pointer accent-primary-6 disabled:cursor-not-allowed"
-        checked={checked}
-        disabled={disabled}
-        onChange={(e) => onToggle(e.target.checked)}
-        aria-label={`Link ${row.displayName} to this team`}
-      />
       <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-bg-1">
         {iconForProvider(row.providerId)}
       </span>
@@ -489,8 +453,22 @@ function PickerRow({
         </span>
         <span className="text-[12px] text-text-3">
           {row.hasApiKey ? "Personal key" : "No API key set"}
-          {!row.integrationEnabled && " · disabled on Integration tab"}
           {reason && ` · ${reason}`}
+        </span>
+      </div>
+      <div className="flex shrink-0 items-center gap-3">
+        <Switch
+          checked={checked}
+          disabled={disabled}
+          onCheckedChange={(next) => onToggle(next)}
+          aria-label={
+            checked
+              ? `Unlink ${row.displayName} from this team`
+              : `Link ${row.displayName} to this team`
+          }
+        />
+        <span className="w-12 text-right text-[12px] text-text-3">
+          {checked ? "Active" : "Inactive"}
         </span>
       </div>
     </li>

--- a/apps/web/src/components/team-integrations-section.tsx
+++ b/apps/web/src/components/team-integrations-section.tsx
@@ -264,12 +264,6 @@ export function TeamIntegrationsSection({
           <p className="font-medium text-text-1">
             AI Provider Keys are configured in the Integration tab.
           </p>
-          <p className="mt-1 text-text-3">
-            Add or rotate keys there. Below, activate the ones you want
-            this team&apos;s members to use. Rotation on the Integration
-            tab applies everywhere a key is linked — no need to update
-            per team.
-          </p>
         </div>
         <Link
           href="/teams?tab=integration"

--- a/apps/web/src/components/team-integrations-section.tsx
+++ b/apps/web/src/components/team-integrations-section.tsx
@@ -1,27 +1,27 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 import {
-  BookOpen,
-  Check,
+  AlertTriangle,
+  ArrowUpRight,
   Info,
   KeyRound,
   Loader2,
-  Plus,
-  Trash2,
+  PlugZap,
 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { DisabledReasonTooltip } from "@/components/ui/tooltip";
 import { Switch } from "@/components/ui/switch";
-import { SettingsDialog } from "@/components/settings-dialog";
+import { useAuth } from "@/components/providers";
 import {
-  deleteTeamIntegration,
-  fetchTeamIntegrations,
-  updateTeamIntegration,
-  upsertTeamIntegration,
-  type IntegrationCard,
+  fetchLinkableIntegrations,
+  fetchTeamIntegrationLinks,
+  setTeamIntegrationLinkEnabled,
+  setTeamIntegrationLinks,
+  type LinkableIntegration,
+  type TeamIntegrationLink,
 } from "@/lib/api";
 
 /* ─── Icons ──────────────────────────────────────────────────────────── */
@@ -59,577 +59,56 @@ function BrandIcon({ color, letter }: { color: string; letter: string }) {
   );
 }
 
-function iconForHint(hint: string): React.ReactNode {
-  switch (hint) {
+function iconForProvider(providerId: string): React.ReactNode {
+  // Compact mapping of providerId → glyph. Mirrors the IntegrationTab
+  // visual treatment so a Gemini key looks the same here as it does
+  // on /teams?tab=integration. Custom rows fall through to the
+  // neutral KeyRound below.
+  switch (providerId) {
+    case "google":
     case "gemini":
       return <GeminiIcon />;
-    case "chatgpt":
+    case "openai":
       return <BrandIcon color="#10a37f" letter="G" />;
     case "deepseek":
       return <BrandIcon color="#1a73e8" letter="D" />;
     case "mistral":
       return <BrandIcon color="#f7931e" letter="M" />;
-    case "claude":
+    case "anthropic":
       return <BrandIcon color="#d97706" letter="C" />;
     case "perplexity":
       return <BrandIcon color="#20b2aa" letter="P" />;
     case "qwen":
       return <BrandIcon color="#7c3aed" letter="Q" />;
-    case "copilot":
+    case "cohere":
       return <BrandIcon color="#0078d4" letter="Co" />;
-    case "grok":
+    case "xai":
       return <BrandIcon color="#1a1a1a" letter="X" />;
     case "custom":
-      return <BrandIcon color="#64748b" letter="·" />;
     default:
-      return <BrandIcon color="#64748b" letter="·" />;
+      return <KeyRound className="h-4 w-4 text-text-3" />;
   }
-}
-
-/* ─── Edit Custom LLM dialog ─────────────────────────────────────────── */
-
-function EditTeamCustomLLMDialog({
-  teamId,
-  card,
-  canManage,
-  onClose,
-}: {
-  teamId: string;
-  card: IntegrationCard;
-  canManage: boolean;
-  onClose: () => void;
-}) {
-  const queryClient = useQueryClient();
-  // Seed the form from the saved values. apiKey starts blank because
-  // we never expose the stored secret — same pattern as the predefined
-  // dialog (Replace flow).
-  const [customName, setCustomName] = useState(card.displayName);
-  const [apiUrl, setApiUrl] = useState(card.apiUrl ?? "");
-  const [apiKey, setApiKey] = useState("");
-  const [enabled, setEnabled] = useState(card.isEnabled);
-  // Same hide-saved-key pattern as the predefined dialog. Reveal the
-  // input on Replace; Cancel reverts without touching the saved key.
-  const [editingKey, setEditingKey] = useState(!card.hasApiKey);
-
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      if (!card.id) {
-        throw new Error("Internal: custom card has no id.");
-      }
-      // Send only fields the admin actually changed. Sending undefined
-      // tells the BE to leave that field alone (matches the personal
-      // tab's update semantic).
-      const apiKeyForBE: string | null | undefined = !canManage
-        ? undefined
-        : editingKey && apiKey
-          ? apiKey
-          : undefined;
-      return updateTeamIntegration(teamId, card.id, {
-        isEnabled: enabled !== card.isEnabled ? enabled : undefined,
-        apiUrl:
-          apiUrl.trim() && apiUrl.trim() !== card.apiUrl
-            ? apiUrl.trim()
-            : undefined,
-        customName:
-          customName.trim() && customName.trim() !== card.displayName
-            ? customName.trim()
-            : undefined,
-        apiKey: apiKeyForBE,
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["team-integrations", teamId],
-      });
-      // Member pickers read effective models — refresh so the renamed
-      // alias label propagates.
-      queryClient.invalidateQueries({ queryKey: ["models", "effective"] });
-      toast.success(`${customName || "Custom LLM"} updated.`);
-      onClose();
-    },
-    onError: (err: Error) =>
-      toast.error(err.message ?? "Couldn't save Custom LLM."),
-  });
-
-  const canSubmit =
-    customName.trim().length > 0 && apiUrl.trim().length > 0;
-
-  return (
-    <SettingsDialog
-      open
-      onClose={onClose}
-      onApply={canManage ? () => saveMutation.mutate() : undefined}
-      applyLabel={saveMutation.isPending ? "Saving…" : "Apply"}
-      applyPending={saveMutation.isPending}
-      applyDisabled={!canManage || !canSubmit}
-      title={`${card.displayName} (Team Custom LLM)`}
-      description="Update the URL, key, or display name. The underlying model identifier is preserved so ongoing chats keep working."
-      headerIcon={iconForHint(card.iconHint)}
-      headerContent={
-        <Switch
-          checked={enabled}
-          disabled={!canManage}
-          onCheckedChange={setEnabled}
-        />
-      }
-    >
-      <div className="space-y-4">
-        <div className="flex items-start gap-2 rounded-lg border border-primary-3 bg-primary-1/40 px-3 py-2">
-          <Info className="h-4 w-4 shrink-0 text-primary-7 mt-0.5" />
-          <p className="text-[13px] text-primary-7 leading-snug">
-            Renaming changes only the label members see in the dropdown.
-            The model identifier stays the same so existing
-            conversations bound to it keep working.
-          </p>
-        </div>
-
-        <div>
-          <p className="text-[14px] font-normal text-text-2 mb-1.5">
-            Display name
-          </p>
-          <input
-            type="text"
-            value={customName}
-            onChange={(e) => setCustomName(e.target.value)}
-            disabled={!canManage}
-            className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[14px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:opacity-60 disabled:cursor-not-allowed"
-          />
-        </div>
-
-        <div>
-          <p className="text-[14px] font-normal text-text-2 mb-1.5">
-            API URL
-          </p>
-          <input
-            type="text"
-            value={apiUrl}
-            onChange={(e) => setApiUrl(e.target.value)}
-            disabled={!canManage}
-            className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[13px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:opacity-60 disabled:cursor-not-allowed"
-          />
-        </div>
-
-        <div className="space-y-2">
-          <p className="text-[14px] font-normal text-text-2">API key</p>
-          {card.hasApiKey && !editingKey && (
-            <div className="flex items-center gap-3 rounded-lg border border-success-3 bg-success-1/40 px-4 py-3">
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-success-7 text-white">
-                <Check className="h-4 w-4" strokeWidth={2.5} />
-              </span>
-              <div className="flex min-w-0 flex-1 flex-col">
-                <span className="text-[13px] font-semibold text-success-7">
-                  API key configured
-                </span>
-                <span className="flex items-center gap-1.5 text-[13px] text-text-2">
-                  <KeyRound className="h-3.5 w-3.5 text-text-3" />
-                  <span className="font-mono tracking-wide">
-                    ••••••••••••••••
-                  </span>
-                </span>
-              </div>
-              {canManage && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingKey(true);
-                    setApiKey("");
-                  }}
-                  className="text-[13px] font-medium text-primary-6 hover:underline"
-                >
-                  Replace
-                </button>
-              )}
-            </div>
-          )}
-          {(editingKey || !card.hasApiKey) && (
-            <>
-              <input
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={
-                  card.hasApiKey
-                    ? "Enter a new key to replace the saved one"
-                    : "Optional — leave blank for anonymous endpoints"
-                }
-                disabled={!canManage}
-                className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[16px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:opacity-60 disabled:cursor-not-allowed"
-              />
-              {card.hasApiKey && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingKey(false);
-                    setApiKey("");
-                  }}
-                  className="text-[13px] text-text-3 hover:underline"
-                >
-                  Cancel — keep the saved key
-                </button>
-              )}
-            </>
-          )}
-        </div>
-      </div>
-    </SettingsDialog>
-  );
-}
-
-/* ─── Add Custom LLM dialog ──────────────────────────────────────────── */
-
-function AddTeamCustomLLMDialog({
-  teamId,
-  onClose,
-}: {
-  teamId: string;
-  onClose: () => void;
-}) {
-  const queryClient = useQueryClient();
-  const [customName, setCustomName] = useState("");
-  const [apiUrl, setApiUrl] = useState("");
-  const [apiKey, setApiKey] = useState("");
-
-  const createMutation = useMutation({
-    mutationFn: () =>
-      upsertTeamIntegration(teamId, {
-        providerId: "custom",
-        apiUrl: apiUrl.trim(),
-        apiKey: apiKey.trim() || undefined,
-        customName: customName.trim(),
-        isEnabled: true,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["team-integrations", teamId],
-      });
-      // Models picker for team members reads from /models — invalidate
-      // so the new alias shows up without a page reload.
-      queryClient.invalidateQueries({ queryKey: ["models", "effective"] });
-      toast.success(`${customName || "Custom LLM"} added for this team.`);
-      onClose();
-    },
-    onError: (err: Error) =>
-      toast.error(err.message ?? "Couldn't add team Custom LLM."),
-  });
-
-  const canSubmit =
-    customName.trim().length > 0 && apiUrl.trim().length > 0;
-
-  return (
-    <SettingsDialog
-      open
-      onClose={onClose}
-      onApply={() => createMutation.mutate()}
-      applyLabel={createMutation.isPending ? "Adding…" : "Add"}
-      applyPending={createMutation.isPending}
-      applyDisabled={!canSubmit}
-      title="Add Custom LLM (Team)"
-      description="Register an OpenAI-compatible endpoint members can pick from the model dropdown."
-    >
-      <div className="space-y-4">
-        <div className="flex items-start gap-2 rounded-lg border border-primary-3 bg-primary-1/40 px-3 py-2">
-          <Info className="h-4 w-4 shrink-0 text-primary-7 mt-0.5" />
-          <p className="text-[13px] text-primary-7 leading-snug">
-            Members of this team will see this Custom LLM in their
-            model picker. Chat calls route through the URL below using
-            the (optional) shared API key. Per-member caps still apply.
-          </p>
-        </div>
-
-        <div>
-          <p className="text-[14px] font-normal text-text-2 mb-1.5">
-            Display name
-          </p>
-          <input
-            type="text"
-            value={customName}
-            onChange={(e) => setCustomName(e.target.value)}
-            placeholder="e.g. Local Llama 3.1"
-            className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[14px] text-text-1 placeholder:text-text-3 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
-          />
-          <p className="text-[12px] text-text-3 mt-1">
-            What members will see in the model dropdown.
-          </p>
-        </div>
-
-        <div>
-          <p className="text-[14px] font-normal text-text-2 mb-1.5">
-            API URL
-          </p>
-          <input
-            type="text"
-            value={apiUrl}
-            onChange={(e) => setApiUrl(e.target.value)}
-            placeholder="https://your-endpoint/v1"
-            className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[13px] text-text-1 placeholder:text-text-3 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
-          />
-        </div>
-
-        <div>
-          <p className="text-[14px] font-normal text-text-2 mb-1.5">
-            API key (optional)
-          </p>
-          <input
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="Leave blank if the endpoint accepts anonymous"
-            className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[16px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50"
-          />
-        </div>
-
-        <button
-          type="button"
-          className="inline-flex h-[40px] items-center gap-2 rounded-md border border-border-2 px-4 text-[14px] font-normal text-text-1 hover:bg-bg-1 transition-colors"
-          onClick={() =>
-            window.open(
-              "https://platform.openai.com/docs/api-reference/chat",
-              "_blank",
-              "noopener,noreferrer",
-            )
-          }
-        >
-          <BookOpen className="h-4 w-4 text-success-7" />
-          Integration documentation
-        </button>
-      </div>
-    </SettingsDialog>
-  );
-}
-
-/* ─── Configure dialog ───────────────────────────────────────────────── */
-
-function TeamProviderDialog({
-  teamId,
-  card,
-  canManage,
-  onClose,
-}: {
-  teamId: string;
-  card: IntegrationCard;
-  canManage: boolean;
-  onClose: () => void;
-}) {
-  const queryClient = useQueryClient();
-  const [useOwnKey, setUseOwnKey] = useState(card.hasApiKey);
-  const [apiKey, setApiKey] = useState("");
-  const [enabled, setEnabled] = useState(card.isEnabled);
-  // Mirror the personal Integration tab pattern: when a key is already
-  // saved, show a "configured" status panel by default and only reveal
-  // the input on Replace. Avoids overtyping a working key by accident.
-  const [editingKey, setEditingKey] = useState(!card.hasApiKey);
-
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      if (card.id) {
-        return updateTeamIntegration(teamId, card.id, {
-          isEnabled: enabled,
-          // Same 3-state semantic as the personal dialog: undefined →
-          // leave the saved key alone; null → explicit clear (when the
-          // admin unticks "Use the team's own API KEY"); string → save
-          // a new key.
-          apiKey: !useOwnKey
-            ? null
-            : editingKey && apiKey
-              ? apiKey
-              : undefined,
-        });
-      }
-      return upsertTeamIntegration(teamId, {
-        providerId: card.providerId,
-        apiKey: useOwnKey && apiKey ? apiKey : undefined,
-        isEnabled: enabled,
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["team-integrations", teamId],
-      });
-      toast.success(
-        editingKey && apiKey && useOwnKey
-          ? `${card.displayName} key saved for this team.`
-          : `${card.displayName} settings saved.`,
-      );
-      onClose();
-    },
-    onError: (err: Error) =>
-      toast.error(err.message ?? "Couldn't save team integration."),
-  });
-
-  const successRatePct = (card.stats.successRate * 100).toFixed(1);
-  // Disclaimer when the provider's BYOK can't be honored end-to-end yet
-  // (Anthropic native, Google native, …). The key is stored but chat
-  // routing falls back to OpenRouter — surface that to the admin.
-  const showCompatibilityNotice = !card.byokSupported && !card.isCustom;
-
-  return (
-    <SettingsDialog
-      open
-      onClose={onClose}
-      onApply={canManage ? () => saveMutation.mutate() : undefined}
-      applyLabel={saveMutation.isPending ? "Saving…" : "Apply"}
-      applyPending={saveMutation.isPending}
-      applyDisabled={!canManage}
-      title={card.displayName}
-      description={`Configure ${card.displayName} integration settings.`}
-      headerIcon={iconForHint(card.iconHint)}
-      headerContent={
-        <Switch
-          checked={enabled}
-          disabled={!canManage}
-          onCheckedChange={setEnabled}
-        />
-      }
-    >
-      <div className="space-y-5">
-        {showCompatibilityNotice && (
-          <div className="flex items-start gap-2 rounded-lg border border-warning-3 bg-warning-1/40 px-3 py-2">
-            <Info className="h-4 w-4 shrink-0 text-warning-7 mt-0.5" />
-            <p className="text-[13px] text-warning-7 leading-snug">
-              {card.displayName}&rsquo;s native API isn&rsquo;t
-              OpenAI-compatible yet, so a BYOK key here is stored but chat
-              calls still route through the WorkenAI default. We&rsquo;ll
-              honor it directly once native support lands.
-            </p>
-          </div>
-        )}
-
-        {/* Stats row */}
-        <div className="flex items-start gap-8">
-          <div>
-            <p className="text-[16px] font-normal text-text-1 mb-0.5">
-              Success rate:
-            </p>
-            <p className="text-[18px] font-bold text-text-1">{successRatePct}%</p>
-          </div>
-          <div>
-            <p className="text-[16px] font-normal text-text-1 mb-0.5">
-              API calls:
-            </p>
-            <p className="text-[18px] font-bold text-text-1">
-              {card.stats.apiCalls.toLocaleString()}
-            </p>
-          </div>
-          <div>
-            <p className="text-[16px] font-normal text-text-1 mb-0.5">
-              Peak / day:
-            </p>
-            <p className="text-[18px] font-bold text-text-1">
-              {card.stats.peakDailyCalls.toLocaleString()}
-              <span className="text-[13px] font-normal text-text-3 ml-2">
-                calls (30d max)
-              </span>
-            </p>
-          </div>
-        </div>
-
-        {/* WorkenAI default note */}
-        <div>
-          <p className="text-[14px] font-normal leading-[20px] text-text-2 mb-1.5">
-            Use WORKENAI API
-          </p>
-          <div className="w-full rounded-lg bg-bg-3 px-[17px] py-[13px] text-[15px] leading-[22px] text-text-1">
-            Additional costs on the WorkenAI subscription will be added.
-          </div>
-        </div>
-
-        {/* Team's own API key */}
-        <div className="space-y-2">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={useOwnKey}
-              disabled={!canManage}
-              onChange={(e) => {
-                setUseOwnKey(e.target.checked);
-                // Toggling off and back on resets the editor — keeps
-                // the "key already saved" path visible until the admin
-                // explicitly clicks Replace.
-                if (!e.target.checked) {
-                  setEditingKey(true);
-                  setApiKey("");
-                } else {
-                  setEditingKey(!card.hasApiKey);
-                }
-              }}
-              className="h-3.5 w-3.5 rounded-[5px] border border-border-4 accent-success-7 cursor-pointer disabled:cursor-not-allowed"
-            />
-            <span className="text-[14px] font-normal leading-[20px] text-text-2">
-              Use your own API KEY
-            </span>
-          </label>
-
-          {useOwnKey && card.hasApiKey && !editingKey && (
-            <div className="flex items-center gap-3 rounded-lg border border-success-3 bg-success-1/40 px-4 py-3">
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-success-7 text-white">
-                <Check className="h-4 w-4" strokeWidth={2.5} />
-              </span>
-              <div className="flex min-w-0 flex-1 flex-col">
-                <span className="text-[13px] font-semibold text-success-7">
-                  API key configured
-                </span>
-                <span className="flex items-center gap-1.5 text-[13px] text-text-2">
-                  <KeyRound className="h-3.5 w-3.5 text-text-3" />
-                  <span className="font-mono tracking-wide">
-                    ••••••••••••••••
-                  </span>
-                </span>
-              </div>
-              {canManage && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingKey(true);
-                    setApiKey("");
-                  }}
-                  className="text-[13px] font-medium text-primary-6 hover:underline"
-                >
-                  Replace
-                </button>
-              )}
-            </div>
-          )}
-
-          {useOwnKey && (editingKey || !card.hasApiKey) && (
-            <>
-              <input
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                disabled={!canManage}
-                placeholder={
-                  card.hasApiKey
-                    ? "Enter a new key to replace the saved one"
-                    : "Enter your API key"
-                }
-                className="w-full h-[50px] rounded-lg border border-border-3 bg-transparent px-[17px] py-[13px] text-[16px] leading-[24px] text-text-1 outline-none focus:border-ring focus:ring-[1px] focus:ring-ring/50 disabled:opacity-60 disabled:cursor-not-allowed"
-              />
-              {card.hasApiKey && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setEditingKey(false);
-                    setApiKey("");
-                  }}
-                  className="text-[13px] text-text-3 hover:underline"
-                >
-                  Cancel — keep the saved key
-                </button>
-              )}
-            </>
-          )}
-        </div>
-
-        <p className="text-[16px] font-normal leading-[24px] text-text-1">
-          API calls will incur a small Technology fee.
-        </p>
-      </div>
-    </SettingsDialog>
-  );
 }
 
 /* ─── Section ────────────────────────────────────────────────────────── */
 
+/**
+ * AI Provider Key management on the team-details page. Replaces the
+ * legacy add-a-key flow with a *picker* over the integrations the
+ * caller already configured on /teams?tab=integration:
+ *
+ *   - Keys are not entered here. The banner steers admins back to the
+ *     Integration tab as the single place to add / rotate / delete a
+ *     personal BYOK row.
+ *   - "Active for this team" lists everything currently linked, with
+ *     a per-team Switch and (for caller-owned rows) an Unlink action.
+ *     Rows linked by other admins are visible read-only; only their
+ *     owner can remove the link, but anyone with team-edit rights
+ *     can flip the per-team toggle.
+ *   - "Your integrations" surfaces every caller-owned personal
+ *     integration as a save-staged checkbox — pre-checked when
+ *     already linked. Save commits the diff in a single round-trip.
+ */
 export function TeamIntegrationsSection({
   teamId,
   canManage,
@@ -638,299 +117,407 @@ export function TeamIntegrationsSection({
   canManage: boolean;
 }) {
   const queryClient = useQueryClient();
-  const { data: cards = [], isLoading } = useQuery({
-    queryKey: ["team-integrations", teamId],
-    queryFn: () => fetchTeamIntegrations(teamId),
+  const { user } = useAuth();
+  const callerId = user?.id ?? null;
+
+  const linksKey = ["team-integration-links", teamId] as const;
+  const linkableKey = ["team-linkable-integrations", teamId] as const;
+
+  const { data: links = [], isLoading: linksLoading } = useQuery({
+    queryKey: linksKey,
+    queryFn: () => fetchTeamIntegrationLinks(teamId),
   });
-  const [openCard, setOpenCard] = useState<IntegrationCard | null>(null);
+  const { data: linkable = [], isLoading: linkableLoading } = useQuery({
+    queryKey: linkableKey,
+    queryFn: () => fetchLinkableIntegrations(teamId),
+  });
 
-  // Show only providers that are configured (have a key OR have ever been
-  // touched) plus an "Add Provider" button to bring in new ones. The full
-  // catalog lives in the dialog so the section stays focused on what the
-  // team actively uses.
-  const configured = cards.filter((c) => c.id !== null);
-  const unconfigured = cards.filter((c) => c.id === null);
+  // Save-staged picker state. Seeded from `linkable.alreadyLinked` so
+  // the first paint reflects the current backend set; re-seeded any
+  // time the linkable query refetches with a fresh server state so
+  // an outside change (another tab, another admin) doesn't leave the
+  // user staring at a phantom "unsaved" badge.
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const initialPickedKey = useMemo(
+    () =>
+      linkable
+        .filter((l) => l.alreadyLinked)
+        .map((l) => l.integrationId)
+        .sort()
+        .join(","),
+    [linkable],
+  );
+  useEffect(() => {
+    setPicked(
+      new Set(
+        linkable
+          .filter((l) => l.alreadyLinked)
+          .map((l) => l.integrationId),
+      ),
+    );
+  }, [initialPickedKey, linkable]);
 
-  // Cleanup: remove the row entirely. Drops the team's BYOK config for
-  // that provider — chat routing falls back to user-personal BYOK or
-  // OpenRouter on the next call. Surfaced as a trash icon on Custom
-  // LLM cards (mirrors the personal Integration tab).
-  const removeMutation = useMutation({
-    mutationFn: ({ integrationId }: { integrationId: string }) =>
-      deleteTeamIntegration(teamId, integrationId),
+  const initialPickedSet = useMemo(() => {
+    return new Set(
+      linkable
+        .filter((l) => l.alreadyLinked)
+        .map((l) => l.integrationId),
+    );
+  }, [linkable]);
+
+  const hasUnsavedChanges = useMemo(() => {
+    if (picked.size !== initialPickedSet.size) return true;
+    for (const id of picked) if (!initialPickedSet.has(id)) return true;
+    return false;
+  }, [picked, initialPickedSet]);
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      setTeamIntegrationLinks(teamId, Array.from(picked)),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["team-integrations", teamId],
-      });
-      toast.success("Team integration removed.");
+      queryClient.invalidateQueries({ queryKey: linksKey });
+      queryClient.invalidateQueries({ queryKey: linkableKey });
+      toast.success("Team integrations updated.");
     },
     onError: (err: Error) =>
-      toast.error(err.message ?? "Couldn't remove team integration."),
+      toast.error(err.message ?? "Couldn't save team integrations."),
   });
 
-  // Direct-from-card toggle with optimistic update. Same shape as the
-  // personal Integration tab: PATCH if the row exists, upsert
-  // otherwise so the first toggle on an unconfigured provider creates
-  // the team row. Cache flips ahead of the request so the Switch
-  // never shows its disabled cursor-not-allowed state mid-flight.
+  // Per-link enabled toggle. Optimistic update so the Switch never
+  // shows its disabled cursor-not-allowed state during the round
+  // trip; cache rolls back on error.
   const toggleMutation = useMutation({
-    mutationFn: ({ card, next }: { card: IntegrationCard; next: boolean }) => {
-      if (card.id) {
-        return updateTeamIntegration(teamId, card.id, { isEnabled: next });
-      }
-      return upsertTeamIntegration(teamId, {
-        providerId: card.providerId,
-        isEnabled: next,
-      });
-    },
-    onMutate: async ({ card, next }) => {
-      const key = ["team-integrations", teamId];
-      await queryClient.cancelQueries({ queryKey: key });
-      const previous = queryClient.getQueryData<IntegrationCard[]>(key);
-      queryClient.setQueryData<IntegrationCard[]>(key, (old) =>
-        old?.map((c) =>
-          c.providerId === card.providerId && c.id === card.id
-            ? { ...c, isEnabled: next }
-            : c,
+    mutationFn: ({
+      integrationId,
+      next,
+    }: {
+      integrationId: string;
+      next: boolean;
+    }) => setTeamIntegrationLinkEnabled(teamId, integrationId, next),
+    onMutate: async ({ integrationId, next }) => {
+      await queryClient.cancelQueries({ queryKey: linksKey });
+      const previous =
+        queryClient.getQueryData<TeamIntegrationLink[]>(linksKey);
+      queryClient.setQueryData<TeamIntegrationLink[]>(linksKey, (old) =>
+        old?.map((l) =>
+          l.integrationId === integrationId ? { ...l, linkEnabled: next } : l,
         ),
       );
       return { previous };
     },
     onError: (err: Error, _vars, ctx) => {
       if (ctx?.previous) {
-        queryClient.setQueryData(
-          ["team-integrations", teamId],
-          ctx.previous,
-        );
+        queryClient.setQueryData(linksKey, ctx.previous);
       }
       toast.error(err.message ?? "Couldn't toggle integration.");
     },
     onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["team-integrations", teamId],
-      });
+      queryClient.invalidateQueries({ queryKey: linksKey });
     },
   });
 
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const [customDialogOpen, setCustomDialogOpen] = useState(false);
+  const loading = linksLoading || linkableLoading;
+
+  // Cross-section split: caller-owned vs others' links. Caller-owned
+  // are managed via the picker checkboxes below; others' links show
+  // up here as read-only rows (the toggle still works because a team
+  // admin can pause use of another's key without owning it).
+  const callerOwnsIntegration = useMemo(() => {
+    const ids = new Set(linkable.map((l) => l.integrationId));
+    return (link: TeamIntegrationLink) => ids.has(link.integrationId);
+  }, [linkable]);
+
+  const othersLinks = links.filter((l) => !callerOwnsIntegration(l));
+  const myLinks = links.filter((l) => callerOwnsIntegration(l));
+
+  const noPersonalKeys = !loading && linkable.length === 0;
+  const noActivity = !loading && links.length === 0 && linkable.length === 0;
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-6">
-        <div className="space-y-1 max-w-2xl">
-          <p className="text-[18px] font-bold text-text-1">
+    <div className="flex flex-col gap-5">
+      <header className="flex items-end justify-between gap-3">
+        <div>
+          <h2 className="text-[18px] font-bold text-text-1">
             AI Provider Keys
-          </p>
-          <p className="text-[13px] text-text-3">
-            Share an API key with the whole team. Chat calls from any
-            member route through this key before falling back to their
-            personal BYOK or the WorkenAI default.
+          </h2>
+          <p className="mt-1 text-[13px] text-text-2">
+            Pick which of your personal keys this team can use for chat,
+            arena, and tooling.
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {canManage ? (
-            <>
-              <Button
-                variant="outline"
-                className="rounded-lg"
-                onClick={() => setCustomDialogOpen(true)}
-              >
-                <Plus className="h-4 w-4" />
-                Add Custom LLM
-              </Button>
-              <Button
-                variant="plusAction"
-                className="rounded-lg"
-                disabled={unconfigured.length === 0}
-                onClick={() => setPickerOpen(true)}
-              >
-                <Plus className="h-4 w-4 text-text-white" />
-                Add Provider Key
-              </Button>
-            </>
-          ) : (
-            <DisabledReasonTooltip
-              disabled
-              reason="Not available for basic users"
-            >
-              <Button
-                variant="plusAction"
-                className="rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
-                disabled
-              >
-                <Plus className="h-4 w-4 text-text-white" />
-                Add Provider Key
-              </Button>
-            </DisabledReasonTooltip>
-          )}
+      </header>
+
+      {/* Warning banner: keys are managed elsewhere. Always rendered
+          so the redirect to /teams?tab=integration is one click away,
+          even when the team already has links. */}
+      <div className="flex items-start gap-3 rounded-lg border border-warning-2 bg-warning-1/40 px-4 py-3">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-warning-7" />
+        <div className="flex-1 text-[13px] leading-relaxed text-text-2">
+          <p className="font-medium text-text-1">
+            AI Provider Keys are configured in the Integration tab.
+          </p>
+          <p className="mt-1 text-text-3">
+            Add or rotate keys there. Below, activate the ones you want
+            this team&apos;s members to use. Rotation on the Integration
+            tab applies everywhere a key is linked — no need to update
+            per team.
+          </p>
         </div>
+        <Link
+          href="/teams?tab=integration"
+          className="inline-flex shrink-0 items-center gap-1 rounded-md bg-bg-white px-3 py-1.5 text-[12px] font-medium text-text-1 transition-colors hover:bg-bg-1"
+        >
+          Manage keys
+          <ArrowUpRight className="h-3.5 w-3.5" />
+        </Link>
       </div>
 
-      {isLoading ? (
-        <div className="bg-bg-white rounded p-8 flex justify-center">
-          <Loader2 className="h-5 w-5 animate-spin text-text-3" />
+      {loading ? (
+        <div className="flex items-center gap-2 text-[13px] text-text-3">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading
+          integrations…
         </div>
-      ) : configured.length === 0 ? (
-        <div className="bg-bg-white rounded overflow-hidden">
-          <div className="px-4 py-8 text-center text-[16px] text-text-3">
-            No team-shared keys yet. Add one above to share a single
-            provider API key with all members.
-          </div>
-        </div>
+      ) : noActivity ? (
+        <EmptyStateCta />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {configured.map((card) => {
-            // Stable key: predefined → providerId (unique per team),
-            // custom → row id (multiple Custom LLMs share
-            // providerId="custom"). Without this, a card whose id
-            // transitions from null → uuid on first save would
-            // unmount/remount, visible as a flicker.
-            const cardKey = card.isCustom ? card.id! : card.providerId;
-            return (
-              <div
-                key={cardKey}
-                className="flex flex-col rounded-[4px] border border-border-3 bg-bg-white p-5 h-[165px] cursor-pointer hover:border-border-4 transition-colors"
-                onClick={() => setOpenCard(card)}
-              >
-                {/* Header: icon + name + toggle */}
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2 min-w-0">
-                    {iconForHint(card.iconHint)}
-                    <span className="truncate text-[16px] font-normal text-text-1">
-                      {card.displayName}
-                    </span>
-                  </div>
-                  <span onClick={(e) => e.stopPropagation()}>
-                    <Switch
-                      checked={card.isEnabled}
-                      onCheckedChange={(next) =>
-                        toggleMutation.mutate({ card, next })
-                      }
-                      disabled={!canManage}
-                    />
-                  </span>
-                </div>
-
-                {/* Persistent BYOK indicator */}
-                {card.hasApiKey && (
-                  <span
-                    className="mt-2 inline-flex w-fit items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[11px] font-medium text-success-7"
-                    title="A team-shared API key is saved for this provider"
-                  >
-                    <Check className="h-3 w-3" strokeWidth={2.5} />
-                    Key set
-                  </span>
-                )}
-
-                {/* Description */}
-                <p className="mt-2 text-[14px] font-normal text-text-2 line-clamp-2">
-                  {card.description}
-                </p>
-
-                {/* Footer: custom-only delete + Settings link */}
-                <div className="mt-auto flex items-center justify-between">
-                  {card.isCustom && card.id && canManage ? (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (
-                          confirm(
-                            `Remove the "${card.displayName}" Custom LLM? Members will lose access to this endpoint.`,
-                          )
-                        ) {
-                          removeMutation.mutate({ integrationId: card.id! });
-                        }
-                      }}
-                      disabled={removeMutation.isPending}
-                      className="text-[13px] text-danger-6 hover:underline inline-flex items-center gap-1 disabled:opacity-60"
-                      title="Delete custom LLM"
+        <>
+          {/* Active for this team — current link set, including links
+              owned by other admins. Read-only checkbox state for
+              those; per-team Switch always works for any team
+              manager. */}
+          {links.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-[13px] font-semibold text-text-1">
+                Active for this team
+              </h3>
+              <ul className="flex flex-col divide-y divide-border-2 overflow-hidden rounded-lg border border-border-2 bg-bg-white">
+                {[...myLinks, ...othersLinks].map((link) => {
+                  const mine = link.ownerId === callerId;
+                  return (
+                    <li
+                      key={link.integrationId}
+                      className="flex items-center gap-3 px-4 py-3"
                     >
-                      <Trash2 className="h-3.5 w-3.5" />
-                      Delete
-                      {card.boundAliasCount > 0 && (
-                        <span className="ml-1 rounded-full bg-danger-1 px-1.5 py-0 text-[10px] font-medium text-danger-6">
-                          {card.boundAliasCount}
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-bg-1">
+                        {iconForProvider(link.providerId)}
+                      </span>
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate text-[14px] font-medium text-text-1">
+                          {link.displayName}
+                          {link.isCustom && link.apiUrl ? (
+                            <span className="ml-2 text-[12px] font-normal text-text-3">
+                              {link.apiUrl}
+                            </span>
+                          ) : null}
+                        </span>
+                        <span className="text-[12px] text-text-3">
+                          {mine
+                            ? "Your key"
+                            : `by ${link.ownerName ?? "another admin"}`}
+                          {!link.hasApiKey && " · no API key set"}
+                          {!link.integrationEnabled &&
+                            " · disabled in Integration tab"}
+                        </span>
+                      </div>
+                      {canManage ? (
+                        <div className="flex shrink-0 items-center gap-3">
+                          <Switch
+                            checked={link.linkEnabled}
+                            onCheckedChange={(next) =>
+                              toggleMutation.mutate({
+                                integrationId: link.integrationId,
+                                next,
+                              })
+                            }
+                            aria-label={
+                              link.linkEnabled
+                                ? "Pause use on this team"
+                                : "Resume use on this team"
+                            }
+                          />
+                          <span className="w-12 text-right text-[12px] text-text-3">
+                            {link.linkEnabled ? "Active" : "Paused"}
+                          </span>
+                        </div>
+                      ) : (
+                        <span className="shrink-0 text-[12px] text-text-3">
+                          {link.linkEnabled ? "Active" : "Paused"}
                         </span>
                       )}
-                    </button>
-                  ) : (
-                    <span />
-                  )}
-                  <span className="text-[14px] font-normal text-text-3">
-                    {canManage ? "Settings" : "View"}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+
+          {/* Picker for caller's own integrations. Save-staged so
+              admin can untick three at once and commit in one
+              round-trip — important when each commit could rotate
+              chat routing for every team member. */}
+          {canManage && linkable.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <div className="flex items-end justify-between gap-3">
+                <h3 className="text-[13px] font-semibold text-text-1">
+                  Your AI Provider Keys
+                </h3>
+                {hasUnsavedChanges && (
+                  <span className="text-[12px] text-text-3">
+                    Unsaved changes
                   </span>
-                </div>
+                )}
               </div>
-            );
-          })}
-        </div>
-      )}
+              <ul className="flex flex-col divide-y divide-border-2 overflow-hidden rounded-lg border border-border-2 bg-bg-white">
+                {linkable.map((row) => (
+                  <PickerRow
+                    key={row.integrationId}
+                    row={row}
+                    checked={picked.has(row.integrationId)}
+                    onToggle={(next) => {
+                      setPicked((prev) => {
+                        const out = new Set(prev);
+                        if (next) out.add(row.integrationId);
+                        else out.delete(row.integrationId);
+                        return out;
+                      });
+                    }}
+                  />
+                ))}
+              </ul>
+              <div className="flex items-center justify-end gap-2 pt-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="cursor-pointer"
+                  disabled={!hasUnsavedChanges || saveMutation.isPending}
+                  onClick={() => setPicked(new Set(initialPickedSet))}
+                >
+                  Discard
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  className="cursor-pointer bg-primary-6 hover:bg-primary-7"
+                  disabled={!hasUnsavedChanges || saveMutation.isPending}
+                  onClick={() => saveMutation.mutate()}
+                >
+                  {saveMutation.isPending ? (
+                    <>
+                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                      Saving…
+                    </>
+                  ) : (
+                    "Save changes"
+                  )}
+                </Button>
+              </div>
+            </section>
+          )}
 
-      {/* Add-provider picker — lists all providers without a row yet. */}
-      {pickerOpen && (
-        <SettingsDialog
-          open
-          onClose={() => setPickerOpen(false)}
-          title="Add Provider Key"
-          description="Pick a provider to configure for the team."
-        >
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {unconfigured.map((card) => (
-              <button
-                key={card.providerId}
-                type="button"
-                onClick={() => {
-                  setPickerOpen(false);
-                  setOpenCard(card);
-                }}
-                className="flex items-center gap-2.5 rounded-lg border border-border-2 p-3 text-left hover:bg-bg-1 transition-colors"
-              >
-                {iconForHint(card.iconHint)}
-                <div className="min-w-0">
-                  <p className="text-[14px] font-medium text-text-1 truncate">
-                    {card.displayName}
-                  </p>
-                  <p className="text-[12px] text-text-3 truncate">
-                    {card.description}
-                  </p>
-                </div>
-              </button>
-            ))}
-            {unconfigured.length === 0 && (
-              <p className="col-span-full text-center text-[14px] text-text-3 py-4">
-                Every supported provider already has a team row. Configure
-                an existing one to set its key.
-              </p>
-            )}
-          </div>
-        </SettingsDialog>
-      )}
+          {canManage && noPersonalKeys && links.length === 0 && (
+            <EmptyStateCta />
+          )}
 
-      {openCard &&
-        (openCard.isCustom ? (
-          <EditTeamCustomLLMDialog
-            teamId={teamId}
-            card={openCard}
-            canManage={canManage}
-            onClose={() => setOpenCard(null)}
-          />
-        ) : (
-          <TeamProviderDialog
-            teamId={teamId}
-            card={openCard}
-            canManage={canManage}
-            onClose={() => setOpenCard(null)}
-          />
-        ))}
+          {canManage && noPersonalKeys && links.length > 0 && (
+            <div className="flex items-start gap-3 rounded-lg border border-border-2 bg-bg-1/60 px-4 py-3 text-[13px] text-text-2">
+              <PlugZap className="mt-0.5 h-4 w-4 shrink-0 text-text-3" />
+              <div>
+                You haven&apos;t configured any keys of your own yet — the
+                links above were added by other team admins. Add your
+                first key on the Integration tab to link it here.
+              </div>
+            </div>
+          )}
 
-      {customDialogOpen && (
-        <AddTeamCustomLLMDialog
-          teamId={teamId}
-          onClose={() => setCustomDialogOpen(false)}
-        />
+          {!canManage && (
+            <div className="flex items-start gap-3 rounded-lg border border-border-2 bg-bg-1/60 px-4 py-3 text-[13px] text-text-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-text-3" />
+              <div>
+                Read-only view. Only team owners, admins, managers, and
+                editors can link or unlink AI Provider Keys.
+              </div>
+            </div>
+          )}
+        </>
       )}
+    </div>
+  );
+}
+
+function PickerRow({
+  row,
+  checked,
+  onToggle,
+}: {
+  row: LinkableIntegration;
+  checked: boolean;
+  onToggle: (next: boolean) => void;
+}) {
+  // Disable + explain why when:
+  //   - the integration is master-off on the Integration tab, or
+  //   - another personal predef already holds this team's slot.
+  const masterOff = !row.integrationEnabled;
+  const blocked = row.blockedByProvider;
+  const disabled = (masterOff && !checked) || blocked;
+  const reason = blocked
+    ? `Another ${row.providerId} key is already linked to this team. Unlink it first.`
+    : masterOff
+      ? "This integration is disabled on the Integration tab. Re-enable it there to link."
+      : null;
+  return (
+    <li className="flex items-center gap-3 px-4 py-3">
+      <input
+        type="checkbox"
+        className="h-4 w-4 cursor-pointer accent-primary-6 disabled:cursor-not-allowed"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onToggle(e.target.checked)}
+        aria-label={`Link ${row.displayName} to this team`}
+      />
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-bg-1">
+        {iconForProvider(row.providerId)}
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-[14px] font-medium text-text-1">
+          {row.displayName}
+          {row.isCustom && row.apiUrl ? (
+            <span className="ml-2 text-[12px] font-normal text-text-3">
+              {row.apiUrl}
+            </span>
+          ) : null}
+        </span>
+        <span className="text-[12px] text-text-3">
+          {row.hasApiKey ? "Personal key" : "No API key set"}
+          {!row.integrationEnabled && " · disabled on Integration tab"}
+          {reason && ` · ${reason}`}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+function EmptyStateCta() {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border-3 bg-bg-1/40 px-6 py-10 text-center">
+      <PlugZap className="h-8 w-8 text-text-3" strokeWidth={1.5} />
+      <div className="flex flex-col gap-1">
+        <p className="text-[14px] font-medium text-text-1">
+          No AI Provider Keys yet
+        </p>
+        <p className="max-w-[420px] text-[12px] text-text-3">
+          Add your first key on the Integration tab — Anthropic, OpenAI,
+          Gemini, or a self-hosted endpoint. Once it&apos;s there, come
+          back to activate it for this team.
+        </p>
+      </div>
+      <Link
+        href="/teams?tab=integration"
+        className="inline-flex items-center gap-1 rounded-md bg-primary-6 px-3 py-1.5 text-[13px] font-medium text-text-white transition-colors hover:bg-primary-7"
+      >
+        Add your first key
+        <ArrowUpRight className="h-3.5 w-3.5" />
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useMemo } from "react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+interface PaginationProps {
+  /** 1-indexed current page. */
+  page: number;
+  /** Total pages — usually `Math.ceil(total / pageSize)`. */
+  totalPages: number;
+  onPageChange: (next: number) => void;
+  /**
+   * Hide the bar entirely when only one page exists. Defaults to true
+   * because a single-page "1" pill with disabled Prev/Next adds visual
+   * noise without giving the user anything to act on.
+   */
+  hideOnSinglePage?: boolean;
+  /** Visual sibling count on each side of the current page. Defaults
+   *  to 1 so 7 pages renders as `1 … 5 [6] 7 … 10` style layouts. */
+  siblingCount?: number;
+  className?: string;
+}
+
+/**
+ * Build the visible run of page numbers + ellipses. Matches the
+ * Figma comp's `1, 2, 3, …, 8, 9, 10` shape:
+ *  - first and last page always visible
+ *  - up to `siblingCount` pages on each side of the current page
+ *  - "…" placeholder where the run is non-contiguous
+ *
+ * Returns an array of items the renderer can map over: either a
+ * number (clickable page link) or the literal string `"ellipsis-l"`
+ * / `"ellipsis-r"` so React keys stay stable across re-renders.
+ */
+function paginationRange(
+  page: number,
+  totalPages: number,
+  siblingCount: number,
+): Array<number | "ellipsis-l" | "ellipsis-r"> {
+  // Tight ranges (≤ siblings*2 + first + last + 2 ellipses ≈ 7 by
+  // default) render every number — no ellipses needed.
+  const SHOW_ALL_THRESHOLD = siblingCount * 2 + 5;
+  if (totalPages <= SHOW_ALL_THRESHOLD) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const leftSibling = Math.max(page - siblingCount, 2);
+  const rightSibling = Math.min(page + siblingCount, totalPages - 1);
+  const showLeftEllipsis = leftSibling > 2;
+  const showRightEllipsis = rightSibling < totalPages - 1;
+
+  const out: Array<number | "ellipsis-l" | "ellipsis-r"> = [1];
+  if (showLeftEllipsis) out.push("ellipsis-l");
+  for (let p = leftSibling; p <= rightSibling; p++) out.push(p);
+  if (showRightEllipsis) out.push("ellipsis-r");
+  out.push(totalPages);
+  return out;
+}
+
+/**
+ * Pagination control matching Figma `Centered page numbers/Desktop`.
+ *
+ * The bar starts with a 1px top divider, then Previous on the left,
+ * the page-number run in the middle, and Next on the right —
+ * justify-between so the controls always pin to the edges of the
+ * surrounding card regardless of how many numbers are visible. The
+ * current page gets a 2px primary-blue top border (mirrors the
+ * Figma `#33AFF3` accent on the active number link).
+ */
+export function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+  hideOnSinglePage = true,
+  siblingCount = 1,
+  className,
+}: PaginationProps) {
+  const items = useMemo(
+    () => paginationRange(page, totalPages, siblingCount),
+    [page, totalPages, siblingCount],
+  );
+
+  if (totalPages <= 1 && hideOnSinglePage) return null;
+
+  const clampedPage = Math.min(Math.max(1, page), Math.max(1, totalPages));
+  const prevDisabled = clampedPage <= 1;
+  const nextDisabled = clampedPage >= totalPages;
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className={`flex w-full items-stretch justify-between border-t border-border-2 ${className ?? ""}`}
+    >
+      <StepLink
+        direction="prev"
+        disabled={prevDisabled}
+        onClick={() => onPageChange(clampedPage - 1)}
+      />
+
+      <ul className="flex items-stretch">
+        {items.map((item) => {
+          if (item === "ellipsis-l" || item === "ellipsis-r") {
+            return (
+              <li
+                key={item}
+                aria-hidden="true"
+                className="flex w-10 items-start justify-center border-t-2 border-transparent pt-4 text-[13px] text-text-3"
+              >
+                …
+              </li>
+            );
+          }
+          const isCurrent = item === clampedPage;
+          return (
+            <li key={item} className="flex">
+              <button
+                type="button"
+                onClick={() => {
+                  if (!isCurrent) onPageChange(item);
+                }}
+                aria-current={isCurrent ? "page" : undefined}
+                aria-label={`Page ${item}`}
+                className={`flex min-w-10 items-start justify-center border-t-2 px-4 pt-4 text-[13px] transition-colors ${
+                  isCurrent
+                    ? "cursor-default border-primary-6 font-medium text-text-1"
+                    : "cursor-pointer border-transparent text-text-3 hover:border-border-4 hover:text-text-1"
+                }`}
+              >
+                {item}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <StepLink
+        direction="next"
+        disabled={nextDisabled}
+        onClick={() => onPageChange(clampedPage + 1)}
+      />
+    </nav>
+  );
+}
+
+function StepLink({
+  direction,
+  disabled,
+  onClick,
+}: {
+  direction: "prev" | "next";
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  const isPrev = direction === "prev";
+  const Icon = isPrev ? ArrowLeft : ArrowRight;
+  const label = isPrev ? "Previous" : "Next";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      className={`flex items-start gap-3 border-t-2 border-transparent pt-4 text-[13px] transition-colors ${
+        isPrev ? "pr-1" : "pl-1"
+      } ${
+        disabled
+          ? "cursor-not-allowed text-text-3/40"
+          : "cursor-pointer text-text-3 hover:border-border-4 hover:text-text-1"
+      }`}
+    >
+      {isPrev && <Icon className="h-5 w-5" />}
+      {label}
+      {!isPrev && <Icon className="h-5 w-5" />}
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -91,7 +91,7 @@ export function Pagination({
   return (
     <nav
       aria-label="Pagination"
-      className={`flex w-full items-stretch justify-between border-t border-border-2 ${className ?? ""}`}
+      className={`flex h-14 w-full items-stretch justify-between border-t border-border-2 ${className ?? ""}`}
     >
       <StepLink
         direction="prev"
@@ -106,7 +106,7 @@ export function Pagination({
               <li
                 key={item}
                 aria-hidden="true"
-                className="flex w-10 items-start justify-center border-t-2 border-transparent pt-4 text-[13px] text-text-3"
+                className="flex min-w-10 items-center justify-center border-t-2 border-transparent px-2 text-[13px] text-text-3"
               >
                 …
               </li>
@@ -122,7 +122,7 @@ export function Pagination({
                 }}
                 aria-current={isCurrent ? "page" : undefined}
                 aria-label={`Page ${item}`}
-                className={`flex min-w-10 items-start justify-center border-t-2 px-4 pt-4 text-[13px] transition-colors ${
+                className={`flex min-w-10 items-center justify-center border-t-2 px-4 text-[13px] transition-colors ${
                   isCurrent
                     ? "cursor-default border-primary-6 font-medium text-text-1"
                     : "cursor-pointer border-transparent text-text-3 hover:border-border-4 hover:text-text-1"
@@ -162,9 +162,7 @@ function StepLink({
       onClick={onClick}
       disabled={disabled}
       aria-label={label}
-      className={`flex items-start gap-3 border-t-2 border-transparent pt-4 text-[13px] transition-colors ${
-        isPrev ? "pr-1" : "pl-1"
-      } ${
+      className={`flex items-center gap-3 border-t-2 border-transparent px-2 text-[13px] transition-colors ${
         disabled
           ? "cursor-not-allowed text-text-3/40"
           : "cursor-pointer text-text-3 hover:border-border-4 hover:text-text-1"

--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -91,7 +91,13 @@ export function Pagination({
   return (
     <nav
       aria-label="Pagination"
-      className={`flex h-14 w-full items-stretch justify-between border-t border-border-2 ${className ?? ""}`}
+      // No top divider on the bar itself — the table card already
+      // has its own bottom edge, and the 2px primary-blue accent on
+      // the current page is the only horizontal line that should
+      // read at a glance. Stacking a continuous 1px gray *under*
+      // that accent (as the literal Figma export does) made the
+      // edge look heavy.
+      className={`flex h-14 w-full items-stretch justify-between ${className ?? ""}`}
     >
       <StepLink
         direction="prev"

--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -10,9 +10,11 @@ interface PaginationProps {
   totalPages: number;
   onPageChange: (next: number) => void;
   /**
-   * Hide the bar entirely when only one page exists. Defaults to true
-   * because a single-page "1" pill with disabled Prev/Next adds visual
-   * noise without giving the user anything to act on.
+   * Hide the bar entirely when only one page exists. Defaults to
+   * *false* to match the Figma comp, which always renders the bar
+   * under the table for visual anchoring — even on single-page
+   * datasets where Prev/Next are disabled and only "1" is active.
+   * Pass `true` to fall back to the hide-when-trivial behavior.
    */
   hideOnSinglePage?: boolean;
   /** Visual sibling count on each side of the current page. Defaults
@@ -71,7 +73,7 @@ export function Pagination({
   page,
   totalPages,
   onPageChange,
-  hideOnSinglePage = true,
+  hideOnSinglePage = false,
   siblingCount = 1,
   className,
 }: PaginationProps) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -396,6 +396,7 @@ export async function detachKnowledgeFile(
 export interface ProjectKnowledgeUploadResult {
   uploaded: Array<{ id: string; name: string; ingestionStatus: string }>;
   duplicates: KnowledgeUploadDuplicate[];
+  nameConflicts: KnowledgeUploadNameConflict[];
 }
 
 /**
@@ -404,6 +405,11 @@ export interface ProjectKnowledgeUploadResult {
  * project. `folderId` / `visibility` / `teamIds` are optional —
  * omit them to use the smart-default ("Projects" folder, scope-
  * aware visibility).
+ *
+ * `nameConflictActions` (optional) carries the user's resolution for
+ * same-name-different-content collisions surfaced by a prior call.
+ * See `uploadKnowledgeFiles` for the semantics; the BE routes both
+ * uploads through the same service so behaviour is identical.
  */
 export async function uploadProjectKnowledgeFiles(
   projectId: string,
@@ -413,6 +419,7 @@ export async function uploadProjectKnowledgeFiles(
     visibility?: KnowledgeFileVisibility;
     teamIds?: string[];
     projectIds?: string[];
+    nameConflictActions?: Record<string, NameConflictAction>;
   } = {},
 ): Promise<ProjectKnowledgeUploadResult> {
   const form = new FormData();
@@ -424,6 +431,15 @@ export async function uploadProjectKnowledgeFiles(
   }
   if (options.visibility === "project" && options.projectIds) {
     options.projectIds.forEach((id) => form.append("projectIds", id));
+  }
+  if (
+    options.nameConflictActions &&
+    Object.keys(options.nameConflictActions).length > 0
+  ) {
+    form.append(
+      "nameConflictActions",
+      JSON.stringify(options.nameConflictActions),
+    );
   }
   const res = await apiFetch(
     `/projects/${projectId}/knowledge-files/upload`,
@@ -1946,9 +1962,24 @@ export interface KnowledgeUploadDuplicate {
   };
 }
 
+/**
+ * Surfaced by the BE when an upload hits a same-name-different-bytes
+ * row in the *same folder*, under the same uploader. Content-hash
+ * duplicates land in `duplicates` instead — these are the cases
+ * where the user is plausibly uploading a new revision of a doc and
+ * needs to pick what happens to the prior copy.
+ */
+export interface KnowledgeUploadNameConflict {
+  name: string;
+  existing: { id: string };
+}
+
+export type NameConflictAction = "overwrite" | "keep_both" | "skip";
+
 export interface KnowledgeUploadResult {
   uploaded: Omit<KnowledgeFile, "uploadedByName">[];
   duplicates: KnowledgeUploadDuplicate[];
+  nameConflicts: KnowledgeUploadNameConflict[];
 }
 
 export async function uploadKnowledgeFiles(
@@ -1957,6 +1988,13 @@ export async function uploadKnowledgeFiles(
   visibility: KnowledgeFileVisibility = "all",
   teamIds: string[] = [],
   projectIds: string[] = [],
+  // Per-name decisions the user picked on the resolution dialog.
+  // Keys are the original `File.name` values; values are the action
+  // the BE should take for that specific file. Missing entries are
+  // treated as 'skip' BE-side, so the safe default is "no map → no
+  // overwrite", and the BE will simply bounce conflicts back to the
+  // FE again.
+  nameConflictActions?: Record<string, NameConflictAction>,
 ): Promise<KnowledgeUploadResult> {
   const form = new FormData();
   files.forEach((f) => form.append("files", f));
@@ -1973,6 +2011,11 @@ export async function uploadKnowledgeFiles(
   }
   if (visibility === "project") {
     projectIds.forEach((id) => form.append("projectIds", id));
+  }
+  if (nameConflictActions && Object.keys(nameConflictActions).length > 0) {
+    // Multipart can't carry an object natively; serialise to JSON.
+    // The controller parses + validates.
+    form.append("nameConflictActions", JSON.stringify(nameConflictActions));
   }
   const res = await apiFetch(`/knowledge-core/folders/${folderId}/files`, {
     method: "POST",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2756,6 +2756,38 @@ export function fetchObservabilityEvents(
   return fetchObservability(`/observability/events?${params.toString()}`);
 }
 
+/**
+ * Un-paginated event fetch used by the CSV export button. Same
+ * filter shape as `fetchObservabilityEvents` minus pagination — the
+ * BE caps the result at `maxRows` (currently 10k) and sets
+ * `truncated=true` when the cap was hit so the FE can warn the user
+ * to narrow the filter before re-exporting.
+ */
+export interface ObservabilityEventsExport {
+  range: ObservabilityRange;
+  total: number;
+  truncated: boolean;
+  maxRows: number;
+  events: ObservabilityEvent[];
+}
+
+export interface ObservabilityEventsExportQuery {
+  range: ObservabilityRange;
+  search?: string;
+  eventType?: string;
+}
+
+export function fetchObservabilityEventsExport(
+  query: ObservabilityEventsExportQuery,
+): Promise<ObservabilityEventsExport> {
+  const params = new URLSearchParams({ range: query.range });
+  if (query.search?.trim()) params.set("search", query.search.trim());
+  if (query.eventType) params.set("eventType", query.eventType);
+  return fetchObservability(
+    `/observability/events/export?${params.toString()}`,
+  );
+}
+
 export interface ObservabilityGuardrailTrigger {
   guardrailId: string | null;
   guardrailName: string | null;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2911,85 +2911,116 @@ export async function deleteIntegration(id: string): Promise<void> {
 
 // ─── Team-scoped integrations (BYOK keys shared across team members) ──────
 
-export async function fetchTeamIntegrations(
+// ── Integration links (new picker model) ──────────────────────────
+//
+// Replaces the legacy team-scoped integrations endpoints above:
+// admins manage their personal BYOK keys on /teams?tab=integration,
+// then link them into one or more teams via these endpoints. The
+// FE picker on team-details only uses these — the legacy helpers
+// above are kept for the transition.
+
+export interface TeamIntegrationLink {
+  integrationId: string;
+  // Identity of the integration owner — lets the FE picker tell
+  // "my key" (editable checkbox + trash) apart from "someone else's
+  // key" (read-only with per-team toggle only). Pair with the
+  // caller's user id from the auth store.
+  ownerId: string;
+  ownerName: string | null;
+  providerId: string;
+  isCustom: boolean;
+  displayName: string;
+  apiUrl: string | null;
+  hasApiKey: boolean;
+  // Per-team toggle. False ⇒ chat-time routing for this team skips
+  // this key even if the underlying integration is on.
+  linkEnabled: boolean;
+  // Master switch on the integration owner's personal /teams?tab=
+  // integration tab. False ⇒ key is off everywhere; team toggle
+  // becomes a no-op until the owner re-enables it.
+  integrationEnabled: boolean;
+  linkedAt: string;
+  linkedBy: string | null;
+}
+
+export interface LinkableIntegration {
+  integrationId: string;
+  providerId: string;
+  isCustom: boolean;
+  displayName: string;
+  apiUrl: string | null;
+  hasApiKey: boolean;
+  integrationEnabled: boolean;
+  alreadyLinked: boolean;
+  // Predefined-provider-only: another integration already occupies
+  // this provider slot for the team. FE disables the checkbox +
+  // explains in tooltip ("One Anthropic key per team").
+  blockedByProvider: boolean;
+}
+
+export async function fetchTeamIntegrationLinks(
   teamId: string,
-): Promise<IntegrationCard[]> {
-  const res = await apiFetch(`/teams/${teamId}/integrations`);
+): Promise<TeamIntegrationLink[]> {
+  const res = await apiFetch(`/teams/${teamId}/integration-links`);
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.message || "Failed to fetch team integrations");
+    throw new Error(body.message || "Failed to fetch team integration links");
   }
   return res.json();
 }
 
-export async function upsertTeamIntegration(
+export async function fetchLinkableIntegrations(
   teamId: string,
-  input: {
-    providerId: string;
-    /** Required when providerId === "custom": the OpenAI-compatible
-     *  endpoint URL (Ollama / vLLM / Together / …). */
-    apiUrl?: string | null;
-    apiKey?: string | null;
-    isEnabled?: boolean;
-    /** Required when providerId === "custom": the friendly name
-     *  members see in the model picker. The BE auto-creates a
-     *  team-scoped model_configs alias bound to this integration so
-     *  members can use it without admin touching /catalog. */
-    customName?: string | null;
-  },
-): Promise<IntegrationCard> {
-  const res = await apiFetch(`/teams/${teamId}/integrations`, {
-    method: "POST",
+): Promise<LinkableIntegration[]> {
+  const res = await apiFetch(`/teams/${teamId}/integration-links/linkable`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || "Failed to fetch linkable integrations");
+  }
+  return res.json();
+}
+
+/**
+ * Replace the team's link set atomically. Pass the complete list of
+ * integrationIds that should be linked after the save; the BE
+ * computes the delta and adds/removes accordingly. Returns the new
+ * link list so the caller can update local state without a second
+ * round-trip.
+ */
+export async function setTeamIntegrationLinks(
+  teamId: string,
+  integrationIds: string[],
+): Promise<TeamIntegrationLink[]> {
+  const res = await apiFetch(`/teams/${teamId}/integration-links`, {
+    method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
+    body: JSON.stringify({ integrationIds }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.message || "Failed to save team integration");
+    throw new Error(body.message || "Failed to save integration links");
   }
   return res.json();
 }
 
-export async function updateTeamIntegration(
+export async function setTeamIntegrationLinkEnabled(
   teamId: string,
   integrationId: string,
-  input: {
-    isEnabled?: boolean;
-    apiKey?: string | null;
-    /** Custom LLM rows only — new endpoint URL. */
-    apiUrl?: string;
-    /** Custom LLM rows only — new display name. The underlying
-     *  modelIdentifier stays stable so ongoing chats keep working. */
-    customName?: string;
-  },
-): Promise<IntegrationCard> {
+  isEnabled: boolean,
+): Promise<TeamIntegrationLink[]> {
   const res = await apiFetch(
-    `/teams/${teamId}/integrations/${integrationId}`,
+    `/teams/${teamId}/integration-links/${integrationId}`,
     {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
+      body: JSON.stringify({ isEnabled }),
     },
   );
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body.message || "Failed to update team integration");
+    throw new Error(body.message || "Failed to toggle integration link");
   }
   return res.json();
-}
-
-export async function deleteTeamIntegration(
-  teamId: string,
-  integrationId: string,
-): Promise<void> {
-  const res = await apiFetch(
-    `/teams/${teamId}/integrations/${integrationId}`,
-    { method: "DELETE" },
-  );
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body.message || "Failed to delete team integration");
-  }
 }
 
 // ───── API keys (programmatic access tokens) ──────────────────────────

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2067,9 +2067,13 @@ export async function updateKnowledgeFileVisibility(
 }
 
 /**
- * Force a fresh chunk + embed pass on a single file. Owner-only at
- * the BE; FE just kicks the request and refetches to surface the
- * new "Queued" / "Training" badge.
+ * Re-run chunk + embed on a single file so it's available to chat /
+ * arena again. Owner-only at the BE; FE just kicks the request and
+ * refetches to surface the new "Queued" / "Adding" badge.
+ *
+ * The endpoint path is still `/reingest` (and the in-memory function
+ * keeps that name) — only the user-visible copy was renamed; user
+ * surfaces always talk about adding the file to context now.
  */
 export async function reingestKnowledgeFile(
   fileId: string,
@@ -2079,7 +2083,7 @@ export async function reingestKnowledgeFile(
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body?.message || "Failed to re-train this file");
+    throw new Error(body?.message || "Failed to include this file in context");
   }
   return res.json();
 }
@@ -2088,7 +2092,11 @@ export async function reingestKnowledgeFile(
  * Wipe a file's embeddings without deleting the upload. Inverse of
  * `reingestKnowledgeFile` — chunks go away, the file row stays so
  * download still works, and chat-time RAG stops surfacing it until
- * the owner triggers Retrain.
+ * the owner re-includes it.
+ *
+ * The endpoint path is still `/untrain` (legacy name kept on the BE
+ * to avoid a coordinated rename) — user-visible copy now says
+ * "Exclude from context".
  */
 export async function untrainKnowledgeFile(
   fileId: string,
@@ -2098,7 +2106,7 @@ export async function untrainKnowledgeFile(
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
-    throw new Error(body?.message || "Failed to untrain this file");
+    throw new Error(body?.message || "Failed to exclude this file from context");
   }
   return res.json();
 }

--- a/packages/database/backfill/migrate-team-integrations-to-links.sql
+++ b/packages/database/backfill/migrate-team-integrations-to-links.sql
@@ -1,0 +1,113 @@
+-- Migrate the legacy "team_id-on-integrations" model to the new
+-- team_integration_links many-to-many table.
+--
+-- Why: old model duplicated the encrypted API key into a separate
+-- integrations row per team (one personal row + N team-scoped rows
+-- for the same provider). The new model stores the key once on a
+-- personal row and links it into teams via team_integration_links,
+-- so key rotation only has to land once.
+--
+-- What this does, in one transaction:
+--   1. For every team-scoped row, find or create a personal twin
+--      under the same owner_id + provider_id (+ api_url, for custom
+--      LLMs). Personal twin matched on (owner, provider, api_url IS
+--      [NOT] NULL) so a custom LLM with a different URL doesn't
+--      collide with a personal predef of the same providerId.
+--   2. Insert a team_integration_links row pointing the original
+--      team_id at the personal twin. is_enabled inherited from the
+--      team-scoped row so members keep the same toggle state.
+--   3. Delete the now-redundant team-scoped row.
+--
+-- Idempotent: running twice on a DB that's already migrated finds no
+-- team-scoped rows and exits cleanly. ON CONFLICT DO NOTHING on the
+-- link insert covers the case where someone manually pre-linked.
+--
+-- Run with: psql -f migrate-team-integrations-to-links.sql
+
+BEGIN;
+
+-- Step 1: ensure a personal twin exists for every team-scoped row.
+-- Personal predef twin = same owner_id + provider_id + api_url IS NULL.
+-- For custom LLMs (provider_id = 'custom'), we match on (owner, url)
+-- so two different on-prem endpoints stay distinct.
+INSERT INTO integrations (
+  owner_id,
+  team_id,
+  provider_id,
+  api_url,
+  api_key_encrypted,
+  is_enabled,
+  created_at,
+  updated_at
+)
+SELECT DISTINCT ON (t.owner_id, t.provider_id, t.api_url)
+  t.owner_id,
+  NULL::uuid AS team_id,
+  t.provider_id,
+  t.api_url,
+  t.api_key_encrypted,
+  t.is_enabled,
+  t.created_at,
+  t.updated_at
+FROM integrations t
+WHERE t.team_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM integrations p
+    WHERE p.team_id IS NULL
+      AND p.owner_id = t.owner_id
+      AND p.provider_id = t.provider_id
+      AND (
+        (p.api_url IS NULL AND t.api_url IS NULL)
+        OR p.api_url = t.api_url
+      )
+  )
+ORDER BY t.owner_id, t.provider_id, t.api_url, t.created_at ASC;
+
+-- Step 2: create the link rows. JOIN on the same matching key to find
+-- the personal twin we just guaranteed exists.
+INSERT INTO team_integration_links (
+  team_id,
+  integration_id,
+  is_enabled,
+  linked_by,
+  linked_at,
+  updated_at
+)
+SELECT
+  t.team_id,
+  p.id AS integration_id,
+  t.is_enabled,
+  t.owner_id AS linked_by,
+  t.created_at AS linked_at,
+  NOW() AS updated_at
+FROM integrations t
+JOIN integrations p
+  ON p.team_id IS NULL
+ AND p.owner_id = t.owner_id
+ AND p.provider_id = t.provider_id
+ AND (
+       (p.api_url IS NULL AND t.api_url IS NULL)
+       OR p.api_url = t.api_url
+     )
+WHERE t.team_id IS NOT NULL
+ON CONFLICT (team_id, integration_id) DO NOTHING;
+
+-- Step 3: drop the redundant team-scoped rows.
+DELETE FROM integrations
+WHERE team_id IS NOT NULL;
+
+-- Sanity: every old team_id should now have at least one link.
+-- (Commented out — uncomment if you want a hard fail when something
+-- slipped through.)
+-- DO $$
+-- DECLARE
+--   leftover_count int;
+-- BEGIN
+--   SELECT count(*) INTO leftover_count FROM integrations WHERE team_id IS NOT NULL;
+--   IF leftover_count > 0 THEN
+--     RAISE EXCEPTION 'Backfill incomplete: % team-scope rows remain', leftover_count;
+--   END IF;
+-- END $$;
+
+COMMIT;

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -772,6 +772,57 @@ export const integrations = pgTable(
   ],
 );
 
+// Many-to-many link between `teams` and `integrations`. Lets an admin
+// configure a BYOK key once in their personal Integration tab and then
+// link it into one or more teams, instead of duplicating the encrypted
+// key into a separate team-scoped `integrations` row per team.
+//
+// `isEnabled` is per-link so an admin can temporarily disable a key's
+// use on a single team without affecting other teams that share the
+// same underlying integration. The underlying `integrations.isEnabled`
+// is the "is the personal key on at all" master switch; both must be
+// true for chat-time routing to surface this key for a team.
+//
+// The link table replaces the legacy pattern of putting `team_id` on
+// `integrations` directly. Existing team-scoped rows still work for
+// reads during the transition, but new ones are not created — the
+// picker on the team-details page now writes to this table instead.
+export const teamIntegrationLinks = pgTable(
+  "team_integration_links",
+  {
+    teamId: uuid("team_id")
+      .references(() => teams.id, { onDelete: "cascade" })
+      .notNull(),
+    integrationId: uuid("integration_id")
+      .references(() => integrations.id, { onDelete: "cascade" })
+      .notNull(),
+    // Per-link enable flag — distinct from `integrations.isEnabled` so
+    // pausing one team's access to a shared key doesn't take the key
+    // off for the admin's personal use or for other teams.
+    isEnabled: boolean("is_enabled").notNull().default(true),
+    // Audit only — who added this link. Set to null on the actor's
+    // user delete so we don't cascade-remove the link itself; the link
+    // outlives the actor.
+    linkedBy: uuid("linked_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    linkedAt: timestamp("linked_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.teamId, table.integrationId] }),
+    // Reverse lookup: "which teams link this integration?" — used when
+    // the admin updates / disables an integration so we can flag
+    // affected teams in the UI.
+    index("team_integration_links_integration_idx").on(table.integrationId),
+    // Per-team-per-provider uniqueness is enforced in service code
+    // (TeamsService.setIntegrationLinks) rather than at the DB level:
+    // the constraint depends on the JOINed integrations.provider_id,
+    // which can't be expressed in a single partial index. Service-side
+    // it's a select-then-throw inside the link-set transaction.
+  ],
+);
+
 // Org-level singleton settings. The Company tab on the FE renders a
 // "Company Monthly Budget" target the admin sets here; future org-wide
 // flags (logo URL, default infraChoice, branding overrides…) will land


### PR DESCRIPTION
  ## Povzetek

  Velik nabor sprememb po Figmi in povratnih informacijah uporabnika. Zajemajo refactor BYOK ključev na ekipah, dodajanje resolution flow-a za istoimenske datoteke v Knowledge Core, CSV export za Observability,
   jezikovni cleanup ter mass-rollout Figma-spec Pagination komponente.

  ## Glavne stvari

  ### Team Integrations — link model namesto duplikatov
  - Nova `team_integration_links` tabela in idempotentni backfill SQL.
  - Admin nastavi BYOK ključ enkrat na **/teams?tab=integration**, nato ga preko picker-ja aktivira na poljubnem številu ekip. Rotacija na osebnem tabu se propagira povsod, kjer je linkan.
  - Team details ima nov picker: per-row Switch z immediate-commit-om (default OFF, vklop linka + aktivacijo, izklop odlinka), z ločenim section-om "Linked by other admins" za links, ki jih je dodal drug admin
  (per-team pause toggle ostane, ne sme jih odstraniti).
  - BE chat-transport in models.service zdaj resolve-ata team BYOK ključ skozi link tabelo — oba flag-a (link in integration) morata biti enabled.
  - Stari `/teams/:id/integrations` endpoint-i + service metode + FE helperji odstranjeni.

  ### Knowledge Core — resolution za istoimenske datoteke
  - Doslej se je file z enakim imenom ampak drugačno vsebino samodejno vstavil kot drugi row.
  - Nov flow: BE detektira name-conflict znotraj `(uploader, folder)` in vrne ga FE-ju. Uporabnik za vsak file izbere **Overwrite / Keep both / Skip** (z apply-to-all bulk akcijami).
  - Shared `KnowledgeNameConflictDialog` wire-an v vse tri upload paths (root KC, KC folder, Manage Context v projektu).

  ### Observability — CSV export pokrije celoten filter
  - Doslej je CSV vseboval samo trenutno paginirano stran (25 vrstic).
  - Nov `GET /observability/events/export` endpoint vrne celoten filtriran set (cap 10k server-side). FE pokaže "Preparing CSV…" toast, ob truncate-u opozori da naj uporabnik zoži filter.
  - Export gumb v appbar-u je disabled, ko ni vrstic; ščitenje z `observability:export-enabled` event-om.

  ### Pagination komponenta po Figmi
  - Nova `Pagination` komponenta po Figma node-u 67:6264 (Previous/Next z arrow ikoni, številke z modrim 2px top border accent na current strani, ellipsis za dolge range-e).
  - Wired v **vsako tabelo** v aplikaciji: Observability events + Team Analytics, Guardrails overview, Subteams/Users/Guardrails na team details, KC recent + KC folder files, Management Company/Catalog/API
  tabs.
  - Default page size 10 (25 za Observability events in Catalog).
  - Pagination bar je vidna tudi pri single-page (Prev/Next disabled, "1" active) za vizualno konsistenco.

  ### Copy cleanup — brez "train AI" jezika
  - "Trained" → "In context", "Untrained" → "Excluded", "Indexing…/Training" → "Adding…".
  - DropdownMenu akcije: "Retrain" → "Include in context", "Untrain" → "Exclude from context".
  - Onboarding step-6: "Training your AI…" → "Setting up your AI…".
  - Resources stran: "tools and training" → "tools and resources".
  - BE error sporočila usklajena z novo terminologijo (kar surface-a v toast-e).

  ### Manjše stvari
  - **Compare Models**: stabiliziran "Compare models side by side" placeholder + composer (z `flex-1 h-0` namesto `h-full` page wrapper-jem) + auto-grow textarea cap-an na 200px.
  - **Team details responsive**: header card stack-a na mobile, vsi 3 section header-ji wrap-ajo, tabele skrijejo nepomembne stolpce na manjših viewport-ih.
  - **App shell**: `overflow-x-hidden` na outer scrollable + `min-w-0` na content column da long-content elementi ne razširijo page-a čez viewport.
  - **Invite Member dialog**: dodani vsi 4 team role-i (admin/manager/editor/viewer) — backend je že podpiral, samo UI je bil omejen.
  - **AI Provider Keys sekcija**: premaknjena pod Users na team details.
  - **Teams Integration tab picker**: zdaj prikaže samo `is_enabled=true` osebne integration-e.

  ## Test plan

  - [ ] Konfiguriraj BYOK Anthropic na **/teams?tab=integration**, aktiviraj ga na ekipi, preveri da chat na projektu ekipe gre skozi ta ključ.
  - [ ] Disable-aj integration na osebnem tabu — preveri da chat ne uporablja več, ostane pa link viden v team details s pravilnim opozorilom.
  - [ ] Drugi admin (admin B) ima svoj OpenAI ključ; aktiviraj ga na isti ekipi. Admin A vidi link v "Linked by other admins" sekciji s per-team pause toggle-om, brez možnosti odstranitve.
  - [ ] Knowledge Core: upload-aj `report.pdf` z drugačno vsebino kot obstoječi `report.pdf` v istem folderju. Preveri da se pojavi resolution dialog. Testiraj vse 3 izbire.
  - [ ] Knowledge Core: upload-aj `report.pdf` z **isto** vsebino kot obstoječi — preveri da gre skozi content-hash dedupe (info toast), ne pa skozi name-conflict resolution.
  - [ ] Observability: export CSV z dnevnim range-om (testno če imaš >10k dogodkov, sicer truncate ne fire-a). Preveri toast feedback.
  - [ ] Vsaka tabela (KC root, KC folder, Subteams, Users, Guardrails, Catalog, API keys, Company Users, Observability) prikaže Pagination bar pod sabo; pri <10 vrsticah Prev/Next disabled, "1" active.
  - [ ] Team details na mobile (375px width): header stack-a, tabele scrollajo notranje z skritimi stolpci, page ne preseže 100vw.
  - [ ] Compare models: preklapljaj zgodovinske run-e in History toggle — bela kartica ne sme skakati.
  - [ ] Onboarding step-6: preveri da nikjer ne piše "Training your AI".
